### PR TITLE
docs(specs): runtime-plane system specs — workspaces, harnesses, subagents, terminals, artifacts, desktop host

### DIFF
--- a/specs/FEATURE_DOCS/DESKTOP_HOST.md
+++ b/specs/FEATURE_DOCS/DESKTOP_HOST.md
@@ -1,5 +1,7 @@
 # Desktop Host
 
+> Ownership: this document is the depth reference for the **desktop-host** system spec ([README.md](../codebase/systems/runtime/desktop-host/README.md)). Laws, owned state, fences and the checked code map are authoritative there; flow-level detail stays here.
+
 Read before touching: `apps/desktop/`, `apps/packages/product-client/`, `apps/packages/product-client/src/host/`, `apps/packages/product-client/src/app/ProductClient.tsx`
 
 This doc owns the web bundle ↔ native shell ↔ sidecar seam. It does not own

--- a/specs/anyharness/agents.md
+++ b/specs/anyharness/agents.md
@@ -1,5 +1,7 @@
 # Agents
 
+> Ownership: this document is the depth reference for the **harnesses** system spec ([README.md](../codebase/systems/runtime/harnesses/README.md)). Laws, owned state, fences and the checked code map are authoritative there; flow-level detail stays here.
+
 `anyharness-lib/src/domains/agents/**` owns supported-agent metadata, installation,
 credential detection, readiness, and the final resolved launch surface handed to
 the live ACP runtime.

--- a/specs/anyharness/mobility.md
+++ b/specs/anyharness/mobility.md
@@ -1,5 +1,7 @@
 # Mobility
 
+> Ownership: this document is the depth reference for the **workspaces** system spec ([README.md](../codebase/systems/runtime/workspaces/README.md)). Laws, owned state, fences and the checked code map are authoritative there; flow-level detail stays here.
+
 `anyharness-lib/src/domains/mobility/**`,
 `anyharness-lib/src/api/http/mobility.rs`, and the repo-root mobility helpers
 own target-local workspace safety, clean archive export, exact destination

--- a/specs/anyharness/workspaces.md
+++ b/specs/anyharness/workspaces.md
@@ -1,5 +1,7 @@
 # Workspaces
 
+> Ownership: this document is the depth reference for the **workspaces** system spec ([README.md](../codebase/systems/runtime/workspaces/README.md)). Laws, owned state, fences and the checked code map are authoritative there; flow-level detail stays here.
+
 `anyharness-lib/src/domains/workspaces/**` owns execution-surface identity, workspace
 registration from paths, worktree creation, and workspace-derived environment.
 

--- a/specs/codebase/platforms/product/agent-features/definitions/workspace.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/workspace.md
@@ -1,5 +1,7 @@
 # Workspace Product MCP
 
+> Ownership: this document is the depth reference for the **subagents** system spec ([README.md](../../../../systems/runtime/subagents/README.md)). Laws, owned state, fences and the checked code map are authoritative there; flow-level detail stays here.
+
 Status: authoritative current definition for the Workspace product MCP,
 session attachment, current-role authorization, and agent product context.
 

--- a/specs/codebase/systems/README.md
+++ b/specs/codebase/systems/README.md
@@ -7,6 +7,9 @@ state, behavior, and acceptance boundaries.
   workflows.
 - [Engineering Systems](engineering/README.md) — complete engineering and
   operational domains.
+- [Runtime Systems](runtime/README.md) — the AnyHarness plane's systems
+  (workspaces, harnesses, subagents, terminals, artifacts) and the desktop
+  host seam, in the Organization Standard anatomy.
 
 Use [Structures](../structures/README.md) for source-area organization and
 [Platforms](../platforms/README.md) for reusable capabilities shared across

--- a/specs/codebase/systems/product/agents/cowork-artifacts.md
+++ b/specs/codebase/systems/product/agents/cowork-artifacts.md
@@ -1,5 +1,7 @@
 # Cowork Artifacts
 
+> Ownership: this document is the depth reference for the **artifacts** system spec ([README.md](../../runtime/artifacts/README.md)). Laws, owned state, fences and the checked code map are authoritative there; flow-level detail stays here.
+
 Scope:
 
 - `anyharness/crates/anyharness-contract/**` for cowork artifact wire shapes

--- a/specs/codebase/systems/runtime/README.md
+++ b/specs/codebase/systems/runtime/README.md
@@ -1,0 +1,31 @@
+# Runtime Systems
+
+One living document per system, in the nine-section anatomy the Organization
+Standard fixes: **Purpose · Owned state · Public surface · Consumes · Laws ·
+Emits · Fences · Code map · Proof**. A system spec is the ownership unit: every
+source file belongs to exactly one spec's code map, and a change is filed
+against the spec that owns the code, not the surface that discovered it.
+
+These documents describe `main` unless a section says otherwise. Where the
+target monorepo tree renames a folder, the code map records the rename as
+`current path → target path` and nothing moves in the spec PR. Judgment calls
+the founder still owes are marked inline as `> [!decision] PABLO DECIDES:`.
+
+The older owner docs under [`../anyharness/`](../../../anyharness/README.md),
+[`../desktop-native.md`](../../../desktop-native.md), [`../worker.md`](../../../worker.md)
+and [`../codebase/`](../../README.md) remain the depth references the
+system specs link into; each one carries a banner naming its owning system spec.
+
+## Runtime plane (AnyHarness)
+
+| Spec | Owns | Grade |
+| --- | --- | --- |
+| [workspaces.md](workspaces/README.md) | execution-surface identity, worktrees, repo roots, workspace files/git/setup surface, archive, checkpoints, purge, mobility | system |
+| [harnesses.md](harnesses/README.md) | supported agent kinds, catalog/registry, install/seed/reconcile, readiness, launch options and probes, provider adapters | system |
+| [subagents.md](subagents/README.md) | in-environment delegated agents: the Workspace product MCP, relationship lifecycle, completion delivery | system |
+| [terminals.md](terminals/README.md) | PTY terminals, command runs, setup/archive-script runs, terminal output streams | system |
+| [artifacts.md](artifacts/README.md) | file-backed artifact manifest, lifecycle, write protection (today: Cowork's artifact machinery) | system |
+| [desktop_host.md](desktop-host/README.md) | the Desktop shell ↔ sidecar ↔ desktop worker seam | seam |
+
+Systems owned by other planes (sessions, seam, environments, agent_auth,
+integration_gateway, …) are listed here as they land.

--- a/specs/codebase/systems/runtime/artifacts/README.md
+++ b/specs/codebase/systems/runtime/artifacts/README.md
@@ -1,0 +1,136 @@
+# Artifacts
+
+Status: current (grade B). System spec in the Organization Standard anatomy.
+The runtime system that owns **file-backed artifacts a workspace declares**:
+a per-workspace manifest (`.proliferate/artifacts.json`), the create / update /
+delete / read / list lifecycle over it, and write protection that stops generic
+file operations from clobbering manifest-tracked paths. There is no artifact
+table; git history is the version history.
+
+Honesty about scope: on `main` this domain is **Cowork's artifact machinery**
+— every entry point is gated on `WorkspaceSurface::Cowork` and the only tools
+that call it are the Cowork MCP's. The Organization Standard's coverage audit
+recorded exactly that, and the roster's *artifacts/evidence* system (screenshots,
+files and run outputs captured as evidence for any run) is greenfield. This
+spec describes what exists and marks the graduation path. Depth reference:
+[cowork-artifacts.md](../../../../codebase/systems/product/agents/cowork-artifacts.md).
+
+## 1. Purpose
+
+Let an agent produce renderable, durable outputs (markdown, HTML, SVG, React)
+that the product treats as first-class objects rather than loose files: listed,
+titled, protected from accidental overwrite, and readable over HTTP by the
+client. The future purpose (evidence) is the same mechanism with the Cowork
+gate lifted and a run/session attribution added.
+
+## 2. Owned state
+
+| State | Where |
+| --- | --- |
+| `.proliferate/artifacts.json` — `ArtifactManifestDocument { version: 1, artifacts: BTreeMap<id, entry> }`; entry = id, immutable path, type, title, description, timestamps | [manifest.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/artifacts/manifest.rs) |
+| The artifact files themselves, at manifest-declared relative paths inside the workspace | written only through [runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/artifacts/runtime.rs) (temp-file + atomic commit) |
+| Per-workspace in-process lock serializing manifest mutations | `ArtifactRuntime.workspace_locks` |
+
+Supported types ([model.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/artifacts/model.rs)):
+`text/markdown`, `text/html`, `image/svg+xml`, `application/vnd.proliferate.react`.
+
+## 3. Public surface
+
+- HTTP read model ([cowork.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/cowork.rs)):
+  `GET /v1/workspaces/{id}/cowork/manifest`,
+  `GET /v1/workspaces/{id}/cowork/artifacts/{artifact_id}`.
+- MCP tools (served by the Cowork product MCP today):
+  `create_artifact`, `update_artifact`, `delete_artifact`, `list_artifacts`,
+  `get_artifact` — dispatch in `domains/cowork/mcp/**`, behavior here.
+- In-process: `ArtifactRuntime` (get_manifest, get_artifact, create, update,
+  delete), `ArtifactService` (pure plans: `plan_create` / `plan_update`,
+  [service.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/artifacts/service.rs)),
+  `ArtifactProtectionService::is_protected_relative_path`
+  ([protection.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/artifacts/protection.rs))
+  — the hook [workspaces.md](../workspaces/README.md) consults before generic file
+  mutations.
+
+## 4. Consumes
+
+- `workspaces` — `WorkspaceRecord` (path, surface) and the
+  `WorkspaceFileProtection` port in
+  [files_runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/files_runtime.rs).
+  Declared edge: `artifacts → workspaces`.
+- Nothing else. The domain is the in-repo exemplar of the pure-policy /
+  effects-in-runtime use-case shape ([domains.md](../../../../anyharness/domains.md)).
+
+## 5. Laws
+
+**The manifest is the truth; only listed files are artifacts.** A renderable
+extension without a manifest entry is an ordinary file; a manifest entry whose
+file is missing reports `exists: false` rather than disappearing.
+
+**Paths are immutable.** `create_artifact` chooses the path; `update_artifact`
+may change content, title, description only; there is no rename/move. Renames
+would break the git-history-is-version-history contract.
+
+**Writes are atomic and serialized per workspace.** Content and manifest are
+written to temp files and committed together under the workspace lock; a
+failed commit rolls back both ([runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/artifacts/runtime.rs)).
+
+**Protected paths fail closed.** The manifest path and every manifest-declared
+artifact path are refused by generic file writes/renames/deletes for a
+protected workspace; only the artifact tools may touch them.
+
+**Policy is pure.** `plan_create` / `plan_update` take `(manifest, input)` and
+return a plan; identity and clock are minted in the runtime step.
+
+## 6. Emits
+
+- `ArtifactManifest` / `ArtifactDetail` read models (client cowork pane).
+- Turn-end autosave is *triggered* by cowork's runtime, not emitted here.
+
+## 7. Fences
+
+| Not owned | Owner |
+| --- | --- |
+| Cowork roots, threads, session startup prompts, MCP server registration, turn-end autosave trigger | cowork (`domains/cowork/**`) |
+| Which sessions get the artifact tools | sessions' MCP binding assembly |
+| Generic file operations | workspaces / adapters |
+| Client rendering (iframe sandboxing, JSX transform) | client workspace surface ([components/workspace/cowork](../../../../../apps/packages/product-client/src/components/workspace/cowork)) |
+| Run-level evidence capture, screenshots, artifact upload to the control plane | artifacts/evidence — greenfield, see decision |
+
+> [!decision] PABLO DECIDES: artifacts vs evidence. Options: (a) keep this
+> domain as-is under cowork's ownership (rename the spec `cowork_artifacts`,
+> fold into the cowork decision in [subagents.md](../subagents/README.md)); (b) generalize:
+> lift the `WorkspaceSurface::Cowork` gate to "any workspace", attach artifacts
+> to a session/run id, expose the five tools through the Workspace MCP, and let
+> the control-plane *evidence* primitive (run result + attachments) ship
+> manifest entries as checkpoints. Recommendation: (b) — the manifest +
+> protection + atomic-write core is exactly the evidence substrate, and the
+> cowork coupling is one enum check.
+
+## 8. Code map
+
+```text
+anyharness/crates/anyharness-lib/src/domains/artifacts/   → target: systems/artifacts/
+├── model.rs          types, read models, inputs, ArtifactError
+├── manifest.rs       schema v1, load/validate/normalize/persist, enrich
+├── service.rs        pure plans (create/update), manifest read model
+├── runtime.rs        ArtifactRuntime: lifecycle ops, per-workspace lock, atomic commit
+└── protection.rs     ArtifactProtectionService (WorkspaceFileProtection impl)
+anyharness/crates/anyharness-lib/src/domains/cowork/{manifest,artifacts}.rs   compatibility wrappers (cowork-owned)
+anyharness/crates/anyharness-lib/src/domains/cowork/mcp/**                  tool dispatch (cowork-owned)
+anyharness/crates/anyharness-lib/src/api/http/cowork.rs                     HTTP read model (cowork-owned transport)
+anyharness/crates/anyharness-contract/src/v1/cowork.rs                      wire shapes
+```
+
+## 9. Proof
+
+- There is **no test module inside `domains/artifacts/`** — the lifecycle is
+  pinned indirectly by cowork's MCP tests and the desktop cowork pane. This is
+  the spec's first gap.
+- Protection is exercised by the workspace file-operation tests that write
+  through `files_runtime.rs`.
+
+## Known gaps / follow-ups
+
+- Add `domains/artifacts/tests.rs` pinning: manifest round-trip, immutable
+  path, atomic-commit rollback, protection fail-closed.
+- If decision (b) lands, the Cowork gate becomes a per-workspace policy value
+  and `cowork/{manifest,artifacts}.rs` wrappers are deleted.

