### PR TITLE
docs(specs): cloud-core cluster system specs — seam, sessions, environments

### DIFF
--- a/server/proliferate/server/seam/MANIFEST.toml
+++ b/server/proliferate/server/seam/MANIFEST.toml
@@ -4,7 +4,7 @@
 # permission-by-intention: the checker fails on drift in either direction.
 
 name = "seam"
-spec = "specs/FEATURE_DOCS/MANAGED_RUNTIME.md"
+spec = "specs/codebase/systems/product/seam/README.md"
 owns = "Runtime worker enrollment, identity, and heartbeat endpoints: the CP↔runtime seam's worker registry."
 
 public_surface = [

--- a/specs/FEATURE_DOCS/MANAGED_RUNTIME.md
+++ b/specs/FEATURE_DOCS/MANAGED_RUNTIME.md
@@ -28,6 +28,10 @@ The agent catalog rides inside the runtime binary, so binary convergence IS cata
 
 ### Enrollment and Identity
 
+> Owner: the control-plane side of enrollment, identity, and heartbeat is now
+> specified by [specs/codebase/systems/product/seam/README.md](../codebase/systems/product/seam/README.md); this section keeps
+> the worker-side mechanics.
+
 The worker has a one-time bootstrap credential and one durable Cloud identity:
 
 ```text
@@ -61,6 +65,10 @@ The integration-gateway authorization value is distinct from `worker_token`. On 
 Source: [`proliferate-worker/src/identity/`](../../anyharness/crates/proliferate-worker/src/identity/), [`store/identity.rs`](../../anyharness/crates/proliferate-worker/src/store/identity.rs), [`integration_gateway.rs`](../../anyharness/crates/proliferate-worker/src/integration_gateway.rs)
 
 ### Heartbeat and Version Divergence
+
+> Owner: the heartbeat contract (routes, verdicts, liveness thresholds) is
+> specified by [specs/codebase/systems/product/seam/README.md](../codebase/systems/product/seam/README.md); this section keeps
+> the convergence consequences.
 
 The worker heartbeat is both its liveness signal and the carrier for desired binary versions:
 

--- a/specs/FEATURE_DOCS/SANDBOX/lifecycle.md
+++ b/specs/FEATURE_DOCS/SANDBOX/lifecycle.md
@@ -5,7 +5,8 @@ dissolving the legacy cloud sandbox stack: the E2B webhook lane, orphan
 reaper, worktree policy, and agent run configs are
 already deleted (delivery/cull-sweep/delivery-spec-delete-dark-cloud.md,
 part 1); the remaining provisioning/workspace machinery follows in part 2.
-The environments system spec replaces this document.
+The environments system spec replaces this document:
+[specs/codebase/systems/product/environments/README.md](../../codebase/systems/product/environments/README.md).
 
 Status: target. This document describes the accepted destination for the
 cloud sandbox container. The body is written in the ideal state. Every

--- a/specs/codebase/systems/product/README.md
+++ b/specs/codebase/systems/product/README.md
@@ -18,6 +18,9 @@ restating folder rules or low-level reusable contracts.
 | Workspace files, mobility boundary, and terminals | User-facing workspace file, shell, dispatch, and terminal behavior; current migration absence and retained runtime mobility boundary. | [workspaces/README.md](workspaces/README.md) |
 | Mobile client | Mobile auth, cloud chat, sessions, and settings on the mobile surface. | No current system spec. Mobile ships from `apps/mobile`; architecture boundary owned by [specs/frontend/README.md](../../../frontend/README.md), local/QA lanes by [guides/local/mobile.md](../../../../guides/local/mobile.md). |
 | Workflows | User-owned workflow definitions, ordered stages and prompt steps, opaque launch intent revalidated against the execution target, revisioning, optional default repository configuration, and definition-authoring UX. | [specs/FEATURE_DOCS/WORKFLOWS.md](../../../FEATURE_DOCS/WORKFLOWS.md) |
+| Seam | The CP ↔ runtime contract: worker enrollment, identity, heartbeat (current); courier and event shipping (target). Grade B/C. | [seam/README.md](seam/README.md) |
+| Sessions | The session as a product object: the runtime event log and its five invariants (current); the control-plane registry row, external bindings, checkpointed record (target). Grade B/C. | [sessions/README.md](sessions/README.md) |
+| Environments | The container: provisioning engine, lifecycle states and causes, usage fencing, template pipeline; personal and task classes (target). Grade C. | [environments/README.md](environments/README.md) |
 | Agents | The agent-systems overview map (distribution, auth, gateway, target-observed launch options), plus delegated-work UX and cowork artifact lifecycle. | [agents/README.md](agents/README.md) |
 | Settings and appearance | Settings/admin information architecture, Appearance scaling, billing/account/team/config surfaces, filtering, origins, and admin-facing state. | [settings/README.md](settings/README.md) |
 | Support reporting | Currently shipped private support capture. | [support/README.md](support/README.md) |
@@ -52,6 +55,11 @@ new system spec or Product MCP definition:
 | Plugins | No current platform document owns runtime/config expansion; create a system spec only for catalog/install/manage UX. |
 
 ## Adding A Product System Spec
+
+System specs written after 2026-08-25 follow the nine-section anatomy (Purpose,
+Owned state, Public surface, Consumes, Laws, Emits, Fences, Code map, Proof) with
+a `Known gaps` list and inline `PABLO DECIDES` callouts for founder rulings; see
+[seam/README.md](seam/README.md) for the form.
 
 Add a system spec when a workflow becomes durable enough that contributors
 need one place to learn:

--- a/specs/codebase/systems/product/environments/README.md
+++ b/specs/codebase/systems/product/environments/README.md
@@ -1,0 +1,374 @@
+# Environments
+
+Status: target. Grade C. The body asserts the destination — one sandbox
+primitive with two lifecycle classes — and the current implementation
+(personal sandboxes under `server/cloud/`, dissolving under
+[delivery-spec-delete-dark-cloud.md](../../../../../delivery/cull-sweep/delivery-spec-delete-dark-cloud.md))
+is recorded as archaeology in [Known gaps](#known-gaps). Supersedes
+[SANDBOX/lifecycle.md](../../../../FEATURE_DOCS/SANDBOX/lifecycle.md).
+
+Read before touching: `server/proliferate/integrations/sandbox/**`,
+`server/proliferate/db/models/cloud/sandboxes.py`,
+`server/proliferate/db/store/cloud_sandboxes.py`,
+`server/proliferate/server/cloud/cloud_sandboxes/**`,
+`server/proliferate/server/cloud/materialization/**`,
+`server/proliferate/server/cloud/runtime/**`, `scripts/build-template.mjs`.
+
+## 1. Purpose
+
+An environment is the container a run executes in: a provider VM (E2B
+today) carrying the execution bundle — supervisor, worker, AnyHarness —
+provisioned from one immutable template. This system owns the container and
+nothing inside it: provisioning, lifecycle states and their single causes,
+the template pipeline, usage-segment fencing, health, and reaping.
+
+The generalization the rebuild delivers is **one primitive, two classes**:
+
+| | Personal | Task |
+| --- | --- | --- |
+| Cardinality | singleton per (user, org) | one per run (or run group) |
+| Lifecycle owner | the user | the run |
+| Wake | traffic (provider auto-resume) | never — provisioned live |
+| Death | explicit delete only | complete → checkpoint → pause → reap after retention |
+| Provision trigger | GitHub authority-chain completion | placement of a run; org installation only, no user-auth leg |
+
+Same template, same provisioning engine, same supervisor topology, same
+fencing. The existing "one per (user, org)" law becomes a law *about the
+personal class*. Compute is a lazily-bound resource of a run, never the
+other way around.
+
+## 2. Owned state
+
+The sandbox row
+([sandboxes.py](../../../../../server/proliferate/db/models/cloud/sandboxes.py)),
+written only through
+[db/store/cloud_sandboxes.py](../../../../../server/proliferate/db/store/cloud_sandboxes.py):
+
+```text
+cloud_sandbox
+├── owner_user_id                    personal class: the person
+├── sandbox_type                     provider kind (e2b)
+├── provider_sandbox_id              current provider binding (nullable, detachable, unique)
+├── status                           creating | ready | paused | error | destroyed
+├── materialization_attempt          attempt epoch — the fence every completion compares
+├── provider_observed_at             provider freshness floor
+├── last_error                       sanitized receipt of the last failed attempt
+├── anyharness_base_url · runtime_token_ciphertext · anyharness_data_key_ciphertext
+│                                    stamped runtime access (custody: secrets)
+├── ready_at · last_health_at · destroyed_at
+└── desired_anyharness_version · desired_worker_version   per-target pins (seam admin route)
+```
+
+Target additions (※ new): `class` (`personal | task`), a polymorphic owner
+(`owner_user_id` for personal, `run_id` for task), `organization_id` NOT
+NULL, per-class uniqueness (`(owner_user_id, organization_id)` for personal;
+`run_id` for task), a per-class causes table, a reap policy, and the
+org/class **concurrency policy row + placement queue**.
+
+Also owned: the template artifacts and their promotion state (immutable
+sha tags, `:staging` / `:production` rolling tags — produced by
+[build-template.mjs](../../../../../scripts/build-template.mjs),
+[promote-cloud-template.mjs](../../../../../scripts/promote-cloud-template.mjs),
+[smoke-cloud-template.mjs](../../../../../scripts/smoke-cloud-template.mjs) and the
+two workflows
+[release-cloud-template.yml](../../../../../.github/workflows/release-cloud-template.yml),
+[promote-cloud-template.yml](../../../../../.github/workflows/promote-cloud-template.yml));
+and the fenced open/close operations on compute usage segments (billing owns
+what a segment costs).
+
+> [!decision] PABLO DECIDES: class as a column or as two tables.
+> Options: (a) one `cloud_sandbox` table with a `class` column and
+> check-constrained owner polymorphism (the Cull Plan's ruling); (b) a
+> `task_environment` table sharing the engine through a protocol.
+> Recommendation: (a) — the engine, fencing, webhooks, and reaper are
+> identical and keyed by row id; two tables would fork every fence.
+
+## 3. Public surface
+
+Today, under `/v1/cloud`
+([cloud_sandboxes/api.py](../../../../../server/proliferate/server/cloud/cloud_sandboxes/api.py)):
+
+| Route | Purpose |
+| --- | --- |
+| `GET /cloud-sandbox` | the caller's personal row (status, timestamps, last-error receipt) |
+| `POST /cloud-sandbox/ensure` | create or return the row, billing-gated; never touches the provider |
+| `DELETE /cloud-sandbox` | revoke workers and gateway token, mark destroyed, kill the provider VM after commit |
+
+Internal surface consumed by other systems:
+[materialization/service.py](../../../../../server/proliferate/server/cloud/materialization/service.py)
+(`schedule_materialize_sandbox`, `schedule_repair_materialize_sandbox`,
+`schedule_materialize_repo_environment`, `schedule_materialize_secret_set`,
+`schedule_materialize_agent_auth`) and the engine entry
+`connect_ready_sandbox` in
+[sandbox_io/connect.py](../../../../../server/proliferate/server/cloud/materialization/sandbox_io/connect.py),
+always invoked through
+[operation.py](../../../../../server/proliferate/server/cloud/materialization/operation.py).
+
+Target surface (※ new): **placement** — `place(run) → environment` for the
+task class, called by the runs system and answered from the concurrency
+queue; **reap** after the run's terminal checkpoint; the personal
+ensure/destroy verbs unchanged; no user-facing ensure for the task class
+(runs own it).
+
+## 4. Consumes
+
+- **Provider adapter** —
+  [integrations/sandbox/](../../../../../server/proliferate/integrations/sandbox/base.py)
+  (`SandboxProvider` protocol: create, connect, resume, pause, destroy,
+  state reads, command and file I/O) with the E2B implementation in
+  [e2b.py](../../../../../server/proliferate/integrations/sandbox/e2b.py) and
+  [constants/sandbox/e2b.py](../../../../../server/proliferate/constants/sandbox/e2b.py)
+  (2700 s idle timeout, runtime port 8457). Multi-provider stays behind
+  this adapter; it is a dial, not a build item.
+- **Billing** — the ensure gate and the resume gate
+  ([billing_subjects](../../../../../server/proliferate/db/store/billing_subjects.py));
+  segment cost and holds are billing's
+  ([BILLING.md](../../../../FEATURE_DOCS/BILLING.md)).
+- **Seam** — `create_cloud_sandbox_enrollment` at runtime launch
+  ([runtime_launch.py](../../../../../server/proliferate/server/cloud/materialization/sandbox_io/runtime_launch.py))
+  and worker liveness for `workerDegraded` ([seam.md](../seam/README.md)).
+- **GitHub** — the authority chain (membership ∧ installation ∧ user-auth)
+  that triggers personal-class provisioning; installation-only for the task
+  class ([SANDBOX/github-auth.md](../../../../FEATURE_DOCS/SANDBOX/github-auth.md)).
+- **Secrets / agent auth** — what is materialized into the VM
+  ([materialize/secret_set.py](../../../../../server/proliferate/server/cloud/materialization/materialize/secret_set.py),
+  [materialize/agent_auth.py](../../../../../server/proliferate/server/cloud/materialization/materialize/agent_auth.py));
+  custody laws are theirs.
+- **Managed runtime** — the supervisor-owned launch topology inside the VM
+  ([runtime/bootstrap.py](../../../../../server/proliferate/server/cloud/runtime/bootstrap.py)
+  builds env, launcher, and supervisor config;
+  [MANAGED_RUNTIME.md](../../../../FEATURE_DOCS/MANAGED_RUNTIME.md)).
+- **Runs** (※ new) — the placement request and the terminal checkpoint
+  signal that permits reaping.
+
+## 5. Laws
+
+Lifecycle:
+
+**Only explicit delete destroys a personal sandbox; a task sandbox is reaped
+by its run.** No timeout, error, webhook, or reaper pass sets `destroyed` on
+an attributed personal row — idle sandboxes pause. A task row's death is a
+lifecycle event of the run: terminal → checkpoint acknowledged → pause →
+reap after retention.
+
+**`error` is per-attempt, not terminal.** It records the last failed
+materialization with a sanitized receipt; the next attempt retries the same
+row ([failures.py](../../../../../server/proliferate/server/cloud/materialization/failures.py)).
+
+**Ensure never provisions.** Row bookkeeping is free and unconditionally
+safe to call; provider work happens only inside a materialization operation.
+
+**A sandbox provisions when it first becomes able to do work — not before,
+not lazier.** Personal: authority-chain completion for the (user, org) pair
+schedules one background bootstrap that ends *paused*. Task: placement of a
+run provisions live, with the org installation as the only GitHub authority
+(Law 6: headless runs never hold human credentials).
+
+**The gateway gates on policy, the provider wakes on traffic,
+materialization repairs.** No wake verb exists (grep-gate E6 holds). A row
+with no stamped runtime access answers `409 cloud_sandbox_runtime_not_ready`
+and schedules exactly one repair, claim-deduplicated across processes
+([locks.py](../../../../../server/proliferate/server/cloud/materialization/locks.py)).
+
+**One engine, serialized per sandbox.** `connect_ready_sandbox` under the
+per-sandbox lock: refuse destroyed, re-check the billing gate, bump the
+attempt epoch, resume-or-create, accept the resume conservatively
+([resume_acceptance.py](../../../../../server/proliferate/server/cloud/materialization/sandbox_io/resume_acceptance.py)),
+health-probe the existing runtime
+([liveness_health.py](../../../../../server/proliferate/server/cloud/runtime/liveness_health.py)),
+initialize if needed, mark ready with a CAS write. Lock timeout is a typed
+busy error, never a second engine run.
+
+Fencing (the billing primitives this system owns):
+
+**Three fence inputs, all on the row.** `materialization_attempt` (epoch),
+`provider_sandbox_id` (identity), `provider_observed_at` (freshness floor).
+Every usage open and close names the exact binding it fences; any delayed
+observation at or before the floor is inert.
+
+**Supersession is transactional and committed first.** Only authoritative
+provider-target-not-found detaches a binding: CAS the binding to absent and
+close that exact provider's segment in one transaction before creating a
+replacement. Transient failures never supersede.
+
+**Create records identity and usage together.** A provider create persists
+the exact new provider id and its provision usage in one transaction; an
+ambiguous commit adopts the known candidate rather than losing custody of a
+spending VM.
+
+**Terminal events close exactly one segment.** Kill, delete, and reap each
+close the exact bound provider's segment and nothing else.
+
+Capacity (※ new):
+
+**Placement is admission-controlled per (org, class).** A concurrency policy
+row bounds live task environments per org; placement beyond it queues, never
+fails, and the queue is the one genuinely new backend piece.
+
+**The org is the only billing subject.** No stored payer on the row; the
+subject derives from `organization_id`.
+
+> [!decision] PABLO DECIDES: reap retention for task environments.
+> Options: reap immediately after the checkpoint ack; keep paused for a
+> fixed window (e.g. 24 h) so "open" still works for a just-finished run;
+> per-definition policy. Recommendation: fixed 24 h paused window, then
+> reap — paused compute is nearly free and it keeps the triage view's
+> "open" verb honest for a day.
+
+> [!decision] PABLO DECIDES: personal-class eager bootstrap.
+> The current law provisions on authority-chain completion and ends paused
+> (~bootstrap minutes of spend per user). Options: keep; or make personal
+> sandboxes provision on first workspace use like the task class.
+> Recommendation: keep — the desktop-first product means personal cloud
+> sandboxes are rare, and warm-on-first-open is the whole point of the
+> class.
+
+## 6. Emits
+
+- Sandbox status transitions, projected onto workspace runtime status
+  (`GET /workspaces/{id}/runtime-status` with `workerDegraded`; shape owned
+  by [SANDBOX/access.md](../../../../FEATURE_DOCS/SANDBOX/access.md)).
+- Usage segment open/close with exact provider identity, consumed by
+  billing.
+- Provisioning telemetry
+  ([provisioning_observability.py](../../../../../server/proliferate/server/cloud/provisioning_observability.py)).
+- Target: `environment_bound` / `environment_lost` on the session registry
+  row (drives open / wake / fork), placement queued/admitted for triage, and
+  the task-class `killed → run failed` mapping.
+
+## 7. Fences
+
+- **Seam** owns worker identity, enrollment, heartbeat
+  ([seam.md](../seam/README.md)); environments only mint the ticket at launch.
+- **Managed runtime** owns what runs inside the VM after launch
+  ([MANAGED_RUNTIME.md](../../../../FEATURE_DOCS/MANAGED_RUNTIME.md)).
+- **Runtime gateway** owns the wire from clients to a sandbox's runtime and
+  the bearer swap ([SANDBOX/gateway.md](../../../../FEATURE_DOCS/SANDBOX/gateway.md)).
+- **Workspaces** own repository clones, worktrees, and the two workspace
+  records ([SANDBOX/content.md](../../../../FEATURE_DOCS/SANDBOX/content.md),
+  [cloud-workspace.md](../workspaces/cloud-workspace.md)).
+- **GitHub** owns the authority chain and PR identity.
+- **Billing** owns cost, credits, holds
+  ([BILLING.md](../../../../FEATURE_DOCS/BILLING.md)).
+- **Secrets / agent auth** own custody of what is materialized.
+- **Runs** (※ new) own the run row, its result, and when a task environment
+  may be reaped.
+
+## 8. Code map
+
+Current (`main`; every path under `server/cloud/` relocates to
+`server/environments/` when the cloud shell dissolves — a pure move):
+
+```text
+scripts/
+├── build-template.mjs                              template build, binaries baked in
+├── promote-cloud-template.mjs                      rolling tag → verified immutable tag
+└── smoke-cloud-template.mjs                        throwaway-sandbox smoke
+.github/workflows/
+├── release-cloud-template.yml                      immutable sha-tag build lane, moves :staging
+└── promote-cloud-template.yml                      smoke an immutable tag, move :production
+server/proliferate/
+├── constants/sandbox/e2b.py                        timeout, runtime port, binary path
+├── integrations/sandbox/
+│   ├── base.py                                     SandboxProvider protocol
+│   ├── e2b.py                                      the adapter
+│   ├── e2b_webhooks.py                             webhook shapes (lane re-added for task class)
+│   └── factory.py
+├── db/models/cloud/sandboxes.py                    the row + HarnessLaunchOptionState (agent auth's)
+├── db/store/cloud_sandboxes.py                     fenced transitions: ensure, retry, observe, destroy
+├── server/cloud/provisioning_observability.py      provisioning telemetry
+└── server/cloud/
+    ├── cloud_sandboxes/
+    │   ├── api.py · models.py                      ensure/destroy routes
+    │   ├── service.py                              ensure_personal_cloud_sandbox_exists, destroy
+    │   └── transactions.py
+    ├── materialization/
+    │   ├── service.py                              schedule_* entry points
+    │   ├── operation.py                            per-sandbox lock around every engine run
+    │   ├── locks.py                                Redis claim + distributed lock
+    │   ├── failures.py                             receipts, classification
+    │   ├── manifests.py · paths.py · runner.py
+    │   ├── sandbox_io/
+    │   │   ├── connect.py                          the provisioning engine
+    │   │   ├── resume_acceptance.py                post-resume pause reconciliation
+    │   │   ├── runtime_launch.py                   supervisor-owned launch; mints the worker ticket
+    │   │   ├── commands.py · files.py · safety.py · target.py
+    │   └── materialize/
+    │       ├── sandbox.py                          bootstrap composition
+    │       ├── repo_environment.py · github_credentials.py · git_identity.py   (workspaces / github)
+    │       ├── secret_set.py · agent_auth.py       (secrets / agent auth content)
+    └── runtime/
+        ├── bootstrap.py                            env, launcher, supervisor config
+        ├── liveness_health.py                      health + auth-enforcement probes
+        ├── bundle.py · data_key.py · sandbox_exec.py · domain/
+```
+
+Target additions (※ new): `server/environments/placement/` (concurrency
+policy, queue, `place(run)`), `server/environments/reaper/` (task-class
+reap after checkpoint; orphan backstop), `server/environments/webhooks/`
+(provider lifecycle events, HMAC — salvaged in
+[notes-webhook-hmac.md](../../../../../delivery/cull-sweep/notes-webhook-hmac.md)),
+and a browser in the template for QA / computer-use.
+
+## 9. Proof
+
+Current laws are pinned by
+[test_cloud_sandbox_ensure_billing_gate.py](../../../../../server/tests/integration/test_cloud_sandbox_ensure_billing_gate.py)
+(ensure never provisions, billing gate),
+[test_cloud_sandbox_cold_access_repair.py](../../../../../server/tests/integration/test_cloud_sandbox_cold_access_repair.py)
+(409 + single scheduled repair),
+[test_cloud_sandbox_recovery.py](../../../../../server/tests/integration/test_cloud_sandbox_recovery.py),
+[test_cloud_sandbox_reconnect_self_heal.py](../../../../../server/tests/integration/test_cloud_sandbox_reconnect_self_heal.py),
+[test_cloud_sandbox_billing_recovery.py](../../../../../server/tests/integration/test_cloud_sandbox_billing_recovery.py)
+(fenced segments),
+[test_cloud_sandbox_desired_versions.py](../../../../../server/tests/integration/test_cloud_sandbox_desired_versions.py),
+[test_cloud_materialization_concurrency.py](../../../../../server/tests/unit/test_cloud_materialization_concurrency.py)
+(one engine run per sandbox),
+[test_cloud_materialization_failures.py](../../../../../server/tests/unit/test_cloud_materialization_failures.py)
+(receipts),
+[test_cloud_sandbox_destroy_provider.py](../../../../../server/tests/unit/test_cloud_sandbox_destroy_provider.py)
+(delete kills after commit), and the managed-cloud release world under
+[tests/release/src/worlds/managed-cloud/](../../../../../tests/release/src/worlds/managed-cloud/template.ts).
+
+Target laws (placement, reap, task class) have no tests yet; each lands with
+its build item.
+
+## Known gaps
+
+- [ ] The task class does not exist: no `class` column, no run owner, no
+      placement, no reaper, no concurrency policy. Build order item 2.
+- [ ] Account model is one sandbox per user globally
+      (`ux_cloud_sandbox_personal_active` on `owner_user_id`; the store
+      hardcodes `organization_id=None`). Ruled shape: `organization_id` NOT
+      NULL, uniqueness `(owner_user_id, organization_id)`, no stored payer.
+- [ ] Provisioning does not fire on full authority-chain completion — the
+      user-auth callback alone schedules it; the installation callback and
+      org-join trigger nothing.
+- [ ] The eager bootstrap does not force-pause on completion (~45 idle
+      minutes per provision).
+- [ ] Worker death surfaces as `workerDegraded` but routes to no alert.
+- [ ] The E2B webhook lane and the orphan reaper were deleted in
+      delete-dark-cloud part 1 (zero live consumers while cloud is dark);
+      the task class re-adds both under `server/environments/`, with
+      `killed → run failed` instead of row error-retry.
+- [ ] `runtime_generation` is a hardcoded store constant after its column
+      was dropped; deletion is owned end to end by
+      [SANDBOX/gateway.md](../../../../FEATURE_DOCS/SANDBOX/gateway.md).
+- [ ] Every current path lives under `server/cloud/`, which
+      delete-dark-cloud part 2 is dissolving. Any file above that part 2
+      deletes must come off this map in the same PR; the survivors move to
+      `server/environments/` in sweep Wave 2.
+- [ ] `HarnessLaunchOptionState` shares
+      [sandboxes.py](../../../../../server/proliferate/db/models/cloud/sandboxes.py)
+      with the sandbox row but is agent auth's state; split the model file
+      when the folder moves.
+- [ ] > [!decision] PABLO DECIDES: what survives of `materialization/`.
+      The Cull Plan says the engine and fencing are reused verbatim with a
+      class-aware entry; part 2 of delete-dark-cloud deletes
+      `materialization/` wholesale. These contradict. Options: keep
+      `sandbox_io/connect.py`, `operation.py`, `locks.py`,
+      `resume_acceptance.py`, `runtime_launch.py`, `failures.py` and delete
+      the rest; or delete all and rebuild the engine from this spec.
+      Recommendation: keep the engine files — they are the race-tested money
+      code the fencing laws above describe, and rewriting them is the one
+      part of the rebuild that can lose custody of a spending VM.

--- a/specs/codebase/systems/product/seam/README.md
+++ b/specs/codebase/systems/product/seam/README.md
@@ -1,0 +1,384 @@
+# Seam
+
+Status: target for the courier and event-shipping halves; the worker half
+(enrollment, identity, heartbeat) describes `main`. Grade B / C — see
+[Known gaps](#known-gaps).
+
+Read before touching: `server/proliferate/server/seam/**`,
+`server/proliferate/db/models/runtime_workers.py`,
+`server/proliferate/db/store/runtime_workers.py`,
+`anyharness/crates/proliferate-worker/**` (except `supervisor_bridge/`, which
+belongs to the managed runtime).
+
+## 1. Purpose
+
+The seam is the one contract between the control plane and a runtime. It
+answers three questions and nothing else: *who is this runtime* (identity and
+enrollment), *is it alive and what should it be running* (heartbeat), and —
+the target half — *how do prompts get down and events get up durably*
+(courier and shipping). Everything the control plane knows about a live
+execution environment arrives through this contract; everything a runtime is
+told by the control plane leaves through it. The worker process is the only
+speaker on a target: the runtime never talks to the control plane, and the
+supervisor never does either.
+
+The seam is symmetric by design: prompts travel down keyed by
+`(session, delivery_seq)` with a runtime ack cursor; events travel up keyed by
+`(session, seq)` with a control-plane ack cursor. One cursor discipline, two
+directions. Freezing this contract first is what lets every other system be
+built against it.
+
+## 2. Owned state
+
+Server tables
+([runtime_workers.py](../../../../../server/proliferate/db/models/runtime_workers.py)):
+
+```text
+cloud_runtime_worker_enrollment   single-use ticket: (owner, org?, runtime_kind,
+                                  cloud_sandbox_id | desktop_install_id), token hash,
+                                  status pending|consumed|expired|revoked, TTL
+cloud_runtime_worker              the enrolled identity: runtime_kind cloud_sandbox|desktop,
+                                  status online|offline|revoked, self-reported versions,
+                                  last_seen_at; at most one non-revoked row per sandbox
+                                  and per (owner, desktop install)
+cloud_integration_gateway_token   hash-only derivative of a worker; at most one active
+                                  per worker; revoked with it
+```
+
+Worker-side state (SQLite at `worker_db_path`,
+[store/](../../../../../anyharness/crates/proliferate-worker/src/store/mod.rs)): the
+durable identity `worker_id + worker_token`
+([store/identity.rs](../../../../../anyharness/crates/proliferate-worker/src/store/identity.rs))
+and the last-observed running AnyHarness version
+([store/anyharness_update.rs](../../../../../anyharness/crates/proliferate-worker/src/store/anyharness_update.rs)).
+The worker persists nothing else about its target: sandbox, user, kind,
+revocation, and liveness are control-plane associations.
+
+Worker-written files: the integration-gateway dotfile the runtime reads to
+reach the gateway
+([integration_gateway.rs](../../../../../anyharness/crates/proliferate-worker/src/integration_gateway.rs)).
+
+Target state (※ new, see Known gaps): per-session prompt-outbox delivery
+attempts and the two ack cursors (runtime ack of `delivery_seq`, control-plane
+ack of event `seq`).
+
+> [!decision] PABLO DECIDES: which spec owns the outbox and cursor rows.
+> The session registry row (sessions spec) carries *queued prompts* as
+> content; the seam owns *delivery bookkeeping* (attempt counts, both cursors,
+> the `delivery_stalled` verdict). Options: (a) one `session_prompt_outbox`
+> table owned by the seam, with the registry row holding only a pointer;
+> (b) columns on the registry row owned by sessions, with the seam allowed to
+> write only the cursor columns. Recommendation: (a) — the outbox is a
+> transport object with its own retry laws, and a table with one writer is
+> the Organization Standard's definition of owned state.
+
+## 3. Public surface
+
+All routes mount under `/v1/cloud` via
+[cloud/api.py](../../../../../server/proliferate/server/cloud/api.py) (the mount point
+moves when that shell dissolves; the paths do not change).
+
+Worker-authenticated (bearer `worker_token`,
+[auth.py](../../../../../server/proliferate/server/seam/workers/auth.py)):
+
+| Route | Purpose |
+| --- | --- |
+| `POST /worker/enroll` | Consume a single-use enrollment token; returns `worker_id`, `worker_token`, `heartbeat_interval_seconds`, integration-gateway coordinates |
+| `POST /worker/heartbeat` | Liveness + self-reported versions in; `desired_versions` and the `launch_options_upload_allowed` verdict out |
+| `GET /worker/download/{target}/{asset}` · `GET /runtime/download/{target}/{asset}` | Unauthenticated 302 to the pinned binary on the downloads CDN |
+| `GET /worker/download/{target}/{version}/{asset}` · `GET /runtime/download/{target}/{version}/{asset}` | Exact-version 302; fails closed (404) on an unpublished version, never falls back to a rolling label |
+
+User-authenticated:
+
+| Route | Purpose |
+| --- | --- |
+| `POST /workers/desktop/enrollment` | Mint a 900 s enrollment token for the caller's desktop install, optionally org-scoped (membership-validated) |
+| `POST /workers/desktop/revoke` | Revoke the caller's active desktop worker and its gateway token; idempotent |
+| `PUT /workers/admin/sandboxes/{cloud_sandbox_id}/desired-versions` | Instance-admin per-target version override (`null` clears) |
+
+Python surface (the only importable modules, per
+[MANIFEST.toml](../../../../../server/proliferate/server/seam/MANIFEST.toml)):
+[workers/api.py](../../../../../server/proliferate/server/seam/workers/api.py),
+[workers/service.py](../../../../../server/proliferate/server/seam/workers/service.py)
+— `create_cloud_sandbox_enrollment` is how environments mint a sandbox
+worker's ticket at runtime launch — and
+[workers/models.py](../../../../../server/proliferate/server/seam/workers/models.py).
+`authenticate_worker` in
+[workers/auth.py](../../../../../server/proliferate/server/seam/workers/auth.py) is the
+dependency any worker-facing route on another system uses to establish a
+`WorkerAuthContext`.
+
+Worker binary surface: `proliferate-worker` configured by
+[config.rs](../../../../../anyharness/crates/proliferate-worker/src/config.rs)
+(`cloud_base_url`, `enrollment_token`, `worker_db_path`,
+`heartbeat_interval_seconds`, `runtime_base_url`,
+`supervisor_update_request_dir`); `--once` performs one heartbeat as a dry
+run.
+
+Target surface (※ new): the courier delivery call into the runtime, the
+runtime's ack of `delivery_seq`, the event-ingest POST keyed by
+`(session, seq)`, and the checkpoint upload — all cursor-shaped and
+idempotent. Whether these ride the heartbeat or dedicated routes is a
+decision below.
+
+## 4. Consumes
+
+- [db/store/runtime_workers.py](../../../../../server/proliferate/db/store/runtime_workers.py)
+  — its own store, and the only writer of the three tables above.
+- [db/store/cloud_sandboxes.py](../../../../../server/proliferate/db/store/cloud_sandboxes.py)
+  — read-only: per-sandbox desired-version overrides and `destroyed_at` for
+  the upload verdict (environments).
+- [db/store/organizations.py](../../../../../server/proliferate/db/store/organizations.py)
+  and
+  [db/store/instance_organizations.py](../../../../../server/proliferate/db/store/instance_organizations.py)
+  — membership validation for org-scoped desktop enrollment; instance-admin
+  check for the desired-versions route (organizations / accounts).
+- [server/version.py](../../../../../server/proliferate/server/version.py) — the
+  fleet pins `RUNTIME_VERSION` / `WORKER_VERSION` stamped at build time.
+- [integrations/desktop_downloads.py](../../../../../server/proliferate/integrations/desktop_downloads.py)
+  — CDN URL resolution behind the 302 routes.
+- [constants/cloud.py](../../../../../server/proliferate/constants/cloud.py) — the
+  seam's numbers: heartbeat interval 30 s, offline threshold 90 s, enrollment
+  TTLs 3600 s (sandbox) / 900 s (desktop), HMAC token domains.
+
+Worker side: the runtime's local HTTP surface (read-only version poll
+`GET /v1/catalogs/agents/version`, launch-option state reads) and the
+supervisor mailbox directory (write-only, managed runtime).
+
+## 5. Laws
+
+**One active worker per identity.** Enrollment retires every prior
+non-revoked worker for the same sandbox, or for the same desktop install
+regardless of owner (a user switch on one machine must not leave the previous
+user's worker "online" with a live gateway token). Enforced by the partial
+unique indexes on `cloud_runtime_worker` and by `enroll_worker` in
+[service.py](../../../../../server/proliferate/server/seam/workers/service.py).
+
+**Enrollment tokens are single-use, bounded, and hash-only.** The raw token is
+returned once and never stored; consumption is a compare-and-swap on the
+pending row (`consume_pending_enrollment_by_hash`); a desktop install's newer
+ticket revokes older pending ones so a stranded predecessor cannot enroll
+after its replacement (`revoke_pending_desktop_enrollments_for_install`).
+
+**A durable identity always wins over a config enrollment token, and a
+revoked identity never re-enrolls itself.** The worker uses a stored
+`worker_id + worker_token` if present and only enrolls when none exists
+([identity/mod.rs](../../../../../anyharness/crates/proliferate-worker/src/identity/mod.rs)).
+Re-enrollment is a control-plane act (a new ticket), never a worker reflex.
+
+**Heartbeat is liveness and desired state, nothing more.** The request carries
+status and self-reported versions; the ack carries the fleet or per-target
+pins and one verdict. A missed heartbeat never fails the worker loop — the
+current binary keeps serving and the next tick retries
+([runtime.rs](../../../../../anyharness/crates/proliferate-worker/src/runtime.rs)).
+Liveness on the control plane is `status = online` with `last_seen_at` inside
+the 90 s threshold.
+
+**Authentication is a separate boundary from the verdict.** A missing,
+unknown, or revoked worker receives `401 cloud_worker_unauthorized` with no
+body — never a 200 whose `launch_options_upload_allowed` happens to be
+`false`. The heartbeat service re-loads the row (REL-10) so a revocation
+racing the auth dependency still produces the 401.
+
+**The upload verdict is required on every 200 and fails closed.** The server
+computes it from the same rule the ingest route enforces (cloud-sandbox
+worker, sandbox exists, not destroyed); a worker that receives no field
+treats it as `false`
+([lifecycle/heartbeat.rs](../../../../../anyharness/crates/proliferate-worker/src/lifecycle/heartbeat.rs)).
+It is never cached across ticks and never influences convergence.
+
+**Exact versions or nothing.** The versioned download routes resolve the
+requested version or 404; rolling labels (`stable`, `latest`, …) are refused
+on that path so a pinned target is never handed a differently-labelled
+artifact (`_reject_rolling_or_unsafe_version`).
+
+**The gateway token is a derivative, not a peer.** It is minted at
+enrollment, written to the runtime's dotfile by the worker, revoked with the
+worker, and re-asserted after every successful heartbeat so a delayed
+predecessor write cannot leave stale authority on disk
+(`integration_gateway::ensure_current`). What the token *authorizes* is the
+integration gateway's law, not the seam's.
+
+**The worker is the only control-plane speaker on a target.** The runtime
+and the supervisor have no control-plane credentials; the worker relays. This
+is what makes the seam one contract rather than three.
+
+Target laws (※ new — asserted here so the build has a fixed target):
+
+**Session before compute is durable by construction.** A prompt enqueues into
+the outbox `(session, delivery_seq)` in the same transaction that creates the
+session or invocation; the courier pushes when the environment is ready.
+
+**Ack means persisted, not answered.** The runtime dedups on
+`(session, delivery_seq)`, persists into its own log before acting, and only
+then acks; the response is observed on the event pipe. Delivery is strictly
+ordered per session with head-of-line blocking; undeliverable past N attempts
+marks the session `delivery_stalled` — surfaced, never silently dropped.
+
+**Shipping is idempotent and at-least-once on `(session, seq)`.** The control
+plane dedups; a control-plane outage never affects the runtime — the worker
+retries from its ack cursor, and every heartbeat carries both cursors as the
+≤30 s drain backstop.
+
+**Ship policy is structural.** Ship-now = turn-level and lifecycle events
+(assistant message completed, status transitions, run result, explicit
+milestones); checkpoint = intra-turn durable events at terminal states and
+pauses; never-persist = token deltas and typing. The runtime never knows who
+is watching; fan-out is the control plane's job by binding. The live mirror is
+this same endpoint called more often — a frequency dial, never a migration.
+
+## 6. Emits
+
+- Worker liveness, consumed by the workspace runtime-status projection as
+  `workerDegraded` (environments / runtime gateway) and by the
+  fleet-convergence dashboard (`worker_version`, `anyharness_version`,
+  `catalog_version` are telemetry only — never desired state).
+- `desired_versions` on the heartbeat ack, consumed by the worker's
+  convergence path and, on supervisor-owned targets, turned into a mailbox
+  request (managed runtime).
+- Worker-side structured events in
+  [observability.rs](../../../../../anyharness/crates/proliferate-worker/src/observability.rs)
+  (heartbeat ack, enrollment) with secret scrubbing in
+  [logging/scrub.rs](../../../../../anyharness/crates/proliferate-worker/src/logging/scrub.rs).
+- Target: ship-now session events → control-plane ingest → binding fan-out
+  (Slack thread, push, registry); `delivery_stalled` on the session registry
+  row.
+
+## 7. Fences
+
+- **Managed runtime** owns the supervisor, the file mailbox, binary swaps,
+  and the launch topology — everything under
+  [supervisor_bridge/](../../../../../anyharness/crates/proliferate-worker/src/supervisor_bridge/mod.rs)
+  and the L1–L8 laws in
+  [MANAGED_RUNTIME.md](../../../../FEATURE_DOCS/MANAGED_RUNTIME.md). The seam hands it
+  a `desired_versions` verdict and stops.
+- **Integration gateway** owns what the gateway token may do
+  ([integration_gateway/](../../../../../server/proliferate/server/integration_gateway/MANIFEST.toml)).
+- **Agent auth / models** own the launch-option and model-snapshot content
+  the worker copies up
+  ([launch_options_sync.rs](../../../../../anyharness/crates/proliferate-worker/src/launch_options_sync.rs)
+  is seam transport; the payload is opaque to it —
+  [MODELS.md](../../../../FEATURE_DOCS/MODELS.md)).
+- **Environments** own the sandbox row, provisioning, and the moment a cloud
+  worker's ticket is minted
+  ([environments.md](../environments/README.md)).
+- **Desktop host** owns when and how the desktop app requests a ticket
+  ([use-desktop-worker-enrollment.ts](../../../../../apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts),
+  [DESKTOP_HOST.md](../../../../FEATURE_DOCS/DESKTOP_HOST.md)).
+- **Sessions** own the registry row's content and the runtime's event log;
+  the seam moves envelopes and cursors, never interprets them
+  ([sessions.md](../sessions/README.md)).
+
+## 8. Code map
+
+```text
+server/proliferate/
+├── constants/cloud.py                              intervals, TTLs, HMAC token domains
+├── db/models/runtime_workers.py                    the three tables + uniqueness fences
+├── db/store/runtime_workers.py                     hashing, CAS consumption, revocation cascades
+└── server/seam/
+    ├── MANIFEST.toml
+    ├── __init__.py
+    └── workers/
+        ├── models.py                               wire shapes (camelCase), version-identifier admission
+        ├── auth.py                                 bearer → WorkerAuthContext
+        ├── service.py                              enrollment, heartbeat, artifact redirects, admin pins
+        └── api.py                                  the routes above
+
+anyharness/crates/proliferate-worker/src/
+├── main.rs                                         entry; config load; run loop
+├── config.rs                                       WorkerConfig
+├── runtime.rs                                      ensure_enrolled → heartbeat_and_converge loop
+├── identity/
+│   ├── mod.rs                                      durable-identity-wins precedence
+│   ├── enrollment.rs                               enroll request/response mapping
+│   ├── credentials.rs                              WorkerIdentity
+│   └── fingerprint.rs                              machine fingerprint
+├── cloud_client/
+│   ├── mod.rs                                      HTTP client: enroll, heartbeat, ingest, artifact resolve
+│   ├── auth.rs                                     bearer header
+│   ├── heartbeat.rs                                request builder
+│   └── tests.rs
+├── lifecycle/
+│   ├── mod.rs
+│   └── heartbeat.rs                                send_once, interval floor (10 s), catalog-version poll
+├── integration_gateway.rs                          dotfile write + post-heartbeat repair
+├── launch_options_sync.rs                          verdict-gated launch-option copy (payload opaque)
+├── store/
+│   ├── mod.rs · connection.rs · migrations.rs      worker SQLite
+│   ├── identity.rs                                 worker_id + worker_token
+│   └── anyharness_update.rs                        last observed running runtime version
+├── versions.rs                                     running-version resolution
+├── observability.rs · logging.rs · logging/scrub.rs
+├── process_lock.rs                                 one worker process per db path
+├── error.rs · test_support.rs · runtime_tests.rs
+└── supervisor_bridge/                              NOT SEAM — managed runtime (mailbox)
+```
+
+Target additions (※ new, not on `main`): `server/seam/courier/` (outbox drain,
+delivery attempts, wake-on-completion messages), `server/seam/ingest/`
+(ship-now endpoint, checkpoint upload, cursors, binding fan-out), and the
+worker's event shipper subscribed to the runtime's loopback SSE.
+
+## 9. Proof
+
+- [test_cloud_runtime_workers_api.py](../../../../../server/tests/integration/test_cloud_runtime_workers_api.py)
+  — enrollment consumption, single-active-worker retirement, heartbeat 401
+  on revocation.
+- [test_cloud_runtime_worker_ticket_fencing.py](../../../../../server/tests/integration/test_cloud_runtime_worker_ticket_fencing.py)
+  — newest-wins desktop ticket rotation.
+- [test_cloud_runtime_worker_versions_api.py](../../../../../server/tests/integration/test_cloud_runtime_worker_versions_api.py)
+  — admin per-target pins, rolling-label refusal.
+- [test_cloud_runtime_workers_launch_options_eligibility.py](../../../../../server/tests/integration/test_cloud_runtime_workers_launch_options_eligibility.py)
+  — the verdict rule equals the ingest rule.
+- [test_worker_heartbeat_contract.py](../../../../../server/tests/unit/test_worker_heartbeat_contract.py)
+  with
+  [helpers/worker_heartbeat.py](../../../../../server/tests/helpers/worker_heartbeat.py)
+  — Python model serializes byte-for-byte to the shared fixtures the Rust
+  side decodes (compat both directions).
+- [cloud_client/tests.rs](../../../../../anyharness/crates/proliferate-worker/src/cloud_client/tests.rs)
+  and
+  [runtime_tests.rs](../../../../../anyharness/crates/proliferate-worker/src/runtime_tests.rs)
+  — worker-side enrollment precedence, verdict fail-closed, dotfile repair.
+
+## Known gaps
+
+- [ ] Courier (down) and shipping (up) do not exist. Today the control plane
+      reaches the runtime directly through the runtime gateway for prompts
+      and reads, and nothing ships events up; background runs with no
+      attached client have no egress. Build order item 1.
+- [ ] > [!decision] PABLO DECIDES: transport for the target half.
+      Options: (a) piggyback both cursors and small ship-now batches on the
+      existing heartbeat (one route, 30 s floor, simplest); (b) dedicated
+      `POST /worker/events` + `POST /worker/checkpoints` + a courier pull
+      `GET /worker/deliveries` with the heartbeat carrying only cursors as the
+      drain backstop. Recommendation: (b) — the settled design needs
+      sub-second ship-now for Slack, which the heartbeat cadence cannot give,
+      and the heartbeat stays a pure liveness signal.
+- [ ] > [!decision] PABLO DECIDES: who POSTs events — the worker (subscribed
+      to the runtime's loopback SSE, as the settled design says) or the
+      runtime itself. Recommendation: the worker, to keep "the worker is the
+      only control-plane speaker" a law with zero exceptions.
+- [ ] > [!decision] PABLO DECIDES: desktop courier. Purely local sessions
+      never touch the control plane; a desktop-bound session created by a
+      trigger needs *some* courier. Options: the desktop client polls the
+      outbox as a client courier; or the desktop worker gains the same
+      courier pull as a sandbox worker. Recommendation: the worker — one
+      seam, both target classes, no client-side delivery logic.
+- [ ] Task-class enrollment carries no `(subject, run)` today; the enrollment
+      row is owner-user keyed. Environments' task class needs the ticket
+      minted for a run, with the org as subject (Law 6: headless runs hold no
+      human credentials).
+- [ ] [MANIFEST.toml](../../../../../server/proliferate/server/seam/MANIFEST.toml)
+      `allowed_importers` lists `cloud`, `cloud/harness_launch_options`,
+      `cloud/materialization` — all dissolving under
+      [delivery-spec-delete-dark-cloud.md](../../../../../delivery/cull-sweep/delivery-spec-delete-dark-cloud.md).
+      After part 2 the importers are `environments` (ticket minting at launch)
+      and `agent_auth` (launch-option ingest); the checker re-measures.
+- [ ] The admin desired-versions route and the exact-version download
+      routes serve the managed runtime's convergence story; they live in the
+      seam because they share the worker's auth and store. If the managed
+      runtime spec graduates into `specs/systems/`, re-fence them there.
+- [ ] `MANAGED_RUNTIME.md` still narrates enrollment and heartbeat in full;
+      those two sections now defer here (banner added in this PR) and should
+      shrink to worker-side mechanics only.

--- a/specs/codebase/systems/product/sessions/README.md
+++ b/specs/codebase/systems/product/sessions/README.md
@@ -1,0 +1,321 @@
+# Sessions
+
+Status: target for the control-plane registry half; the runtime event log
+and its API describe `main`. Grade B / C — see [Known gaps](#known-gaps).
+
+Read before touching: `anyharness/crates/anyharness-lib/src/domains/sessions/**`,
+`anyharness/crates/anyharness-lib/src/live/sessions/**`,
+`anyharness/crates/anyharness-lib/src/api/http/sessions_*.rs`,
+`anyharness/crates/anyharness-lib/src/api/sse/sessions.rs`,
+`anyharness/crates/anyharness-contract/src/v1/events.rs`.
+
+## 1. Purpose
+
+A session is the product object a person or an agent talks to: one ordered,
+durable conversation with one harness in one workspace. This system owns
+the session as *two objects with one name*: the runtime's execution-side
+record — the append-only event log and the durable session row beside it —
+and the control plane's registry row, which exists before any compute and
+outlives the environment. The record is what a reader sees; the process
+state is what a resumed harness needs; they are different objects, and
+this spec keeps them different.
+
+The runtime half is converged and proven. The control-plane half is the
+build that makes sessions durable, addressable from Slack and the API, and
+readable without waking a VM.
+
+## 2. Owned state
+
+Runtime (SQLite per runtime, schema in
+[0001_initial.sql](../../../../../anyharness/crates/anyharness-lib/src/persistence/sql/0001_initial.sql)
+and successors under
+[persistence/sql/](../../../../../anyharness/crates/anyharness-lib/src/persistence/sql/0001_initial.sql)):
+
+```text
+sessions                       id, workspace_id, agent_kind, native_session_id, status, timestamps
+session_events                 (session_id, seq) UNIQUE · timestamp · event_type · turn_id · item_id
+                               · payload_json · completion_wake_removal_key — the log
+session_raw_notifications      raw ACP traffic for debugging (never the record)
+session_live_config_snapshots  persisted live-config, queued config changes
+session_pending_config_changes
+session_adapter_markers        adapter migration markers
+session links / fork operations / launch intents / pending prompts /
+completion deliveries / support windows / attachments / titles
+```
+
+Written only through
+[domains/sessions/store/](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/mod.rs).
+The durable session row (`SessionRecord`,
+[model.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/model.rs))
+and the event record (`SessionEventRecord`) are this system's two core
+models.
+
+Control plane (※ new): the **session registry row** — id, subject,
+environment binding, status, external bindings
+(`{kind: "slack", team_id, channel_id, thread_ts}` and later Linear/GitHub/
+email), and the queued-prompt content the seam's outbox delivers — plus the
+**checkpointed record**: the shipped event log, with retention tiers.
+
+> [!decision] PABLO DECIDES: session identity across planes.
+> Options: (a) the registry row's id *is* the runtime session id (the
+> control plane mints it and the courier passes it down, so every event
+> envelope already carries the global id); (b) separate ids joined by a
+> binding column. Recommendation: (a) — one id per session everywhere is the
+> only way "same name every plane" holds for the most-referenced object in
+> the product.
+
+## 3. Public surface
+
+Runtime HTTP (route modules under
+[api/http/](../../../../../anyharness/crates/anyharness-lib/src/api/http/sessions_lifecycle.rs);
+full operation contract in [api.md](../../../../anyharness/api.md)):
+
+| Route | Purpose |
+| --- | --- |
+| `POST /v1/sessions` · `GET /v1/sessions/{id}` | create-and-start (idempotent), read |
+| `POST …/prompt` · `…/pending-prompts/{seq}` · `…/pending-prompts/order` · `…/pending-prompts/{seq}/steer` | prompt queue: enqueue, cancel, reorder, steer |
+| `POST …/cancel` · `…/close` · `…/dismiss` · `…/resume` · `/v1/workspaces/{id}/sessions/restore` | lifecycle |
+| `GET …/events` · `GET …/events/support-window` · `GET …/raw-notifications` | the log: replay from a cursor, support windows |
+| `POST …/fork` | fork-with-context at an anchor seq |
+| `…/interactions/{request_id}/resolve` · `…/mcp-url/reveal` | permission and interaction resolution |
+| `…/live-config` · `…/config-options` · `…/title` · `…/goal` · `…/loops` · `…/reviews` | live configuration and session-scoped features |
+| `…/subagents` · `…/subagents/{child}/open|close|promote` | in-environment subagent fan-out (surface here; laws in the subagents spec) |
+
+Runtime SSE: `GET /v1/sessions/{id}/stream`
+([api/sse/sessions.rs](../../../../../anyharness/crates/anyharness-lib/src/api/sse/sessions.rs))
+— the loopback source the seam's shipper subscribes to.
+
+Contract types: `SessionEvent`, `SessionEventEnvelope`
+([events.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/events.rs))
+— the one canonical envelope every plane speaks.
+
+Control plane (※ new): registry create/read/list, external-binding
+attach/detach, checkpoint read — exposed through the API system's `/v1`
+verbs, not as a second front door.
+
+## 4. Consumes
+
+- **Workspaces** — `workspace_id`, worktree and MCP workspace attachment
+  ([workspace_mcp_attachment.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/workspace_mcp_attachment.rs);
+  owner: [workspaces.md](../../../../anyharness/workspaces.md)).
+- **Harnesses / adapters** — the ACP driver a session actor speaks
+  ([acp.md](../../../../anyharness/acp.md), [adapters.md](../../../../anyharness/adapters.md)).
+- **Agent auth** — launch environment and credential application
+  ([launch_env.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs);
+  owner: [AGENT_AUTH.md](../../../../FEATURE_DOCS/AGENT_AUTH.md)).
+- **Integration gateway** — MCP bindings assembled per session
+  ([mcp_bindings/](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/mod.rs)).
+- **Workflows (gen-2)** — durable workflow links
+  ([workflow_links.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/workflow_links.rs);
+  owner: [WORKFLOWS.md](../../../../FEATURE_DOCS/WORKFLOWS.md)).
+- **Seam** (target) — courier delivery of queued prompts and shipping of
+  ship-now events ([seam.md](../seam/README.md)).
+
+## 5. Laws
+
+The five event-log invariants (architecture Law 10), each with its
+enforcing path:
+
+**Append-only.** There is no UPDATE path on `session_events`; the only
+DELETE is whole-session deletion
+([store/sessions.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/sessions.rs)).
+Repairs write new events, never rewrite old ones.
+
+**Per-session monotonic seq.** Durable appends take
+`COALESCE(MAX(seq), 0) + 1` inside the transaction
+([store/events.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/events.rs)
+`append_event_with_next_seq`); a live actor assigns seq from memory through
+its `SessionEventSink`, and the two never run concurrently — the ACP
+start/inject critical section in [acp.md](../../../../anyharness/acp.md) is the
+guard. `UNIQUE (session_id, seq)` is the backstop.
+
+**One canonical envelope.** `SessionEventEnvelope { session_id, seq,
+timestamp, turn_id?, item_id?, event }` from the contract crate is the
+only shape the log, the SSE stream, the SDKs, and (target) the shipped
+record use. Persisted payloads are sanitized copies
+([persisted_payloads.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/persisted_payloads.rs));
+the original is what the stream emits.
+
+**Classed.** `event_type` is the class key. Ship policy on top of it is
+structural (turn-level and lifecycle = ship now; intra-turn = checkpoint;
+deltas = never persist) and lives in the seam; the runtime never learns who
+is watching.
+
+**Cursor-replayable.** `list_events` reads `ORDER BY seq`; support windows
+and fork anchors are seq ranges
+([support_windows.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/support_windows.rs),
+[fork_anchor.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork_anchor.rs)).
+A client that stops at the first sequence hole (PRO-352) is correct by this
+law, not by convention.
+
+Session-object laws:
+
+**The record and the process state are different objects.** The record is
+the log; process state is harness-native (`native_session_id`, adapter
+markers, the harness's own files). *Resume* is environment-bound; when the
+environment is gone the product offers *fork with context* and never calls
+it resume. The environment binding state drives the verb: live → open,
+paused → wake, reaped or lost → fork.
+
+**Prompt queue admission is durable and ordered.** Prompts persist before
+dispatch ([prompt_queue.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_queue.rs),
+[pending_prompts.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/pending_prompts.rs));
+creation is idempotent
+([idempotent_create.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/idempotent_create.rs)).
+This is the runtime half of the seam's "ack means persisted" law.
+
+**Completion deliveries are exactly-once by removal key.** A child's
+terminal turn wakes its parent through a durable record keyed by
+`completion_wake_removal_key`
+([completion_deliveries/](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/completion_deliveries.rs)),
+so a wake is never delivered twice and never lost across a restart.
+
+**One session, one runtime, one ordered log; every client is a replica.**
+The server relays prompts *as a client* and is never a second writer to the
+log. Multiplayer is fan-out of one stream, not merge of two.
+
+Target laws (※ new):
+
+**Session before compute.** The registry row, its bindings, and the first
+queued prompt are created in one transaction and acknowledged instantly;
+the environment catches up through the courier.
+
+**Reads never wake a VM.** Bound surfaces (Slack, mobile, triage) read the
+checkpointed record at the control plane.
+
+**Deletion orders after checkpoint.** A session is deletable at the runtime
+only once its terminal checkpoint is acknowledged by the control plane;
+otherwise the record is lost with the VM.
+
+> [!decision] PABLO DECIDES: collaboration default. The settled architecture
+> says org-open sessions (Ramp's forced-multiplayer lesson). Options:
+> org-open by default with per-session private; private by default with
+> explicit share. Recommendation: org-open — it is the setting that makes
+> the Slack thread, the triage view, and the parent–child run tree work
+> without a sharing step.
+
+## 6. Emits
+
+- The session event stream (`SessionEventEnvelope`) over SSE, consumed by
+  the product client's transcript
+  ([chat/transcript.md](../chat/transcript.md)),
+  the runtime gateway proxy, and (target) the seam's shipper.
+- Terminal turn and subagent-wake records
+  ([completion_deliveries.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/completion_deliveries.rs)),
+  consumed by subagent orchestration and the wake-on-completion courier
+  message.
+- Session status transitions (`status` on the row), consumed by workspace
+  surfaces and the registry projection.
+- Target: the checkpointed record and `run result` linkage consumed by
+  runs/triage, and binding fan-out posts consumed by the Slack system.
+
+## 7. Fences
+
+- **Subagents** own in-environment fan-out semantics — the `…/subagents`
+  routes are a surface on this object, but per-subagent auth, promotion,
+  and the product MCP are the subagents spec's
+  ([agent_operations/](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mod.rs),
+  [delegated-work.md](../agents/delegated-work.md)).
+- **Observers** (goals, loops, activity roster) are session-scoped
+  features living in this folder today
+  ([active_goals.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/active_goals.rs),
+  [active_loops.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/active_loops.rs),
+  [active_activity_roster.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/active_activity_roster.rs))
+  — sections of this spec until the observers fold (sweep Wave 3) gives
+  them a home.
+- **Live runtime** internals — actor, driver, sink, rendezvous — are the
+  runtime owner docs' ([live-runtime.md](../../../../anyharness/live-runtime.md),
+  [session-actor.md](../../../../anyharness/session-actor.md),
+  [session-engine.md](../../../../anyharness/session-engine.md)); this spec states
+  the laws they uphold, not their folder shape.
+- **Runtime gateway** owns proxying a client to a session's runtime
+  ([SANDBOX/gateway.md](../../../../FEATURE_DOCS/SANDBOX/gateway.md)); sessions own
+  what is proxied.
+- **Chat** (client surface) owns rendering, composer, ingest hydration and
+  hole detection ([chat/](../chat/README.md)).
+- **Seam** owns transport and cursors ([seam.md](../seam/README.md)); sessions own
+  content.
+- **Workspaces** own the worktree a session runs in and session selection
+  within a workspace
+  ([session-selection.md](../workspaces/session-selection.md)).
+
+## 8. Code map
+
+```text
+anyharness/crates/anyharness-contract/src/v1/
+└── events.rs                                    SessionEvent · SessionEventEnvelope — the envelope
+
+anyharness/crates/anyharness-lib/src/
+├── persistence/sql/0001_initial.sql             sessions + session_events + UNIQUE (session_id, seq)
+├── domains/sessions/
+│   ├── mod.rs
+│   ├── model.rs                                 SessionRecord · SessionEventRecord
+│   ├── store/                                   the only writer
+│   │   ├── mod.rs
+│   │   ├── sessions.rs                          row CRUD, whole-session delete
+│   │   ├── events.rs                            append (MAX(seq)+1), list ORDER BY seq
+│   │   ├── persisted_payloads.rs                sanitized persisted copy
+│   │   ├── pending_prompts.rs · idempotent_create.rs
+│   │   ├── completion_deliveries.rs · completion_deliveries/
+│   │   ├── fork_operations.rs · links.rs · link_completions.rs · launch_intents.rs
+│   │   ├── live_config.rs · support_windows.rs · titles.rs · workflow_links.rs
+│   │   ├── adapter_markers.rs · attachments.rs · background_work.rs · mobility.rs
+│   │   ├── notifications.rs · opencode_message_ids.rs
+│   │   └── tests/                               proof (below)
+│   ├── service/                                 durable-layer service
+│   ├── prompt/                                  prompt shapes
+│   ├── runtime/                                 create-and-start, resume, prompt dispatch, fork, lifecycle
+│   ├── live_config/                             persisted live configuration
+│   ├── mcp_bindings/                            per-session MCP assembly (consumes integration gateway)
+│   ├── links/                                   durable session links
+│   ├── admission.rs · delegation.rs · deletion.rs · extensions.rs
+│   ├── execution_summary.rs · fork_operation.rs · launch_intent.rs · live_ports.rs
+│   ├── adapter_migration.rs · attachment_storage.rs
+│   └── active_goals.rs · active_loops.rs · active_activity_roster.rs   observers (fenced above)
+├── live/sessions/                               actor · driver · sink · manager · rendezvous (owner docs)
+├── api/http/sessions_*.rs                       routes above
+└── api/sse/sessions.rs                          the event stream
+
+server/proliferate/server/                       ※ new: sessions/ (registry, bindings, record, retention)
+```
+
+## 9. Proof
+
+- [store/tests/events.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/events.rs)
+  — append/seq/ordering.
+- [store/tests/runtime_event_idempotency.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/runtime_event_idempotency.rs)
+  — idempotent runtime-owned appends.
+- [store/tests/pending_prompt_events.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/pending_prompt_events.rs)
+  and
+  [store/tests/pending_prompts.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/pending_prompts.rs)
+  — durable prompt admission.
+- [store/tests/delete.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/delete.rs)
+  — whole-session deletion is the only delete.
+- [runtime/idempotent_creation_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/idempotent_creation_tests.rs),
+  [runtime/checkpoint_dispatch_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/checkpoint_dispatch_tests.rs),
+  [runtime/fork_prompt_terminal_protection_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork_prompt_terminal_protection_tests.rs)
+  — creation, checkpoint dispatch, fork protection.
+- The five-invariants clearance recorded in the cull investigation
+  (append-only, `MAX(seq)+1`, no UPDATE paths) — re-run as a grep gate:
+  `grep -rn "UPDATE session_events" anyharness/` must stay empty.
+
+## Known gaps
+
+- [ ] The control-plane registry row, external bindings, checkpointed
+      record, and retention tiers do not exist; today the control plane
+      reads sessions only by proxying to the runtime. Build order item 5.
+- [ ] No pinning test for "deletion orders after checkpoint" because
+      checkpoints do not exist yet; add it with the seam's ingest.
+- [ ] Client ingest hole-detection (PRO-351/352) lives in the chat surface
+      and becomes redundant once bound surfaces read the control-plane
+      replica; bugfix-only until then.
+- [ ] > [!decision] PABLO DECIDES: retention tiers for the checkpointed
+      record (full log vs turn-level skeleton vs summary) and who pays.
+      Recommendation: full log for 30 days, skeleton indefinitely, org-billed
+      storage deferred until it measurably matters.
+- [ ] > [!decision] PABLO DECIDES: whether `goals`, `loops`, and the activity
+      roster become one `observers` system (sweep Wave 3) or stay sections
+      here. Recommendation: fold into `observers` — they share a trigger
+      framework and none owns state a session reader needs.
+- [ ] The `…/reviews` route hangs the review lane on sessions; it moves with
+      the one-review-system ruling.


### PR DESCRIPTION
## What

Three living system specs in the nine-section anatomy (Purpose · Owned state · Public surface · Consumes · Laws · Emits · Fences · Code map · Proof + Known gaps), placed per specs/README.md's routing law at `specs/codebase/systems/product/<name>/README.md` (matching #2225):

| Spec | Grade | Notes |
|---|---|---|
| seam | B (workers) / C (courier, shipping) | enrollment/identity/heartbeat from `server/seam/workers` + `proliferate-worker`; courier/shipping asserted as target |
| sessions | B (runtime log) / C (registry) | five event-log invariants each tied to enforcing code; CP registry/bindings/checkpoints as target |
| environments | C | one primitive, two classes; current personal implementation recorded as archaeology (dissolving under delete-dark-cloud part 2) |

Aligned small changes: seam `MANIFEST.toml` → its spec; supersession pointers in `SANDBOX/lifecycle.md` and `MANAGED_RUNTIME.md` (enrollment + heartbeat sections); three rows + anatomy note in the product systems index. No code, no moves.

## Verification
- `python3 scripts/check_docs.py` green (244 files); `scripts/check_manifests.py` OK.
- Adversarial code-map pass (inline script): all 144 code-map entries resolve on main; zero files claimed by two specs; the only non-literal entry is the deliberate glob `api/http/sessions_*.rs`.
- Route tables read from the route modules directly (`seam/workers/api.py`; every `/v1/sessions…` string in `anyharness-lib/src/api/http`; SSE path `/v1/sessions/{id}/stream`).

## PABLO DECIDES (founder rulings requested)
**seam**: outbox/cursor table ownership (rec: seam-owned table) · transport for courier/shipping (rec: dedicated routes, heartbeat carries cursors) · who POSTs events (rec: worker) · desktop courier (rec: worker).
**sessions**: one session id across planes (rec: yes) · collaboration default (rec: org-open) · record retention tiers (rec: full 30d, skeleton indefinitely) · goals/loops/activity → observers (rec: fold).
**environments**: class column vs two tables (rec: column) · task reap retention (rec: 24h paused) · keep personal eager bootstrap (rec: keep) · what survives of `materialization/` vs delete-dark-cloud part 2 — **spec/cull contradiction flagged** (rec: keep the engine files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)