--- a/specs/codebase/systems/runtime/desktop-host/README.md
+++ b/specs/codebase/systems/runtime/desktop-host/README.md
@@ -1,0 +1,193 @@
+# Desktop Host (seam)
+
+Status: current (grade B). System spec in the Organization Standard anatomy.
+The seam between the compiled product (one React bundle mounted by Desktop and
+Web through `ProductHost`), the native Tauri shell, and the two local processes
+the shell owns: the **AnyHarness sidecar** and the **desktop worker**. It is a
+seam spec, not a system: it owns a contract between planes (which bundle calls
+which native command, which process gets which env), and the small amount of
+state that contract needs. Everything the shell hosts *for* another system is
+fenced to that system.
+
+Depth references: [DESKTOP_HOST.md](../../../../FEATURE_DOCS/DESKTOP_HOST.md) (the
+`ProductHost` / `DesktopBridge` contract), [desktop-native.md](../../../../desktop-native.md)
+(build, bundle, sidecar boot, secrets, diagnostics), [worker.md](../../../../worker.md).
+
+## 1. Purpose
+
+Make Desktop a thin native shell: the same product code runs on Web with
+`desktop: null`, and every Desktop-only behavior is a capability behind the
+optional `DesktopBridge`. The shell's jobs are to boot and supervise the local
+runtime, enroll and supervise the desktop worker under the signed-in
+(user, org) identity, keep local secrets, and expose native OS affordances —
+nothing product-shaped.
+
+## 2. Owned state
+
+| State | Where |
+| --- | --- |
+| `runtime-info.json` — sidecar URL, port, status, runtime home, version | [sidecar.rs](../../../../../apps/desktop/src-tauri/src/sidecar.rs) via `app_config::write_runtime_info_record` |
+| Sidecar process + exit observer + diagnostics bridge | `SidecarState` in [sidecar.rs](../../../../../apps/desktop/src-tauri/src/sidecar.rs), [sidecar/lifecycle.rs](../../../../../apps/desktop/src-tauri/src/sidecar/lifecycle.rs), [observer.rs](../../../../../apps/desktop/src-tauri/src/sidecar/observer.rs), [state.rs](../../../../../apps/desktop/src-tauri/src/sidecar/state.rs) |
+| Desktop worker process, credential lock (`cloud-worker-v2` namespace), bounded log tail | [commands/cloud_worker.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker.rs) + [state.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/state.rs), [lifecycle.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/lifecycle.rs), [spawn.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/spawn.rs), [tail.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/tail.rs) |
+| Local secrets: `auth-session.json`, `pending-auth.json`, `env-secrets.json` (0600 under the app home) and the `ANYHARNESS_DATA_KEY` keychain item | [commands/keychain.rs](../../../../../apps/desktop/src-tauri/src/commands/keychain.rs) |
+| App config, desktop install id, telemetry mode | [app_config.rs](../../../../../apps/desktop/src-tauri/src/app_config.rs), [commands/desktop_identity.rs](../../../../../apps/desktop/src-tauri/src/commands/desktop_identity.rs), [desktop_telemetry_mode.rs](../../../../../apps/desktop/src-tauri/src/desktop_telemetry_mode.rs) |
+| The enrolled `(user, org)` identity key (process-wide, renderer side) | [use-desktop-worker-enrollment.ts](../../../../../apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts) |
+
+## 3. Public surface
+
+**Renderer → shell**: the Tauri command list registered in
+[lib.rs](../../../../../apps/desktop/src-tauri/src/lib.rs). Seam-owned commands:
+`get_runtime_info`, `restart_runtime` ([commands/runtime.rs](../../../../../apps/desktop/src-tauri/src/commands/runtime.rs));
+`ensure_desktop_dispatch_worker`, `prepare_desktop_dispatch_worker_update`,
+`stop_desktop_dispatch_worker`; `get_app_config`/`set_app_config`;
+`get_desktop_install_id`; the keychain get/set/clear pairs; `set_running_agent_count`
+(quit flow); shell affordances (`pick_folder`, `open_in_editor`,
+`reveal_in_finder`, `open_in_terminal`, `open_external`, `copy_text`,
+`inspect_path`, `list_available_editors`, `command_exists`); window chrome;
+drag-drop; workspace scratch pad; workspace activity indicator.
+
+**Product-side contract**: `ProductHost` and `DesktopBridge` in
+[product-host.ts](../../../../../apps/packages/product-client/src/host/product-host.ts) and
+[desktop-bridge.ts](../../../../../apps/packages/product-client/src/host/desktop-bridge.ts);
+`host.desktop !== null` is the capability check, never `surface === "desktop"`.
+
+**Shell → sidecar**: `anyharness serve --host 127.0.0.1 --port <port>` with
+launch env = local secrets + agent seed env
+([agent_seed_env.rs](../../../../../apps/desktop/src-tauri/src/agent_seed_env.rs)) +
+login-shell `PATH` + `PROLIFERATE_API_BASE_URL_ORIGIN`; health polled at
+`/health` (250 ms, 60 s timeout).
+
+**Shell → worker**: `proliferate-worker` spawned with a config whose
+`runtime_base_url` is the *current* sidecar URL and a single-use enrollment
+ticket handed in by the renderer.
+
+## 4. Consumes
+
+- The **sessions/workspaces/harnesses** HTTP surfaces through the sidecar URL
+  (the product talks to AnyHarness directly; the shell only hands over the URL).
+- The **seam** (control plane ↔ worker): the enrollment ticket the renderer
+  obtains from the control plane and the worker's enroll/heartbeat client
+  ([worker cloud_client](../../../../../anyharness/crates/proliferate-worker/src/cloud_client/mod.rs)).
+- **diagnostics** (plane-infra): the collector supervisor, child bridge and
+  support snapshot under `src-tauri/src/diagnostics*` — the shell *hosts* them.
+- **release-delivery**: owned updater ([updater_owned.rs](../../../../../apps/desktop/src-tauri/src/updater_owned.rs))
+  and [runtime_version_assert.rs](../../../../../apps/desktop/src-tauri/src/runtime_version_assert.rs).
+
+## 5. Laws
+
+**One host contract, capability-checked.** Product code checks
+`host.desktop`, never the surface string; a Desktop-only lifecycle lives behind
+the bridge or it does not exist ([DESKTOP_HOST.md](../../../../FEATURE_DOCS/DESKTOP_HOST.md)).
+
+**Restart rebuilds the same env classes as boot.** `restart_runtime` re-collects
+local secrets, seed env, sidecar defaults and shell `PATH`; renderer code never
+shells out to restart AnyHarness ([desktop-native.md](../../../../desktop-native.md), Restart Rules).
+
+**The worker follows the sidecar, not the sandbox default.** Desktop worker
+config sets `runtime_base_url` from `SharedSidecar.info.url` — the sidecar port
+is dynamic, so the worker's `127.0.0.1:8457` sandbox default is never valid
+here.
+
+**Enrollment is keyed by (user, org) and rotates identity.** The renderer
+guard enrolls once per `${userId}::${orgId}`; a user or org change re-enrolls
+(server-side ticket consumption rotates worker + integration-gateway identity),
+sign-out tears the worker down and deletes the gateway dotfile, and a failed
+enrollment clears the guard and retries after 15 s while mounted
+([use-desktop-worker-enrollment.ts](../../../../../apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts)).
+This is what makes the desktop the identity-bearing target for integration
+access (Law 5 at the edge).
+
+**Worker credentials are locked while it runs.** Replacing worker credentials
+while a worker process holds the `cloud-worker-v2` lock is refused
+(`WORKER_CREDENTIALS_LOCKED_ERROR`), and a legacy `cloud-worker` lock is never
+inspected or killed.
+
+**Desktop never self-updates its runtime.** `self_update_enabled=false` is
+hardcoded and no runtime-swap gate or bridge field is written
+([commands/cloud_worker.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker.rs));
+binary convergence on desktop is the app update, owned by release-delivery.
+
+**A missing native transport is silent, never a toast.** A worker failure
+raised while `worker.isSupported()` is false (web build, intent tests) is an
+expected environment shape and shows nothing.
+
+**Recreatable secrets live in 0600 files, the data key in the keychain.** A
+keychain ACL is bound to the code signature, so a reinstalled build could not
+read a keychain-held session; only the at-rest encryption key belongs there.
+
+## 6. Emits
+
+- `RuntimeInfo { url, port, status: starting|healthy|failed|stopped }` to the
+  renderer and `runtime-info.json` on disk.
+- Desktop worker startup failure notices (`desktopWorkerStartupFailureNotice`)
+  rendered as one retryable toast per distinct failure.
+- Shortcut events, drag-drop pasteboard changes, workspace activity indicator
+  state (native chrome signals).
+
+## 7. Fences
+
+| Not owned | Owner |
+| --- | --- |
+| Worker enrollment protocol, heartbeat, identity store, gateway credential file | seam (worker crate; today [worker.md](../../../../worker.md)) |
+| Supervisor, mailbox, binary swaps, cloud convergence | managed_runtime ([MANAGED_RUNTIME.md](../../../../FEATURE_DOCS/MANAGED_RUNTIME.md)) |
+| Diagnostics collector, child bridge, support snapshot, scrubbing (`src-tauri/src/diagnostics*`) | diagnostics plane-infra (frozen, ADR-owned; [OBSERVABILITY.md](../../../../OBSERVABILITY.md)) |
+| Owned updater, runtime-version assert, release staging | release-delivery (engineering system; [desktop-updates.md](../../../../codebase/systems/engineering/delivery/desktop-updates.md)) |
+| Google Workspace MCP auth/credentials (`commands/google_workspace_mcp*`) | integration_gateway — a desktop-local integration lane hosted by the shell |
+| Anonymous telemetry bootstrap | observability infra (product telemetry section) |
+| Agent seed archives (contents, pins) | [harnesses.md](../harnesses/README.md); the shell only passes the env |
+| Everything the product renders | client surfaces |
+
+> [!decision] PABLO DECIDES: google_workspace_mcp in the shell. 1.4K lines of
+> OAuth + credential storage for one integration live as Tauri commands.
+> Options: (a) leave (it works, it is desktop-local by design); (b) move behind
+> the integration gateway's connection model so desktop-local and cloud
+> integrations share one lifecycle. Recommendation: (b) when the
+> integration_gateway spec lands; until then it is fenced, not owned, here.
+
+## 8. Code map
+
+```text
+apps/desktop/src-tauri/src/
+├── lib.rs · main.rs                      setup, state, command registration, menu
+├── sidecar.rs · sidecar/{lifecycle,observer,state,diagnostics,tests}.rs   AnyHarness sidecar
+├── commands/runtime.rs                   get_runtime_info / restart_runtime
+├── commands/cloud_worker.rs · cloud_worker/{launcher,launcher_legacy,lifecycle,
+│      observer,spawn,state,tail}.rs      desktop worker launch + supervision
+├── commands/keychain.rs                  local secrets (files + data key)
+├── commands/config.rs · commands/desktop_identity.rs · app_config.rs · desktop_telemetry_mode.rs
+├── commands/{shell,window_chrome,drag_drop,workspace_scratch,process}.rs   native affordances
+├── editors/                              editor discovery for open_in_editor
+├── quit_flow.rs · workspace_activity_indicator.rs · telemetry.rs
+├── agent_seed_env.rs                     seed env passthrough (contents: harnesses)
+├── (diagnostics/, diagnostics_collector/, commands/diagnostics.rs, commands/support*.rs → diagnostics)
+├── (updater_owned.rs, runtime_version_assert.rs → release-delivery)
+└── (commands/google_workspace_mcp* → integration_gateway, fenced)
+apps/packages/product-client/src/host/{product-host,desktop-bridge}.ts       the contract
+apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+apps/packages/product-client/src/lib/workflows/cloud/                         ensure/teardown desktop worker
+apps/desktop/src-tauri/tauri.conf.json · build.rs                             externalBin staging
+```
+
+Target: `specs/FEATURE_DOCS/DESKTOP_HOST.md` graduates into this file (its
+contract section is the depth reference until then); no code moves.
+
+## 9. Proof
+
+- Sidecar: [sidecar/tests.rs](../../../../../apps/desktop/src-tauri/src/sidecar/tests.rs)
+  (boot modes, health polling, restart env classes).
+- Worker launch: [cloud_worker/tests.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs),
+  [launcher_tests.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/launcher_tests.rs),
+  [tail_tests.rs](../../../../../apps/desktop/src-tauri/src/commands/cloud_worker/tail_tests.rs).
+- Enrollment guard: [use-desktop-worker-enrollment.test.tsx](../../../../../apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx)
+  (identity-key transitions, retry, silent-when-unsupported).
+- Config and identity: [app_config_home_env_tests.rs](../../../../../apps/desktop/src-tauri/src/app_config_home_env_tests.rs),
+  [updater_owned_tests.rs](../../../../../apps/desktop/src-tauri/src/updater_owned_tests.rs) (release-delivery's, listed for completeness).
+- Cross-plane: the desktop lanes in [tests/release](../../../../../tests/release) per [TESTING.md](../../../../TESTING.md).
+
+## Known gaps / follow-ups
+
+- `launcher_legacy.rs` (non-macOS worker launch with `worker.log`) is dead on
+  the macOS-only release matrix; delete with the Windows-lane demotion.
+- The enrollment guard is renderer state; a shell-side source of truth for
+  "which identity is the worker enrolled under" would let the shell refuse a
+  stale ticket without a round trip.

--- a/specs/codebase/systems/runtime/harnesses/README.md
+++ b/specs/codebase/systems/runtime/harnesses/README.md
@@ -1,0 +1,222 @@
+# Harnesses
+
+Status: current (grade B). System spec in the Organization Standard anatomy.
+The runtime system that owns *which coding agents exist and whether they can
+launch*: the supported-kind registry, the distribution catalog compiled into the
+binary, install/seed/reconcile of agent artifacts, credential detection and
+readiness, target-observed launch options and the probe that observes them, and
+the per-provider adapters (ACP extensions, live controls, transcript quirks).
+It hands the session engine a **resolved launch surface**; it never runs a
+session.
+
+Today the code lives in `domains/agents/` and the docs call it "agents". The
+Organization Standard names the system **harnesses** (a harness is the thing
+you run; an agent is the thing a user talks to), and the target tree renames
+the folder. Depth references: [agents.md](../../../../anyharness/agents.md),
+[agent-distribution.md](../../../../codebase/platforms/product/agent-distribution.md),
+[harnesses.md](../../../../anyharness/harnesses.md) and the per-provider docs under
+[harnesses/](../../../../anyharness/harnesses/claude.md), [acp.md](../../../../anyharness/acp.md),
+[agent-mode-matrix.md](../../../../anyharness/agent-mode-matrix.md), [MODELS.md](../../../../FEATURE_DOCS/MODELS.md).
+
+## 1. Purpose
+
+Make "is Claude ready on this machine, and with which exact model and
+controls may I launch it?" a pure, side-effect-free question with one answer,
+and make "get it ready" a fenced, sha-verified, idempotent operation. The
+product outcome: a user installs the app and every supported harness converges
+to the catalog pin without a manual step; a cloud task environment does the
+same from a seed; session create can only ever launch an executable surface the
+target has actually observed.
+
+## 2. Owned state
+
+| State | Where | Written by |
+| --- | --- | --- |
+| Supported kinds (`claude`, `codex`, `cursor`, `opencode`, `grok`) and their static install/auth/launch metadata | [model.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/model.rs), [registry/](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/registry/schema.rs) | compiled in (bundled registry) |
+| Distribution catalog — pins, artifact specs, model catalog | [catalog/](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs), [model_catalog.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/model_catalog.rs) | compiled in from `catalogs/agents/**` |
+| `agent_model_registry_snapshots` | **vestigial**: table exists ([0044](../../../../../anyharness/crates/anyharness-lib/src/persistence/sql/0044_agent_model_registry_snapshots.sql)) but no domain code reads or writes it on `main`; drop with the next migration | nobody |
+| Install manifests, downloads, seed archives, quarantine | [installer/](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs) under `<runtime-home>` | this system, under [installer/lock.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/lock.rs) |
+| `harness_launch_option_states` — target-observed model ids and control values per kind | [launch_options/store.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/launch_options/store.rs) | the launch probe only |
+| Readiness overrides, path resolution, version facts | [readiness/](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/readiness/service.rs) | derived, not stored |
+
+Not owned though co-located (see Fences): `auth/`, `auth_state.rs`,
+`route_auth/` — the runtime half of **agent_auth**.
+
+## 3. Public surface
+
+HTTP ([agents.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/agents.rs),
+[agent_launch_options.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/agent_launch_options.rs),
+[catalogs.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/catalogs.rs)):
+
+| Route | Meaning |
+| --- | --- |
+| `GET /v1/agents`, `GET /v1/agents/{kind}` | resolved readiness per kind (`resolve_agent`, side-effect free) |
+| `POST /v1/agents/{kind}/install` | fenced managed install of the catalog pin |
+| `POST /v1/agents/{kind}/login/start`, `/login/terminal`, `GET|DELETE /v1/agents/login-terminals/{id}` | provider login flows (terminal-backed) |
+| `POST /v1/agents/reconcile`, `GET /v1/agents/reconcile` | start/inspect the catalog-pin reconcile job |
+| `GET /v1/agents/{kind}/launch-options`, `POST …/launch-options/refresh` | target-observed launch options; refresh pokes the probe |
+| `GET /v1/catalogs/agents/version` | the compiled catalog version — binary convergence *is* catalog convergence |
+
+Wire shapes: [agents.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/agents.rs),
+[launch_options.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/launch_options.rs),
+[catalogs.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/catalogs.rs).
+
+In-process: `AgentRuntime` ([runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs))
+is the facade — it sequences concern services and owns no mechanism. Sessions
+obtain the resolved executable surface (`ResolvedAgent`) and the exact-validated
+`ResolvedLaunchIntent` inputs through it; the cloud surface flag
+`ANYHARNESS_RUNTIME_SURFACE` selects `RuntimeSurface::{Local,Cloud}`.
+
+## 4. Consumes
+
+- `integrations/agent_cli` ([launcher.rs](../../../../../anyharness/crates/anyharness-lib/src/integrations/agent_cli/launcher.rs),
+  [executable.rs](../../../../../anyharness/crates/anyharness-lib/src/integrations/agent_cli/executable.rs),
+  [model_discovery.rs](../../../../../anyharness/crates/anyharness-lib/src/integrations/agent_cli/model_discovery.rs)) — provider CLI mechanics.
+- `integrations/acp` ([acp/](../../../../../anyharness/crates/anyharness-lib/src/integrations/acp/mod.rs)) —
+  protocol helpers the adapters share.
+- `anyharness-credential-discovery` crate — provider credential file parsing.
+- `terminals` — login terminals run through
+  [live/terminals/agent_login.rs](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/agent_login.rs).
+- `catalogs/agents/**` at build time (the registry + catalog data) and the
+  desktop seed archive delivered through [desktop_host.md](../desktop-host/README.md).
+- agent_auth — the resolved credential ladder and gateway plan the launch
+  needs; this system *applies* what agent_auth *decides*.
+
+## 5. Laws
+
+**The bundled registry is the source of truth for supported kinds.** Catalog
+modules are distribution, presentation and compatibility only and cannot
+authorize executable values ([README.md](../../../../anyharness/README.md), launch-option authority).
+
+**Resolution never mutates.** `resolve_agent(...)` reports installed,
+compatible, credentialed state and nothing else; installation is a separate,
+fenced operation ([readiness/service.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/readiness/service.rs)).
+
+**Managed install materializes exactly the catalog pin, sha-verified.**
+ACP-registry resolution is probe-time only; a drifted or unsigned artifact never
+reaches `Ready` ([installer/pinned.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/pinned.rs)).
+
+**Launch options are observed, never defaulted.** Session create reloads the
+target observation, exact-validates the caller's opaque selection and stores
+`ResolvedLaunchIntent` atomically; omitted values stay omitted — no catalog
+default, alias, or first option fills them
+([launch_options/validation.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/launch_options/validation.rs)).
+
+**The probe is override-free.** [launch_probe/](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/launch_probe/mod.rs)
+detects what the installed binary reports, under a lock, with backoff; it
+records contradictions rather than resolving them.
+
+**Cursor never installs in cloud.** It is login-only with no headless
+credential path, so a cloud install could never reach `Ready`
+(`RuntimeSurface::Cloud` carve-out in [runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs)).
+
+**Binary convergence is catalog convergence.** The active catalog is immutable
+for the runtime process lifetime; there is no document push or faster lane
+([MANAGED_RUNTIME.md](../../../../FEATURE_DOCS/MANAGED_RUNTIME.md)).
+
+## 6. Emits
+
+- `ResolvedAgentStatus` per kind — consumed by the client agent picker and
+  onboarding, and by the seam heartbeat (readiness facts ride to the control
+  plane).
+- Reconcile job snapshots (`AgentReconcileJobSnapshot`) and install progress
+  ([installer/progress.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/progress.rs)).
+- Launch-option observations (`harness_launch_option_states`) — consumed by
+  session create and by the worker's launch-options sync to the control plane
+  ([launch_options_sync.rs](../../../../../anyharness/crates/proliferate-worker/src/launch_options_sync.rs)).
+- Login-terminal lifecycle events (through the terminals stream).
+
+## 7. Fences
+
+| Not owned | Owner |
+| --- | --- |
+| Live session actors, ACP stdio connections, prompt execution | sessions ([session-engine.md](../../../../anyharness/session-engine.md)) |
+| Credential vault, selections, `state.json` delivery, route-auth rendering, gateway plans — `domains/agents/{auth,auth_state.rs,route_auth}` | **agent_auth** (control-plane spec with a runtime section; today [AGENT_AUTH.md](../../../../FEATURE_DOCS/AGENT_AUTH.md)) |
+| Virtual keys, LiteLLM, model gateway enrollment | model_gateway ([MODELS.md](../../../../FEATURE_DOCS/MODELS.md)) |
+| Catalog *generation* (`scripts/agent-catalog/**`) | release-delivery (engineering system) |
+| Supervisor binary swaps, worker mailbox | managed_runtime ([MANAGED_RUNTIME.md](../../../../FEATURE_DOCS/MANAGED_RUNTIME.md)) |
+| Cowork/review/workflow session policy | their owning domains |
+
+Declared edge: `agents → sessions` (baseline; the reverse `sessions → agents`
+is the intended direction and also present). Every other domain reaches
+harnesses through `AgentRuntime` or the readiness facade.
+
+> [!decision] PABLO DECIDES: harness kinds. `AgentKind::all()` is
+> `[Claude, Codex, Cursor, OpenCode, Grok]`; Cursor is login-only and
+> cloud-excluded, Grok has a full adapter doc ([grok.md](../../../../anyharness/harnesses/grok.md)) but an open
+> auto-probe defect (PRO-210) and no known headless credential path.
+> Options: (a) keep all five; (b) drop Cursor and Grok from the registry (their
+> readiness, portability and launch-option branches, plus `harnesses/grok.md`)
+> after the usage check; (c) drop Grok only. Recommendation: (b) unless usage
+> shows real Cursor sessions — the demo and the cloud lane both need headless
+> credential paths, which only Claude/Codex/OpenCode have.
+
+> [!decision] PABLO DECIDES: the agent_auth runtime half. `route_auth` (5.3K
+> lines), `auth/` (3.5K) and `auth_state.rs` sit in `domains/agents`, but their
+> laws (headless never holds human credentials; gateway plan per launch) belong
+> to agent_auth. Options: (a) move them to `domains/agent_auth/` in Wave 3 and
+> let the agent_auth spec own a runtime code map; (b) keep them here as an
+> "auth application" section. Recommendation: (a) — the target tree already
+> names `agent_auth/` in the runtime, and a single spec across both planes is
+> how "identity once, capability per call" stays one law.
+
+## 8. Code map
+
+```text
+anyharness/crates/anyharness-lib/src/domains/agents/    → target: systems/harnesses/
+├── model.rs · model_catalog.rs             AgentKind, artifact specs, readiness models
+├── registry/                               bundled kind registry, schema, validation, projection
+├── catalog/                                distribution catalog: schema, artifact, sync, validation
+├── installer/                              downloads, pinned, npm/managed_npm, seed/, reconcile/,
+│                                           install_policy, lock, progress, off_runtime
+├── readiness/                              resolve_agent, compatibility, overrides, paths, versions
+├── launch_options/                         target-observed options: store, service, validation
+├── launch_probe/                           override-free probe engine, phases, backoff, lock
+├── portability/                            provider auth-file portability (codex)
+├── live_ports.rs                           trait impls for live-defined ports
+├── runtime.rs                              AgentRuntime facade
+└── (auth/, auth_state.rs, route_auth/)     → agent_auth runtime section (fenced, see §7)
+anyharness/crates/anyharness-lib/src/integrations/agent_cli/   provider CLI mechanics (consumed)
+anyharness/crates/anyharness-lib/src/integrations/acp/         shared ACP helpers (consumed)
+anyharness/crates/anyharness-lib/src/api/http/{agents,agents_contract,agents_errors,
+    agent_launch_options,catalogs}.rs                           transport
+anyharness/crates/anyharness-contract/src/v1/{agents,launch_options,catalogs}.rs
+specs/anyharness/harnesses/{claude,codex,grok}.md               per-provider adapter docs
+catalogs/agents/**                                              registry + catalog data (build input)
+```
+
+Client-plane presentation: [components/agents](../../../../../apps/packages/product-client/src/components/agents),
+[hooks/agents](../../../../../apps/packages/product-client/src/hooks/agents),
+[lib/domain/agents](../../../../../apps/packages/product-client/src/lib/domain/agents),
+[stores/agents](../../../../../apps/packages/product-client/src/stores/agents) (agent
+picker, install/login prompts, readiness badges).
+
+## 9. Proof
+
+- Install and seed: [installer/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/tests.rs),
+  [pinned_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/pinned_tests.rs),
+  [downloads_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/downloads_tests.rs),
+  [auto_install_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install_tests.rs),
+  [reconcile/execution_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs),
+  [seed/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/tests.rs).
+- Readiness: [readiness/service_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/readiness/service_tests.rs),
+  [route_aware_read_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/readiness/route_aware_read_tests.rs),
+  [resolution_flip_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/readiness/resolution_flip_tests.rs).
+- Catalog/registry: [catalog/artifact_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/catalog/artifact_tests.rs),
+  [catalog/schema_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs),
+  [registry/validation_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/registry/validation_tests.rs).
+- Launch options and probe: [launch_options/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/launch_options/tests.rs),
+  [launch_probe/runner_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/launch_probe/runner_tests.rs),
+  [contradiction_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agents/launch_probe/contradiction_tests.rs),
+  [api/http/agent_launch_options_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/agent_launch_options_tests.rs).
+- Release lanes: the managed-agent install/spawn scenarios under
+  [tests/release](../../../../../tests/release) (see [TESTING.md](../../../../TESTING.md)).
+
+## Known gaps / follow-ups
+
+- `domains/agents/auth` uses contract auth structs end-to-end (recorded
+  migration exception in [domains.md](../../../../anyharness/domains.md)); resolves with
+  the agent_auth move.
+- The "agents" name is used for three things (this system, the client's
+  "Agents" pane for delegated work, and sessions). The rename to harnesses
+  removes one of the three.

--- a/specs/codebase/systems/runtime/subagents/README.md
+++ b/specs/codebase/systems/runtime/subagents/README.md
@@ -1,0 +1,224 @@
+# Subagents
+
+Status: current (grade B). System spec in the Organization Standard anatomy.
+The runtime system that owns **in-environment delegation**: an agent creating,
+configuring, messaging and closing other agents in the *same* workspace,
+through the product MCP the runtime attaches to every eligible session. This is
+tier one of the two-tier orchestration ruling — fan-out inside one environment,
+owned by AnyHarness. Tier two (spawning a new run in a new environment through
+the public API) is a control-plane system and is not here.
+
+Today the code is `domains/agent_operations/` (policy, orchestration, the
+Workspace MCP) plus the session-owned subdomain `domains/sessions/subagents/`
+(durable relationship mechanics and completion delivery). Depth references:
+[Workspace Product MCP](../../../../codebase/platforms/product/agent-features/definitions/workspace.md)
+(the 20-tool contract), the delegated-agents section of
+[sessions.md](../../../../anyharness/sessions.md), [servers.md](../../../../codebase/platforms/product/agent-features/servers.md)
+(the product-MCP pattern), and the client-side
+[delegated-work.md](../../../../codebase/systems/product/agents/delegated-work.md).
+
+## 1. Purpose
+
+Let a parent agent run a bounded roster of child agents on the same checkout —
+each a normal durable session with its own harness and model — and be woken
+exactly once with each child's result, without any of it forking the session
+engine. Product outcome: a replay-triage agent fans out eight analysis
+subagents, each on a different harness/model, and reads their completions as
+ordinary transcript turns.
+
+## 2. Owned state
+
+| State | Where | Written by |
+| --- | --- | --- |
+| Relationship rows — `session_links` with `relation = subagent` and the `subagent_closed_at` operability marker | sessions' link store, via [subagents/service.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs) | this system only, atomically with child session insert |
+| `session_link_completions` — passive child terminal-turn results | [links/completions](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/links) | terminal persistence |
+| `session_link_completion_deliveries` — the exactly-once parent-wake ledger (pending → enqueued → delivered, coalesced/suppressed outcomes, removal intents) | SQL in sessions' [store/links.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/store/links.rs); driven only by [subagents/delivery/runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/delivery/runtime.rs) | the delivery worker |
+| `activity_subagents` — roster projection for the activity feed | activity domain (consumer) | — |
+| Workspace pin requests and per-turn product context | [product_context.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/product_context.rs) | this system |
+
+The roster cap is a product constant: `MAX_SUBAGENTS_PER_PARENT = 8`
+([service.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs)),
+counting reversibly-Closed relationships.
+
+## 3. Public surface
+
+**The Workspace product MCP** — id `workspace`, ACP server name
+`proliferate_workspace`, tool namespace `mcp__proliferate_workspace__<tool>`
+([mcp/definition.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/definition.rs)).
+Exactly 20 tools ([mcp/tools.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs)):
+`whoami`, `list_workspaces`, `list_workspace_options`, `list_agents`,
+`get_agent`, `list_subagents`, `list_agent_launch_options`,
+`list_agent_config_options`, `get_task_output`, `create_workspace`,
+`pin_workspace`, `unpin_workspace`, `create_agent`, `configure_agent`,
+`resume_agent`, `send_message`, `interrupt_agent`, `close_subagent`,
+`open_subagent`, `promote_subagent`. Served over HTTP by
+[product_mcp.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs)
+with a capability token scoped to runtime × workspace × session × MCP
+([mcp/auth.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/auth.rs)).
+
+**HTTP for humans/clients** ([subagents.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/subagents.rs)):
+`GET /v1/workspaces/{id}/subagents` (roster), `GET /v1/sessions/{parent}/subagents`,
+`POST /v1/sessions/{parent}/subagents/{child}/close|open|promote`. Wire shapes:
+[subagents.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/subagents.rs).
+
+**In-process**: `AgentOperations` ([runtime/mod.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs))
+is the single application boundary both adapters enter; it is built from
+ports ([runtime/ports.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs))
+that sessions, workspaces, harnesses and terminals implement, so this system
+never touches a sibling's store.
+
+## 4. Consumes
+
+- `sessions` — session create/prompt/config/close through `AgentSessionMutations`;
+  `SessionMutationAdmission` for the shared relationship gate; the
+  `SessionExtension` hook for the turn-finished nudge
+  ([hooks.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs)).
+- `workspaces` — `WorkspaceOperationGate` leases, workspace creation/pinning
+  through `AgentWorkspaceOperations`; see [workspaces.md](../workspaces/README.md).
+- `harnesses` — catalog and launch-option reads for `create_agent` /
+  `configure_agent` (`AgentCatalogReads`, `AgentLaunchOptionReads`); see
+  [harnesses.md](../harnesses/README.md).
+- `terminals` — `get_task_output` reads command-run output
+  (`AgentTaskOutputReads`).
+- `integrations/mcp` — JSON-RPC, tool formatting, capability tokens (protocol
+  mechanics, not product behavior).
+
+## 5. Laws
+
+**A child is a normal session; the relationship is the authority.**
+`session_links(relation=subagent)` is the authorization check for every
+relationship-targeting operation, and the child session plus capped
+relationship insert atomically so an in-progress creation is never observable
+as an ordinary session ([service.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs)).
+
+**Authority is resolved per call, never at token mint.** Every `tools/call`
+re-resolves caller role, parent ownership, relationship, workspace and target
+truth ([runtime/authorization_policy.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/authorization_policy.rs));
+a committed promotion changes authority for the next call without a new
+identity. This is the runtime instance of Law 5 (identity once, capability per
+call).
+
+**Delegated agents cannot delegate.** A child receives Workspace for identity,
+reads, messaging and parent-authorized operations, but `create_agent` is denied
+by role ([runtime/subagent_lifecycle.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/subagent_lifecycle.rs)).
+Fan-out depth is one; tree-shaped work is tier two (spawned runs).
+
+**Eight children per parent, Closed included.** The cap is enforced in the
+same transaction as the insert; Closed relationships count so a parent cannot
+churn through unbounded children.
+
+**Close purges prompts, keeps everything else.** Close sets
+`subagent_closed_at`, purges durable pending prompts, then non-terminally
+unloads the actor; transcript, config, native session id and row survive.
+Open restarts the same conversation; failure leaves it Closed and purged
+prompts are not replayed. Promotion is allowed only while Open and deletes only
+the relationship.
+
+**Completion wake is durable admission, exactly once.** Terminal persistence
+captures the child completion and delivery intent in the same transaction as
+the event batch; the delivery worker admits at most one parent prompt with
+`PromptProvenance::SubagentWake` per child, coalescing a still-queued wake in
+place and suppressing a redundant one when the child's own message already
+reached the parent — with a durable removal intent persisted as exactly one
+`pending_prompt_removed` ([delivery/runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/delivery/runtime.rs)).
+Restart and mobility preserve exactly-once visibility.
+
+**Attachment is structural.** Workspace attaches iff
+`workspace.surface == Standard && session.mcp_binding_policy != InternalOnly`;
+selection happens before actor start and never consults the legacy
+`subagents_enabled` flag ([product_catalog.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_catalog.rs)).
+
+## 6. Emits
+
+- `subagent_turn_completed` — one parent-transcript event per
+  Pending → Enqueued delivery transition (or per suppression), carrying the
+  completion metadata the transcript indexes for wake receipts and roster
+  invalidation.
+- `pending_prompt_added` / `pending_prompt_removed` on the parent's queue
+  (sessions' event vocabulary; this system is the producer for wake prompts).
+- Telemetry: `anyharness.subagent.delivery_suppressed` (with reason).
+- Roster view models (`WorkspaceSubagentRoster`, `SubagentLifecycleView` in
+  [subagents.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/subagents.rs))
+  consumed by the client Agents pane and the activity feed.
+
+## 7. Fences
+
+| Not owned | Owner |
+| --- | --- |
+| Session engine, event log, prompt queue mechanics, link graph storage | sessions ([session-engine.md](../../../../anyharness/session-engine.md)) |
+| Spawning a new run in a new environment; run results; cancel-tree | runs / api (control plane, greenfield) |
+| Per-subagent model credentials | agent_auth — the runtime applies the selection the parent chose |
+| MCP protocol scaffolding, capability-token crypto | runtime `mcp-scaffolding` capability ([integrations/mcp](../../../../../anyharness/crates/anyharness-lib/src/integrations/mcp/mod.rs)) |
+| Cowork delegation (`domains/cowork/delegation`), cowork threads and roots | cowork — pending the decision below |
+| Client Agents pane, tab strip, composer popover | client chat/workspace surfaces ([delegated-work.md](../../../../codebase/systems/product/agents/delegated-work.md)) |
+
+Declared edges: `agent_operations → agents, sessions, workspaces` and
+`sessions → agent_operations` (the extension/port direction). Zero grandfathered
+store-reach sites — this domain already obeys AH-FENCE-002 by construction.
+
+> [!decision] PABLO DECIDES: cowork → two-tier orchestration. Cowork
+> (`domains/cowork`, 5K lines; managed workspaces, threads, delegation,
+> `session_link_wake_schedules`) is a second delegation model beside this one:
+> it has its own MCP tools, its own wake schedule table, and the only remaining
+> `workspaces → cowork` core-to-surface edge. Options: (a) fold cowork
+> delegation into subagents (one relationship model, one wake path) and keep
+> cowork artifacts as [artifacts.md](../artifacts/README.md); (b) keep cowork as a
+> separate product-surface domain. Recommendation: (a) — the two-tier ruling
+> leaves no room for a third tier, and the wake-schedule table is exactly the
+> kind of parallel mechanism the session engine doc forbids.
+
+> [!decision] PABLO DECIDES: naming. The product MCP is `proliferate_workspace`
+> and the folder is `agent_operations`; the system is `subagents`. Options: (a)
+> rename the folder only (`systems/subagents/`), keep the MCP name (it is a
+> wire contract agents have learned); (b) rename both. Recommendation: (a).
+
+## 8. Code map
+
+```text
+anyharness/crates/anyharness-lib/src/domains/agent_operations/   → target: systems/subagents/
+├── model.rs                     identities, roles, statuses, capability decisions
+├── product_context.rs           per-turn product context, pin requests
+├── subagents.rs                 roster/lifecycle view models
+├── runtime/                     AgentOperations: authorization_policy, ordinary,
+│   │                            subagent_lifecycle, subagent_roster, messaging,
+│   │                            catalogs, workspaces, target_access, ports, error
+└── mcp/                         the Workspace product MCP: definition, auth,
+                                 context, tools, calls
+anyharness/crates/anyharness-lib/src/domains/sessions/subagents/   session-owned mechanics
+├── model.rs · service.rs        capped relationship insert, roster summaries
+├── delivery/                    completion delivery worker (exactly-once wake)
+├── hooks.rs                     SessionExtension: turn-finished nudge
+└── transcript.rs                completion ↔ transcript correlation
+anyharness/crates/anyharness-lib/src/api/http/{subagents,subagents_contract,
+    subagents_errors,product_mcp}.rs                               transport
+anyharness/crates/anyharness-lib/src/app/agent_operations.rs · app/product_mcp.rs   wiring
+anyharness/crates/anyharness-contract/src/v1/{subagents,mcp}.rs
+```
+
+Client-plane presentation:
+[components/workspace/delegated-work](../../../../../apps/packages/product-client/src/components/workspace/delegated-work),
+[domain/chats/subagents](../../../../../apps/packages/product-client/src/domain/chats/subagents),
+[components/playground/subagents-ux](../../../../../apps/packages/product-client/src/components/playground/subagents-ux).
+
+## 9. Proof
+
+- Tool contract and pins: [mcp/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs),
+  [tests/tool_contract.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests/tool_contract.rs)
+  (pins the exact 20-tool list), [tests/workspace_pins.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests/workspace_pins.rs).
+- Lifecycle and races: [runtime/subagent_lifecycle_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/subagent_lifecycle_tests.rs),
+  [race_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/subagent_lifecycle_tests/race_tests.rs),
+  [ordinary_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ordinary_tests.rs),
+  [messaging_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging_tests.rs),
+  [runtime/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs),
+  [error_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/error_tests.rs).
+- Delivery exactly-once: [delivery/runtime/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/sessions/subagents/delivery/runtime/tests.rs).
+- Intent: the `Agents` pane acceptance in
+  [delegated-work.md](../../../../codebase/systems/product/agents/delegated-work.md).
+
+## Known gaps / follow-ups
+
+- Per-subagent harness/model selection is expressed through `create_agent`
+  arguments today; the agent_auth selection primitive the two-tier ruling
+  assumes ("per-subagent auth via selections") is not yet a first-class input.
+- `subagents_enabled` remains serialized on session records for wire and
+  mobility compatibility only.

--- a/specs/codebase/systems/runtime/terminals/README.md
+++ b/specs/codebase/systems/runtime/terminals/README.md
@@ -1,0 +1,166 @@
+# Terminals
+
+Status: current (grade B). System spec in the Organization Standard anatomy.
+The runtime system that owns interactive PTYs and one-shot command runs inside
+a workspace: creation, input/resize/close, the ordered output stream with
+replay, and the durable `terminal_command_runs` ledger that setup scripts,
+archive scripts, agent logins and `get_task_output` all read. It is small
+(~700 durable + ~2K live lines) but earns a spec by the granularity test: it
+has owned state, a public surface three other systems consume, and kill-ordering
+laws an uninformed change would violate.
+
+Depth references: the Live Terminals section of
+[live-runtime.md](../../../../anyharness/live-runtime.md) and the client-side
+[terminals.md](../../../../codebase/systems/product/workspaces/terminals.md).
+
+## 1. Purpose
+
+Give every workspace a shell the user and the agent can share, and give the
+runtime a single mechanism for "run this command in the workspace env, stream
+it, bound it, and be able to kill it for certain". Product outcome: a terminal
+pane that survives reconnects with replay, setup scripts whose status never
+lies, and workspace stop/archive that provably leaves no PTY behind.
+
+## 2. Owned state
+
+| State | Where |
+| --- | --- |
+| `terminal_command_runs` — purpose (`general`/`run`/`setup`), command, status (`queued`…`timed_out`), exit code, bounded stdout/stderr/combined output (64 KiB cap), timing | [store.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/terminals/store.rs) |
+| Live registry of running PTYs and output hubs (`TerminalRegistry`, `TerminalOutputRegistry`) | [live/terminals/manager.rs](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/manager.rs) — process-lifetime only |
+| Active setup/archive-script task registry | `TerminalService.active_setup_tasks` |
+| Agent-login terminal records | [live/terminals/agent_login.rs](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/agent_login.rs) |
+| `workspace_setup_state` — the durable "latest setup run" pointer per workspace (`set_latest_setup_run`, read by `latest_setup_run`) | [store.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/terminals/store.rs); *when* it is set is [workspaces](../workspaces/README.md)' policy |
+
+`TerminalRecord` itself is a live projection (id, workspace, title, purpose,
+cwd, status, exit code, latest command run) — terminals are not durable across
+runtime restarts; their command runs are.
+
+## 3. Public surface
+
+HTTP ([terminals.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/terminals.rs)):
+
+| Route | Meaning |
+| --- | --- |
+| `GET|POST /v1/workspaces/{id}/terminals` | list / create (cwd, shell, purpose, env, startup command + timeout, cols/rows) |
+| `GET|DELETE /v1/terminals/{id}` | record / close |
+| `POST /v1/terminals/{id}/title`, `/resize` | rename, resize |
+| `POST /v1/terminals/{id}/commands` | run a bounded command in an existing terminal |
+| `GET /v1/terminal-command-runs/{id}` | a command-run record |
+| terminal output stream (SSE/WS) | `TerminalOutputEvent::{Data{seq,…}, Exit{seq,code}, ReplayGap{requested_after_seq, floor_seq}}` |
+
+Wire shapes: [terminals.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/terminals.rs).
+
+In-process: `TerminalService` ([manager.rs](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/manager.rs))
+exposes create/list/close, `start_setup_command` (start-and-poll),
+`run_blocking_command_for_workspace` (await-to-exit),
+`kill_active_run_for_workspace` and `close_all_for_workspace`
+([command_runs/](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/command_runs));
+`TerminalCommandService` ([service.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/terminals/service.rs))
+owns the durable ledger rules.
+
+## 4. Consumes
+
+- `process_kill` (crate root) — `PlaneKills` census; every kill awaits
+  confirmed process death.
+- `adapters/processes` for one-shot spawns; portable-pty for PTYs
+  ([driver/](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/driver)).
+- The workspace-derived env from [workspaces.md](../workspaces/README.md) (terminals never
+  reconstruct env themselves).
+
+## 5. Laws
+
+**Kill by session, not by pid.** `close_all_for_workspace` kills every terminal
+by PTY *session* — the PTY child is a session leader, so this is what reaches a
+`&`-backgrounded job that job control put in its own group — and runs the
+per-terminal kills concurrently so a workspace pays one grace window
+([command_runs/workspace_stop](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/command_runs)).
+
+**`is_setup_running` never lies.** `kill_active_run_for_workspace` kills the
+active setup/archive run by process *group* and marks the command run
+interrupted before returning.
+
+**An archive script never becomes the setup pointer.** `run_blocking_command_for_workspace`
+records with `TerminalPurpose::Run`, registers in the active-run registry so it
+can be cancelled, but never calls `set_latest_setup_run`; and it *owns* the
+terminal it creates, closing it on every exit path (including the
+`ArchiveRunGuard::drop` backstop) because the terminal is rooted in the
+workspace being archived.
+
+**Mechanism only, no composition.** None of the workspace-wide primitives
+takes an operation-gate lease, asserts the access gate, or kills the other
+resource in its pair (killing the setup terminal does not kill the script and
+vice versa); that composition is quiesce's, in [workspaces.md](../workspaces/README.md).
+
+**Startup reconciles the ledger.** `TerminalService::new` marks every
+still-active command run failed and prunes completed non-setup runs to the
+newest 100, so a crash cannot leave a run reported as running.
+
+**Output is bounded and ordered.** Command output is capped at 64 KiB with
+`output_truncated` set; stream events carry a monotonic `seq` and a subscriber
+that asks for a seq below the retained floor receives `ReplayGap` rather than
+silently missing data.
+
+## 6. Emits
+
+- The terminal output stream (`Data`/`Exit`/`ReplayGap`) consumed by the client
+  terminal pane and by agent-login flows.
+- Command-run records consumed by workspaces (setup status), subagents
+  (`get_task_output`), and harnesses (login terminals).
+
+## 7. Fences
+
+| Not owned | Owner |
+| --- | --- |
+| Setup-script *policy* (detect, when to run, rerun) and the durable setup pointer | [workspaces.md](../workspaces/README.md) (`setup_runtime.rs`, `workspace_setup_state`) |
+| Quiesce ordering across sessions/terminals/scripts | workspaces (`archive/quiesce.rs`) |
+| Agent login semantics (which command, when Ready flips) | [harnesses.md](../harnesses/README.md); this system only hosts the PTY |
+| Process spawning and kill mechanics | `process_kill` and `adapters/processes` (runtime capabilities) |
+| Terminal pane UI, creation grid, tab behavior | client workspace surface ([terminals.md](../../../../codebase/systems/product/workspaces/terminals.md)) |
+
+Declared edges into this domain: `workspaces → terminals`, `materialization →
+terminals`, `mobility → terminals`; this domain declares none outward.
+
+## 8. Code map
+
+```text
+anyharness/crates/anyharness-lib/src/
+├── domains/terminals/               durable half   → target: systems/terminals/
+│   ├── model.rs                     TerminalRecord, command-run record, enums, options, output events
+│   ├── service.rs                   TerminalCommandService: ledger rules, 64 KiB cap
+│   └── store.rs                     terminal_command_runs SQL
+├── live/terminals/                  live half      → target: systems/terminals/live/
+│   ├── manager.rs                   TerminalService: registries, create/close, setup tasks
+│   ├── handle.rs                    TerminalHandle: write, resize, close, subscribe
+│   ├── driver/                      PTY + shell process lifecycle
+│   ├── output_sink/                 ordered output/status hub with replay floor
+│   ├── command_runs/                bounded runs, setup runs, workspace-wide stop
+│   └── agent_login.rs               login terminals hosted for harnesses
+├── api/http/terminals.rs            transport
+└── (sse/ws transport for the output stream lives in api/)
+anyharness/crates/anyharness-contract/src/v1/terminals.rs
+```
+
+Client-plane presentation:
+[components/workspace/terminals](../../../../../apps/packages/product-client/src/components/workspace/terminals),
+[hooks/terminals](../../../../../apps/packages/product-client/src/hooks/terminals),
+[lib/domain/terminals](../../../../../apps/packages/product-client/src/lib/domain/terminals),
+[lib/infra/terminals](../../../../../apps/packages/product-client/src/lib/infra/terminals),
+[stores/terminal](../../../../../apps/packages/product-client/src/stores/terminal).
+
+## 9. Proof
+
+- [live/terminals/manager_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/manager_tests.rs)
+  — registry, create/close, setup-run lifecycle, workspace-wide stop.
+- The archive `quiesce` and `undo` scenarios in
+  [workspaces/archive/tests](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/tests/mod.rs)
+  exercise `close_all_for_workspace` + `run_blocking_command_for_workspace`
+  end to end.
+- Client: the creation-grid acceptance in
+  [terminals.md](../../../../codebase/systems/product/workspaces/terminals.md).
+
+## Known gaps / follow-ups
+
+- Terminal records do not survive a runtime restart; a cloud task environment
+  that checkpoints and reaps loses open shells by design — the environments
+  spec should say so explicitly.
+- The durable store has no dedicated unit suite beyond the manager tests.

--- a/specs/codebase/systems/runtime/workspaces/README.md
+++ b/specs/codebase/systems/runtime/workspaces/README.md
@@ -1,0 +1,301 @@
+# Workspaces
+
+Status: current (grade B). System spec in the Organization Standard anatomy.
+The runtime system that owns *where execution happens*: the durable identity of
+a checkout (local clone or managed worktree), the repo root it belongs to, the
+per-workspace surfaces layered on that checkout (files, git, hosting, setup,
+process runs), and the lifecycle verbs that create, archive, checkpoint,
+restore, move, and purge it. Archiving, checkpoints, worktree restore, repo
+roots, and mobility are **sections of this spec**, not systems: each has code
+locality but no owned state or public surface that outlives a workspace
+([granularity test](../README.md)).
+
+Depth references (all banner-linked back here):
+[workspaces.md](../../../../anyharness/workspaces.md) (flows, archive, checkpoints),
+[files.md](../../../../anyharness/files.md), [git.md](../../../../anyharness/git.md),
+[mobility.md](../../../../anyharness/mobility.md),
+[workspace-command-environment.md](../../../../anyharness/workspace-command-environment.md),
+and the client-side [workspaces system docs](../../../../codebase/systems/product/workspaces/README.md).
+
+## 1. Purpose
+
+Give every session, terminal, subagent, review, and workflow one durable,
+canonical execution surface — a `WorkspaceRecord` pointing at exactly one repo
+root and one path — and guarantee that nothing destructive ever runs on a
+guess about that path. The product outcome: a user can open a repo, spin
+worktrees per task, archive them when done, undo cheaply, and never lose a
+checkout the runtime did not explicitly get permission to delete.
+
+## 2. Owned state
+
+All rows live in the AnyHarness SQLite database
+([schema](../../../../GENERATED/anyharness-db-schema.sql)); only this system writes them.
+
+| Table | Meaning | Written by |
+| --- | --- | --- |
+| `workspaces` | `WorkspaceRecord`: kind (`local`/`worktree`), surface (`standard`/`cowork`), repo_root_id, path, branches, lifecycle (`active`/`archived`), archive snapshot columns, origin + creator context | [store/](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/store/mod.rs) |
+| `repo_roots` | `RepoRootRecord`: canonical repo path, default branch, parsed remote | [repo_roots/store.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/repo_roots/store.rs) |
+| `workspace_access_modes` | target-local runtime mode: `normal` / `frozen_for_handoff` / `remote_owned` / `repair_blocked` | [store/access.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/store/access.rs) |
+| `workspace_checkpoints` | turn-start git captures (row = metadata truth; refs = bytes truth) | [store/checkpoints.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/store/checkpoints.rs) |
+| `workspace_setup_state` | last setup-script run pointer per workspace — **owned by [terminals](../terminals/README.md)** (its store writes the row); this system's [setup_runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/setup_runtime.rs) decides *when* | terminals store |
+| `worktree_retention_policy` | **vestigial**: table exists ([0040](../../../../../anyharness/crates/anyharness-lib/src/persistence/sql/0040_worktree_retention_policy.sql)) but no runtime code reads or writes it on `main` — its server-side twin died in the cull (Track A-a part 1); drop with the next migration | nobody |
+| `mobility_archive_installs` | replay ledger for idempotent mobility installs | [mobility/store.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/mobility/store.rs) |
+
+Outside the database this system is the **sole writer** of two private git ref
+namespaces: `refs/proliferate/archive-*` ([archive/refs.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/refs.rs))
+and `refs/proliferate/checkpoints/<workspace>/<checkpoint>/{head,worktree,index}`
+([checkpoints/refs.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/checkpoints/refs.rs)),
+plus the managed worktree directories it materializes under the runtime home
+and `<runtime-home>/mobility/destinations/<repo-root-id>/`.
+
+## 3. Public surface
+
+HTTP, all under `/v1` ([api/http](../../../../../anyharness/crates/anyharness-lib/src/api/http/mod.rs)):
+
+| Route family | Module | Verbs |
+| --- | --- | --- |
+| `/workspaces`, `/workspaces/resolve`, `/workspaces/{id}`, `/workspaces/{id}/display-name` | [workspaces.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/workspaces.rs) | list (`?lifecycle=active|archived|all`), create, resolve-by-path, get, rename |
+| `/workspaces/worktrees` | [workspaces_worktrees.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/workspaces_worktrees.rs) | create a managed worktree |
+| `/workspaces/{id}/archive`, `/unarchive` | [workspaces_lifecycle.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs) | archive at the flip, undo |
+| `DELETE /workspaces/{id}` | [workspaces_purge.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs) | purge |
+| `/workspaces/{id}/worktree/restore` | [workspaces_restore.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/workspaces_restore.rs) | re-materialize a missing worktree |
+| `/workspaces/{id}/detect-setup`, `/setup-status`, `/setup-start`, `/setup-rerun` | [workspaces_setup.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/workspaces_setup.rs) | setup-script lifecycle |
+| `/worktrees/inventory`, `/worktrees/orphans/prune` | [worktrees.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/worktrees.rs) | git-registration inventory + prune |
+| `/workspaces/{id}/files/*` | [files.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/files.rs) | entries, file read/write, stat, search |
+| `/workspaces/{id}/git/*` | [git.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/git.rs) | status, diff, branches, stage/unstage(+patch), revert, commit, push |
+| `/workspaces/{id}/hosting/pull-requests*`, `/repo-roots/{id}/hosting/pull-requests` | [hosting.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/hosting.rs) | PR read model |
+| `/workspaces/{id}/processes/run` | [processes.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/processes.rs) | one-shot process in the workspace env |
+| `/repo-roots`, `/repo-roots/resolve`, `/repo-roots/{id}`, `/repo-roots/{id}/git/branches`, `/files/file`, `/detect-setup`, `/repo-roots/materializations`, `/repo-roots/{id}/workspace-materializations` | [repo_roots.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs) | repo-root registry + materialization listings |
+| `/workspaces/{id}/mobility/preflight`, `/runtime-state`, `/export`, `/install`, `/destroy-source`; `/repo-roots/{id}/mobility/prepare-destination` | [mobility.rs](../../../../../anyharness/crates/anyharness-lib/src/api/http/mobility.rs) | cross-runtime handoff |
+
+Wire shapes: [workspaces.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/workspaces.rs),
+[workspaces_lifecycle.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/workspaces_lifecycle.rs),
+[worktrees.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/worktrees.rs),
+[repo_roots.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/repo_roots.rs),
+[files.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/files.rs),
+[git.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/git.rs),
+[hosting.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/hosting.rs),
+[processes.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/processes.rs),
+[mobility.rs](../../../../../anyharness/crates/anyharness-contract/src/v1/mobility.rs).
+
+In-process surface for sibling domains (the only legal way in — see Fences):
+`WorkspaceRuntime` ([runtime/mod.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/mod.rs))
+for resolution/creation/restore/materialization; `WorkspaceAccessGate`
+([access_gate.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs))
+as the single carrier of "is this workspace mutable right now";
+`WorkspaceOperationGate` ([operation_gate.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/operation_gate.rs))
+for per-workspace leases; `WorkspaceFileProtection` in
+[files_runtime.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/files_runtime.rs)
+as the hook artifacts uses to protect paths; the derived env in
+[env.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/env.rs).
+
+## 4. Consumes
+
+- `adapters/files`, `adapters/git`, `adapters/hosting`, `adapters/processes`
+  ([adapters/](../../../../../anyharness/crates/anyharness-lib/src/adapters/mod.rs)) —
+  the local-capability layer; workspaces decides *meaning*, adapters perform.
+  The one carve-out is the two private ref namespaces above, which shell
+  `git update-ref`/`show-ref`/`for-each-ref` directly.
+- `terminals` — setup and archive-script runs execute through
+  `TerminalService` ([manager.rs](../../../../../anyharness/crates/anyharness-lib/src/live/terminals/manager.rs)); see [terminals.md](../terminals/README.md).
+- `sessions` — quiesce, purge, mobility preflight and destroy-source read
+  session state and close live sessions through session-owned facades.
+- `agents` (harnesses) — mobility and setup consult agent kind and native
+  artifact locations; see [harnesses.md](../harnesses/README.md).
+- `cowork`, `reviews` — the `WorkspaceSurface::Cowork` gate and review-active
+  checks (baseline edges, both slated to invert; see Fences).
+- `process_kill` (crate root) — the `PlaneKills` census every destructive step
+  awaits.
+
+## 5. Laws
+
+**One workspace, one repo root, one stable path.** `WorkspaceRecord.repo_root_id`
+is mandatory and `path` is reserved for the row's lifetime; creation refuses any
+path an archived row still claims for every kind
+([store/lookups.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/store/lookups.rs)).
+Without it native chat resume — keyed on the absolute worktree path — silently
+attaches to the wrong checkout.
+
+**Nothing destructive runs on a guess.** Every path comparison resolves both
+sides through [path_identity.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/path_identity.rs)
+(`same_path` fails closed for claim gates, `same_path_strict` fails closed for
+"is this registration ours?"), and every destructive step re-reads its row
+under the workspace lease. The leftover predicate
+([archive/phase2.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/phase2.rs))
+requires `Worktree ∧ Archived ∧ archived_head_sha ∧ dir present ∧ no other
+row claims the path`; drop any term and the sweep deletes a live checkout.
+
+**The runtime never deletes a checkout the user did not ask it to delete.**
+There is no backstop retention pass for local or worktree workspaces. Checkpoint
+refs are exempt: they are runtime-made copies, not the user's tree
+([checkpoints/retention.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/checkpoints/retention.rs)).
+
+**Archive answers at the flip; undo is cheap.** Everything the user waits for
+precedes `mark_archived`; script, worktree removal, and branch delete run
+detached under a generation-tagged cancellation token registered *before* the
+flip ([archive/tokens.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/tokens.rs)),
+so unarchive can cancel removal and restore in place. "Leftover" is a derived
+listing fact, never stored state — nothing needs repair, only convergence
+([archive/sweep.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/sweep.rs)).
+
+**Archived means read-only, not gone.** `WorkspaceAccessGate` is the single
+predicate; every mutation returns `WORKSPACE_ARCHIVED`, every read succeeds, and
+chat history, file tree and git state keep rendering. An unarchive whose path is
+occupied is a scenario 409 ([archive/tiers.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/tiers.rs)), never a relocation.
+
+**Refs before row on capture, row before refs on delete.** A checkpoint's bytes
+are durable and verified before its metadata exists; deletion marks
+`expired_at` first. A crash between the two leaves an orphan the sweep reaps
+by row-absence, never an unexpired row without bytes
+([checkpoints/capture.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/checkpoints/capture.rs)).
+
+**One lease per prompt flow.** Prompt dispatch, checkpoint capture, actor
+dispatch and settlement share one `SessionPrompt` workspace-operation lease;
+under-lease entrypoints never reacquire it. This prevents the nested-read
+deadlock behind a queued exclusive writer and stops retention/purge/archive from
+observing the refs-before-row interval.
+
+**Mobility moves nothing without external authority.** Export requires the exact
+frozen handoff id, base commit and branch; `destroy-source` requires
+`remote_owned`; the runtime cannot choose a destination or prove another runtime
+canonical ([mobility/runtime/mobility_policy.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy.rs)).
+
+## 6. Emits
+
+- Workspace availability signal — `checkout_directory_missing()` on the record
+  ([model.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/model.rs)) drives the
+  "worktree no longer exists" UI and refuses session starts; fails open to
+  "available" on ambiguous I/O.
+- Setup-run status and the setup terminal (consumed by the client setup pane).
+- Telemetry: `checkpoint.capture.skipped` (`reason="busy_will_queue"`), the
+  archive sweep pass counters, `QuiesceReport` kill census.
+- `fork_operations.checkpoint_id` — a lookup-only reference the sessions system
+  reads at fork boundaries; NULL means "no checkpoint sat here" and must be
+  disclosed, never treated silently.
+
+## 7. Fences
+
+| Not owned | Owner |
+| --- | --- |
+| Session records, actors, prompt queues | sessions (`domains/sessions/**`, [sessions.md](../../../../anyharness/sessions.md)) |
+| PTY lifecycle and command-run records | [terminals.md](../terminals/README.md) |
+| Agent kinds, install, readiness | [harnesses.md](../harnesses/README.md) |
+| Artifact manifest and write protection *policy* (workspaces only calls the hook) | [artifacts.md](../artifacts/README.md) |
+| File path safety, git parsing, PR fetching, process spawning mechanics | runtime `adapters` capability ([adapters.md](../../../../anyharness/adapters.md)) |
+| Cloud-side workspace rows, materialization, sandbox placement | environments (control plane; formerly `server/cloud/workspaces`, culled) |
+| Client presentation: file tree, git pane, repo-setup flow, sidebar recency | client workspace surface ([workspaces/README.md](../../../../codebase/systems/product/workspaces/README.md)) |
+
+Declared domain edges (AH-FENCE-001 baseline in
+[fences.toml](../../../../../lints/anyharness/fences.toml)): `workspaces → agents,
+cowork, repo_roots, reviews, sessions, terminals`. The `workspaces → cowork`
+and `workspaces → reviews` edges are core-depends-on-surface inversions
+tolerated by the baseline; they shrink when the Cowork gate and review-active
+check become extension ports. Twenty-two of the forty-two grandfathered
+AH-FENCE-002 store-reach sites are inside this domain
+([exceptions.toml](../../../../../lints/anyharness/exceptions.toml)) — the largest
+ledger share in the runtime.
+
+> [!decision] PABLO DECIDES: repo roots. `domains/repo_roots` is a 260-line
+> single-concern domain with its own table and routes. Options: (a) keep it a
+> section of this spec and eventually fold the folder in (`workspaces/roots/`);
+> (b) promote to its own spec. Recommendation: (a) — it has owned state but no
+> laws an uninformed change would violate beyond "one root per workspace".
+
+> [!decision] PABLO DECIDES: mobility. `domains/mobility` (4.2K lines, 7
+> store-reach sites) is on the Cull Plan's list but no cull track deleted it.
+> Its only product consumers are the desktop "open in web" remote-access flow
+> ([use-workspace-open-in-web-actions.ts](../../../../../apps/packages/product-client/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.ts))
+> and copy metadata — a lane that is dark while cloud is gated. Options: (a)
+> delete now (domain, routes, contract, `mobility_archive_installs`, client
+> remote-access flow); (b) keep as a frozen section until the environments
+> rebuild decides whether cross-runtime handoff survives. Recommendation: (a);
+> the environments design moves the *record* to the control plane and forks the
+> environment, which makes archive-and-install handoff obsolete.
+
+> [!decision] PABLO DECIDES: checkpoints. Turn-start capture is behind
+> `ANYHARNESS_CHECKPOINT_CAPTURE` (default off) as a cost-observation rung, and
+> the revert/modal consumers it was built for never landed. Options: (a) keep
+> dark as the substrate for the demo's "undo a turn" story; (b) cull. Recommendation:
+> (a) only if turn-revert is on the launch-week roadmap, otherwise (b).
+
+## 8. Code map
+
+```text
+anyharness/crates/anyharness-lib/src/
+├── domains/workspaces/                      the system (23K lines)
+│   ├── model.rs · types.rs · store/         WorkspaceRecord, lifecycle enums, SQL
+│   ├── runtime/                             WorkspaceRuntime: identity, lifecycle,
+│   │                                        worktrees, restore, exact_ref, env,
+│   │                                        materialization, mobility, workflow_placement
+│   ├── resolver.rs · detector.rs            path → repo root/workspace resolution
+│   ├── path_identity.rs                     same_path / same_path_strict
+│   ├── access_gate.rs · access_model.rs     the archived/frozen predicate
+│   ├── operation_gate.rs · checkout_gate.rs per-workspace leases
+│   ├── creator_context.rs · options.rs      creation inputs and validation
+│   ├── env.rs · exclude.rs                  derived workspace env, ignore rules
+│   ├── files_runtime.rs                     file ops + artifact protection hook
+│   ├── setup_runtime.rs · worktree_runtime.rs · worktree_names.rs · worktree_checkout.rs
+│   ├── inventory.rs · branch_refresh.rs · managed_root.rs · restore_runtime.rs
+│   ├── archive/                             SECTION: archive/unarchive, phase2,
+│   │                                        tiers, tokens, inflight, quiesce, sweep, refs
+│   ├── checkpoints/                         SECTION: capture, refs, retention, flags
+│   └── deletion/                            SECTION: purge
+├── domains/repo_roots/                      SECTION: model/store/service
+├── domains/mobility/                        SECTION (cull candidate): preflight,
+│                                            export, install, destination, destroy-source
+├── api/http/{workspaces,workspaces_lifecycle,workspaces_purge,workspaces_restore,
+│             workspaces_setup,workspaces_worktrees,worktrees,files,git,git_task,
+│             hosting,processes,repo_roots,mobility}.rs   transport only
+├── app/workspaces.rs · app/mobility.rs     composition of archive/checkpoint/purge
+└── (adapters/files, adapters/git, adapters/hosting, adapters/processes → adapters capability)
+anyharness/crates/anyharness-contract/src/v1/{workspaces,workspaces_lifecycle,worktrees,
+    repo_roots,files,git,hosting,processes,mobility}.rs   wire shapes
+```
+
+Target layout (Wave 3 rename, **not current**): `domains/` → `systems/`;
+`repo_roots/` folds into `workspaces/roots/`; `mobility/` deleted or folded per
+the decision above. Nothing in this PR moves.
+
+Client-plane presentation of this system's state (owned by the client
+workspace surface, listed here so the bijection closes):
+[components/workspace/files](../../../../../apps/packages/product-client/src/components/workspace/files),
+[components/workspace/git](../../../../../apps/packages/product-client/src/components/workspace/git),
+[components/workspace/repo-setup](../../../../../apps/packages/product-client/src/components/workspace/repo-setup),
+[hooks/workspaces](../../../../../apps/packages/product-client/src/hooks/workspaces),
+[lib/domain/workspaces](../../../../../apps/packages/product-client/src/lib/domain/workspaces),
+[stores/workspaces](../../../../../apps/packages/product-client/src/stores/workspaces).
+
+## 9. Proof
+
+Pinning suites (all in-crate, run with `cargo test -p anyharness-lib`):
+
+- Archive: [archive/tests/](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/tests/mod.rs)
+  — admission, branches, head_mismatch, idempotency, paths, quiesce,
+  restore_interlocks, scenarios, sweep, undo; [archive/refs_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/archive/refs_tests.rs).
+- Checkpoints: [checkpoints/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/checkpoints/tests.rs),
+  [retention_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/checkpoints/retention_tests.rs),
+  [gc_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/checkpoints/gc_tests.rs).
+- Purge: [deletion/tests/](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/deletion/tests/mod.rs).
+- Runtime: [runtime/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/tests.rs),
+  [worktree_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/worktree_tests.rs),
+  [restore_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/restore_tests.rs),
+  [exact_ref_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/exact_ref_tests.rs),
+  [store/tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/workspaces/store/tests.rs).
+- Mobility: [mobility_policy_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy_tests.rs),
+  [destroy_source_tests.rs](../../../../../anyharness/crates/anyharness-lib/src/domains/mobility/runtime/destroy_source_tests.rs).
+- Cross-plane: [workspace-entry.spec.ts](../../../../../tests/intent/specs/workspace-entry.spec.ts)
+  pins the client entry flow over a live runtime.
+- Fence: [check_anyharness_fences.py](../../../../../scripts/check_anyharness_fences.py)
+  holds this domain's edge set; the sole-writer rule for the two ref
+  namespaces is review-enforced (grep `update-ref|show-ref|for-each-ref`
+  against `refs/proliferate/`).
+
+## Known gaps / follow-ups
+
+- `WorkspaceService` vs `WorkspaceRuntime` duplicated bodies and a ~25-file
+  flat root remain the migration exception recorded in
+  [domains.md](../../../../anyharness/domains.md); target is concern folders behind one
+  entry surface.
+- Queue-drain turn starts are not checkpointed (disclosed conformance
+  shortfall of the dispatch-seam hook).
+- The two `workspaces → cowork/reviews` edges should become extension ports.


### PR DESCRIPTION
## What

Six living system specs for the AnyHarness plane, in the Organization Standard's nine-section anatomy (Purpose · Owned state · Public surface · Consumes · Laws · Emits · Fences · Code map · Proof), under a new `specs/codebase/systems/runtime/` plane folder beside `product/` and `engineering/`:

| Spec | Grade | Notes |
| --- | --- | --- |
| `runtime/workspaces` | B | archive, checkpoints, repo roots, mobility as **sections** (archiving ruling) |
| `runtime/harnesses` | B | today's `domains/agents`; agent_auth's runtime half (`auth/`, `auth_state.rs`, `route_auth/`) fenced, not owned |
| `runtime/subagents` | B | `agent_operations` (Workspace MCP, 20 tools) + `sessions/subagents` (exactly-once completion delivery) |
| `runtime/terminals` | B | owns `terminal_command_runs` **and** `workspace_setup_state` (its store writes the row) |
| `runtime/artifacts` | B | honest scope: Cowork's artifact machinery on `main`; evidence graduation path marked |
| `runtime/desktop-host` | seam | shell ↔ sidecar ↔ desktop worker; diagnostics/updater/google-workspace fenced to their owners |

Superseded depth docs (`anyharness/{workspaces,agents,mobility}.md`, `FEATURE_DOCS/DESKTOP_HOST.md`, `cowork-artifacts.md`, the Workspace MCP definition) carry ownership banners pointing at the owning spec. No code moves; target renames (`domains/` → `systems/`, `agents` → `harnesses`, `agent_operations` → `subagents`) are recorded in each code map as current → target.

## PABLO DECIDES (inline `> [!decision]` blocks)

1. **workspaces** — repo roots: fold as a section (rec) vs own spec.
2. **workspaces** — mobility (4.2K lines, 7 grandfathered store-reach sites, cull-listed but never culled; only consumer is the dark "open in web" flow): delete now (rec) vs freeze.
3. **workspaces** — checkpoints behind `ANYHARNESS_CHECKPOINT_CAPTURE`: keep only if turn-revert is on the launch roadmap.
4. **harnesses** — harness kinds: drop Cursor + Grok after usage check (rec) vs keep five.
5. **harnesses** — move `auth/`, `auth_state.rs`, `route_auth/` to `domains/agent_auth/` in Wave 3 (rec).
6. **subagents** — cowork delegation folds into subagents / two-tier orchestration (rec) vs stays a third model.
7. **subagents** — keep the `proliferate_workspace` MCP wire name, rename only the folder (rec).
8. **artifacts** — generalize to evidence by lifting the Cowork gate (rec) vs keep cowork-owned.
9. **desktop-host** — `google_workspace_mcp` commands move behind the integration gateway when that spec lands (rec).

## Findings while verifying against `main` (recorded in the specs)

- `worktree_retention_policy` and `agent_model_registry_snapshots` tables have **no runtime reader or writer** — vestigial; drop with the next migration.
- `workspace_setup_state` is written by the **terminals** store, not workspaces; ownership recorded accordingly.
- `domains/artifacts/` has **no test module**; lifecycle is pinned only indirectly through cowork's MCP tests.
- `agent_operations` already has zero grandfathered AH-FENCE-002 sites; `workspaces` carries 22 of the 42.

## Verification

- `python3 scripts/check_docs.py` — passed (251 files; every link resolves).
- `python3 scripts/check_anyharness_fences.py` — OK, baseline and ledger match reality (docs-only change).
- Inline adversarial pass (subagents unavailable to this fork): every table-writer claim re-grepped (three corrected: setup state, retention policy, registry snapshots), a Grok adapter claim corrected against `harnesses/grok.md`, one tree-line path corrected, route tables cross-checked against `api/http/*.rs` literals.

## Deviation from the original directive

Placed under `specs/codebase/systems/runtime/<name>/README.md` per `specs/README.md`'s routing law and the convention #2225 set (not `specs/systems/`); a new `runtime/` plane folder was created because none existed.

Change taxonomy: spec gap (bucket 2) — no architecture changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
