### PR TITLE
docs(specs): engineering system spec — observability

### DIFF
--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -119,6 +119,7 @@ REQUIRED_READMES = (
     "specs/codebase/systems/engineering/customer-loop/README.md",
     "specs/codebase/systems/engineering/delivery/README.md",
     "specs/codebase/systems/engineering/observability/README.md",
+    "specs/codebase/systems/engineering/testing/README.md",
     "guides/README.md",
     "guides/process/README.md",
     "guides/local/README.md",

--- a/scripts/test_check_docs.py
+++ b/scripts/test_check_docs.py
@@ -61,6 +61,7 @@ class DocumentationIntegrityTest(unittest.TestCase):
             "specs/codebase/systems/engineering/customer-loop/README.md",
             "specs/codebase/systems/engineering/delivery/README.md",
             "specs/codebase/systems/engineering/observability/README.md",
+            "specs/codebase/systems/engineering/testing/README.md",
             "guides/operating/README.md",
             "guides/operating/analytics/README.md",
             "specs/TESTING/manual-release-qa.md",

--- a/specs/codebase/systems/engineering/README.md
+++ b/specs/codebase/systems/engineering/README.md
@@ -16,10 +16,13 @@ from user action to agent to gateways to failure.
   one `session_id` across Sentry, structured logs → Grafana, and Honeycomb;
   the closed catalog, correlation vocabulary, scrubbing law, and the
   per-system Emits audit.
-- Testing and Linting, Building Loop, Alerting, Customer loop — landing
-  tonight as `testing/`, `building-loop/`, `alerting/`, `customer-loop/`;
-  until each lands, [`specs/TESTING.md`](../../../TESTING.md) and
-  [`specs/OBSERVABILITY.md`](../../../OBSERVABILITY.md) are the per-PR law.
+- [Testing and Linting](testing/README.md) — the tier contract
+  ([`specs/TESTING.md`](../../../TESTING.md) stays the per-PR standard), rule
+  records, ratchets, checkers, and the issue→test loop that pins every
+  spec's laws.
+- Building Loop, Alerting, Customer loop — landing tonight as
+  `building-loop/`, `alerting/`, `customer-loop/`; until each lands,
+  [`specs/OBSERVABILITY.md`](../../../OBSERVABILITY.md) is the per-PR law.
 
 Retired (2026-08-25, engineering cull PR #2214): the issue-lifecycle system
 and its hosted tracker. Support report *capture* is a product system

--- a/specs/codebase/systems/engineering/observability/README.md
+++ b/specs/codebase/systems/engineering/observability/README.md
@@ -1,64 +1,407 @@
-# Observability System
+# Observability
 
-Observability owns how Proliferate produces diagnostic evidence: structured
-logs, Sentry events, privacy controls, correlation fields, and the connection
-between application failures and CloudWatch/Grafana signals.
+Status: current for the signal sources, scrubbing law, and the checked-in
+Grafana/Honeycomb artifacts; target for the legibility contract (§5) and the
+cross-linked session story. Grade B — see [Known gaps](#known-gaps).
 
-- [Sentry](sentry.md) — component initialization, release and environment
-  identity, transmitted data, scrubbing, correlation, and failure behavior.
-- [Delivery](../delivery/README.md) — the artifact and deploy identity used as
-  the `release`/`release_id` correlation key.
+Read before touching: [`specs/OBSERVABILITY.md`](../../../../OBSERVABILITY.md)
+(the per-PR decision layer over this spec), [sentry.md](sentry.md) (component
+behavior, closed catalog, privacy), `server/proliferate/integrations/sentry/**`,
+`server/proliferate/middleware/{logging,request_context,request_telemetry}.py`,
+`server/infra/observability/**`, `scripts/ops/grafana-*.mjs`,
+[`specs/anyharness/observability.md`](../../../../anyharness/observability.md)
+(span doctrine), and the
+[rust-observability ADR](../../../../../adrs/2026-08-10-rust-observability.md)
+(diagnostics plane).
 
-## Boundary
+Engineering systems are cross-cutting. This one owns **no product state**: it
+consumes every product and runtime spec's *Emits* section (the signals) and
+*Proof* section (the tests that pin them), and it turns those into one thing —
+a legible account of what happened. A product system whose Emits section is
+empty is invisible in production; §4 lists exactly which ones are.
 
-Observability owns:
+## 1. Purpose
 
-- the code that emits exceptions, traces, breadcrumbs, structured logs, and
-  critical-failure markers;
-- source-owned release, environment, surface, and correlation fields;
-- redaction before vendor transmission;
-- the relationship between server logs, Sentry, CloudWatch, and Grafana.
+Answer, for any session, **what happened end to end** — user action → agent →
+gateways → provider → failure — from one identifier, readable by a person in
+under a minute and by an agent without a person. That is the only outcome;
+everything below serves it.
 
-Observability does not own:
+Two readers, one story:
 
-- product/adoption analytics, which belongs to
-  [Engineering Analytics](../analytics/README.md);
-- release construction and promotion, which belongs to Delivery;
-- mutable Sentry projects, alert rules, integrations, or Slack destinations.
-  Operators discover that state at execution time using the
-  [Sentry operating procedure](../../../../../guides/operating/analytics/sentry.md).
+- **A person triaging**: opens the session, sees the turn timeline, the tool
+  calls that failed, the Sentry issue that fired, and the latency that was
+  outside budget — without switching identifiers between tools.
+- **An agent fixing**: the launch-week demo agent consumes session replays and
+  Sentry issues to propose fixes. It needs stable event names, ids it can
+  join on, and links it can follow. Prose alerts and screenshots are not
+  legible to it.
 
-## Deployment and data contract
+Stack, ruled 2026-08-25: **Sentry** (exceptions, releases, environments,
+fingerprints) + **Grafana** (monitors over CloudWatch logs — the alert
+evaluation source) + **Honeycomb** (traces and SLIs) + the **support
+capture** path ([support](../../product/support/README.md)), all cross-linked
+from one `session_id`. Not Sentry alone.
 
-Proliferate vendor observability is enabled for hosted-product components only.
-Local development and self-managed deployments keep Proliferate vendor DSNs
-unset and use local or deployment-owned logs. A component with no applicable
-DSN must continue without Sentry.
+## 2. Owned state
 
-The source components are the hosted server and background workers, Desktop
-renderer and native shell, hosted Web and Mobile clients, AnyHarness, and the
-managed target Worker and Supervisor. Components with explicit scrubbers may
-transmit scrubbed exceptions, stack traces, traces, breadcrumbs, component
-release/environment, surface tags, and allowlisted correlation identifiers to
-the Sentry destination selected by their configured DSN. AnyHarness applies an
-explicit before-send scrubber to its hosted-product events and breadcrumbs.
-Desktop-native can transmit exceptions and stack traces but lacks that
-explicit scrubber. Server structured logs go to the deployment log sink and
-can be queried through CloudWatch/Grafana in the hosted stack.
+No product tables. Observability owns *contracts and artifacts*, all in-repo,
+plus the discipline that keeps them true:
 
-Sentry is diagnostic telemetry, not session replay by default. Web and Mobile
-set both replay rates to zero. Desktop renderer replay is source-disabled and
-absent; no build configuration can enable it. Re-enablement requires a
-separately reviewed synthetic privacy proof of the exact route/surface
-block-and-mask policy, metadata policy, provider arrival, and absence of
-prompt, transcript, terminal, file, repository, path, token, workspace,
-session, and workflow identifiers. The Desktop runtime telemetry disable
-setting disables vendor telemetry as well.
+```text
+server/proliferate/integrations/sentry/privacy.py       the closed catalog — every tag/extra/context key that may leave the server
+server/proliferate/middleware/request_context.py        the correlation-id vocabulary (ContextVars) — the ID tuple, server side
+server/infra/observability/grafana/*.json               alert rules + dashboard, checksummed; two workspaces today (§ Current state)
+server/infra/observability/honeycomb/product-sli-queries.json   the SLI definitions (three, all parked — §4)
+fixtures/contracts/rust-observability-v1/               diagnostics schema v1.1 golden contract (privacy rejections, limits)
+proliferate-diagnostics-collector/src/export/policy.rs  EXPORT_POLICY — compile-time export ceiling, no config can widen it
+scrubbers on every emitter                              server catalog · product-client scrubTelemetryEvent · AnyHarness/Worker/Supervisor before-send
+```
 
-The sole listed source-code gap is:
+Live provider state — Sentry projects, alert rules, Grafana contact points,
+Honeycomb keys, Slack destinations — is **mutable and discovered**, never
+owned: [operate Sentry](../../../../../guides/operating/analytics/sentry.md),
+[production alerts](../../../../../guides/operating/production-alerts.md).
+A checked-in JSON file is a *statement of intent* the operator scripts apply
+and verify; it is not evidence the live workspace matches.
 
-- the Desktop-native Rust adapter does not install the explicit before-send
-  scrubber used by the server, clients, AnyHarness, Worker, and Supervisor.
+## 3. Public surface
 
-Do not add free-form user content or secrets to tracing events. Closing this
-remaining source-code gap requires a separate implementation PR.
+The instrumentation API every other system calls (the only way a signal
+enters):
+
+| Surface | Owner file | What it is |
+| --- | --- | --- |
+| `report_critical(...)` | `integrations/sentry/client.py` | fatal Sentry event + the exact `CRITICAL_FAILURE` log marker — the one bridge from application failure to a page-worthy alert |
+| `capture_server_sentry_exception(..., level, tags, extras)` | same | anomaly the user did not feel; tags/extras validated against the closed catalog, unlisted keys structurally absent |
+| propagate the exception | Starlette/Celery integrations | genuinely failed operation → `proliferate-server` issue |
+| structured log record | `middleware/logging.py` | JSON: ts, level, logger, message, `release_id`, correlation context, scalar extras — **the alert-evaluation source** |
+| `with_correlation_context(**ids)` · `bind_background_correlation_context(**ids)` | `middleware/request_context.py` | bind the ID tuple for a request or a background job so logs and Sentry carry it |
+| `#[tracing::instrument]` span per use-case entry; named `tracing` targets (`anyharness.*`) | `anyharness-lib/src/observability/mod.rs` | runtime events; the Sentry layer forwards ERROR events, the diagnostics client forwards lifecycle records |
+| lifecycle records, closed P0 catalog (`anyharness.session.create`, `agent.start`, `turn.execute`, `tool.invoke`, `model.request`) | `proliferate-diagnostics-client/src/lifecycle.rs` | one `started` + exactly one terminal; exportable to Honeycomb under `EXPORT_POLICY` |
+| `trackProductEvent(name, payload)` (126 typed names) | `product-client/src/lib/domain/telemetry/events.ts` | client product events → PostHog / anonymous telemetry (analytics owns routing) |
+| `GET /v1/health` exporter fields (`exporter.state`, `dropped_records`, `last_error_classification`) | diagnostics collector | export health, never a product result |
+
+Operator surface: `node scripts/ops/grafana-alerting.mjs <check|export|apply|restore>`
+(old workspace), `grafana-rebuild-bootstrap.mjs <check|apply|verify|slack-*>`
+and `grafana-sli-alerts.mjs` (rebuild workspace), both gated on
+`GRAFANA_ALERTING_LIVE=1`; `scripts/ops/grafana-metadata-inventory.mjs`
+(bounded read-only inventory).
+
+Per-PR surface: every PR states its **observability delta** or an explicit
+"none" ([`specs/OBSERVABILITY.md`](../../../../OBSERVABILITY.md) §"Deciding a
+change's observability delta").
+
+## 4. Consumes
+
+**Every system's Emits section.** Audited 2026-08-25 against the 30 product
+and runtime specs on `main`. "Telemetry-shaped" means the section names at
+least one stable, machine-consumable signal (a log marker, a tracing target,
+a typed event, a named ship-now event); "product-shaped" means it lists only
+UI/contract outputs; "empty" means no Emits section at all. Anything not
+telemetry-shaped is invisible to this system today.
+
+| System | Emits today | Verdict | What this system needs from it |
+| --- | --- | --- | --- |
+| [runs](../../product/runs/README.md) | `run.created/placed/status_changed/spawned_child/result_recorded/cancelled_tree` (target) | telemetry-shaped, **target** | the same names as log markers at the CP transition writer, stamped with the ID tuple |
+| [seam](../../product/seam/README.md) | worker liveness → `workerDegraded`, heartbeat/enrollment events in `observability.rs`, target ship-now ingest | telemetry-shaped | `WORKER_DEGRADED` as a log marker (nothing alerts on it today — §Known gaps) |
+| [environments](../../product/environments/README.md) | sandbox transitions, usage segments, `provisioning_observability.py`, target `environment_bound/lost` | telemetry-shaped | provisioning outcome + duration per target, session-linked |
+| [automations](../../product/automations/README.md) | 14 `anyharness.workflow_*` tracing targets; CP emits nothing for definitions/invocations | telemetry-shaped (runtime only) | CP-side `invocation.created/deduped` markers when the trigger pipeline lands |
+| [api](../../product/api/README.md) | `token.minted/delegated/revoked`, `api.request` (target) | telemetry-shaped, target | audited request records with `run_id`/`session_id` |
+| [billing](../../product/billing/README.md) | segment/spend/envelope events | telemetry-shaped | `BUDGET_ENVELOPE_EXHAUSTED` marker at the enforcement point |
+| [chat](../../product/chat/README.md) | turn-end / reveal performance product events | telemetry-shaped (client) | turn-end latency keyed by `session_id` — today keyed by nothing joinable server-side |
+| [organizations](../../product/organizations/README.md), [subagents](../../runtime/subagents/README.md), runtime [workspaces](../../runtime/workspaces/README.md) | named events | telemetry-shaped | keep; add `session_id` where a session exists |
+| [sessions](../../product/sessions/README.md) | the `SessionEventEnvelope` stream, status transitions, completion deliveries | product-shaped | **the story's spine** — the envelope is the replay; this system needs `session.started/ended`, `turn.started/ended` as ship-now records at the CP (target checkpoint) and the envelope's `session_id` on every Sentry event raised while serving that session |
+| [integration_gateway](../../product/integration_gateway/README.md) | `cloud_integration_tool_call_event` rows, typed error codes, approvals | product-shaped | tool-call outcome as a log record (`tool.invoked` with provider, outcome code, duration, `session_id`) — the rows exist, the log line does not |
+| [model_gateway](../../product/model_gateway/README.md) | ledger, spend attribution | product-shaped | per-request outcome/latency/model as a record with `session_id` (LiteLLM has it; nothing forwards it) |
+| [agent_auth](../../product/agent_auth/README.md), [github](../../product/github/README.md), [slack](../../product/slack/README.md), [accounts](../../product/accounts/README.md), [onboarding](../../product/onboarding/README.md), [settings](../../product/settings/README.md), product [workspaces](../../product/workspaces/README.md), [runs-triage](../../product/runs-triage/README.md) | contract/UI outputs | product-shaped | a failure-path marker each (auth resolution failed, install lookup failed, Slack post failed, …) |
+| runtime [harnesses](../../runtime/harnesses/README.md), [terminals](../../runtime/terminals/README.md), [artifacts](../../runtime/artifacts/README.md), [desktop-host](../../runtime/desktop-host/README.md) | runtime contracts | product-shaped | lifecycle records already exist for harness start (`anyharness.agent.start`); terminals/artifacts have none |
+| [agents](../../product/agents/README.md), [auth](../../product/auth/README.md), [clients](../../product/clients/README.md), [support](../../product/support/README.md), [workflows](../../product/workflows/README.md) | — | **empty** | an Emits section; support in particular must emit `support.report.captured` (report id, session id, release id) — it is the system that ties a human complaint to a session |
+
+Also consumed: **release identity** from
+[delivery](../delivery/README.md) (`release_id` on every log record and
+Sentry release), and the **analytics fence** from
+[analytics](../analytics/README.md) (which typed events may reach PostHog).
+
+## 5. Laws
+
+**L1 — Legibility.** One session, one story. Every signal raised while doing
+work for a session carries that `session_id`; every signal raised for a run
+carries `run_id`; every signal carries `organization_id` and `release_id`.
+The full tuple:
+
+```text
+organization_id · user_id (id only) · session_id · run_id (target) · invocation_id (target)
+cloud_target_id (logical environment) · cloud_sandbox_id (provider — must stay distinct)
+request_id · release_id · surface
+```
+
+These are **bounded correlation identifiers**, never license to copy content.
+Server side the vocabulary is `request_context.py`; it must be *bound* (by the
+request path, the gateway proxy, or the background-job entry) and *admitted*
+(by the closed Sentry catalog) — both, or the id is silently absent. Before
+the minimum-tonight PR the ContextVars for `session_id`, `interaction_id`,
+`command_id`, `worker_id` existed and **nothing bound them, and the catalog
+rejected them** (`test_sentry_transport_privacy.py` pinned `session_id` →
+dropped). This law is target until W1 merges; it is the single most
+important gap in the system.
+
+**L2 — Machine-legible names.** Signal names are stable identifiers in the
+form `<system>.<object>.<verb>` (`run.created`, `session.launch_selection.validated`,
+`anyharness.session.create`, `token.minted`) and never free text; outcomes
+are closed enums (`succeeded / rejected / failed / abandoned`); failures carry
+a bounded code, never an error body. A rename is a seam change.
+
+**L3 — Three surfaces, three jobs.** Structured logs → CloudWatch → Grafana is
+the **alert-evaluation source**. Sentry is the **exception and release
+surface**. Honeycomb is the **trace and SLI surface**. No surface is a
+success condition for a product request; each is best-effort and no-ops when
+unconfigured.
+
+**L4 — Closed catalog, never-suspend scrubbing.** The server builds outbound
+Sentry events from an allowlist, not by deletion; clients, AnyHarness,
+Worker, and Supervisor install explicit before-send scrubbers; child-agent
+stderr never reaches Sentry; anonymous telemetry is the strictest tier.
+Nothing here relaxes for a demo. Full law in [sentry.md](sentry.md) and
+[`specs/OBSERVABILITY.md`](../../../../OBSERVABILITY.md) §Scrubbing.
+
+**L5 — Cross-linked from one id.** Given a `session_id`, a reader can reach
+the Sentry issues for it (tag search), the Honeycomb trace/lifecycle records
+for it (`session_id` column), the CloudWatch log lines for it (JSON field),
+and the product session page. Links are constructed from ids by a fixed
+scheme, never hand-pasted into alerts.
+
+**L6 — Emit on threshold, in code.** Latency and count budgets live in code
+and emit one bounded record when exceeded; alert rules select markers, they
+do not compute business thresholds. (Why: a rule that encodes a threshold is
+invisible to tests.)
+
+**L7 — One capture per failure.** A handled AnyHarness incident returns its
+`urn:proliferate:anyharness:incident:<uuid>` receipt; the client does not
+re-capture it. Propagate *or* capture *or* report-critical — never two.
+
+**L8 — Signals die with their surfaces.** A culled feature's markers, rules,
+SLIs, and typed events are deleted in the same PR (deletion-completeness),
+and display names are grep-gated, not just slugs.
+
+**L9 — The record is the replay.** The runtime session event log
+(`SessionEventEnvelope`, append-only, seq-ordered — sessions Law 10) is the
+canonical replay a fixing agent reads. Observability never builds a second
+transcript; it *links to* the record and *annotates* it with ids.
+
+**L10 — Issue → test.** Every production issue that gets fixed leaves a test
+whose name or docstring cites the Sentry issue id or the event name that
+surfaced it (owner: the testing spec; this system supplies the stable id).
+
+## 6. Emits
+
+- **Alerts** — Grafana rule firings on the six checked-in rules (five
+  production + one SLI), delivered to Slack (`slack-ops-alerts` critical,
+  `slack-eng-triage` warning) and SNS email. Thresholds, severities, and
+  destinations are the **alerting** spec's; this system emits the markers
+  the rules select (`CRITICAL_FAILURE` today).
+- **Sentry issues** with release, environment, surface, and the ID tuple as
+  tags — consumed by the fix loop and the demo fixing agent.
+- **Honeycomb lifecycle records** (`anyharness` dataset, dogfood env) —
+  consumed by the three SLI queries when a key that can execute exists.
+- **Structured log stream** in `/ecs/proliferate-prod` — consumed by Grafana
+  and by anyone reading a session's story.
+- **Exporter health** on `/v1/health` — consumed by desktop support capture.
+- **The per-PR observability delta** — consumed by review.
+
+## 7. Fences
+
+- **Alerting (+ fix loop)** owns rule thresholds, severity policy
+  ("non-noisy": fire only when something is quite broken or something we did
+  not expect to break broke; Slack for prod, phone only for production-down),
+  routing, runbooks, and the issue→test loop. Observability owns the markers
+  and the correlation that make a rule *possible*. The rule JSON files sit in
+  this system's tree until the alerting spec lands; ownership transfers then.
+- **Analytics** owns PostHog, anonymous telemetry, Metabase, and which
+  product events are permitted ([analytics](../analytics/README.md)).
+- **Delivery** owns release construction and the `release_id` identity
+  ([delivery](../delivery/README.md)).
+- **Support** owns capture, S3 custody, redaction, and the Slack receipt
+  ([support](../../product/support/README.md)); observability consumes its
+  report id as a correlation field.
+- **Diagnostics plane** (collector, protocol, client, desktop debug story) is
+  ADR-owned; this spec states the export law it must obey, not its internals.
+- **Each product system owns its Emits.** Observability may *require* a
+  signal (§4) but never writes another system's emitter.
+- **Testing** owns tiers and proof placement; observability supplies ids.
+- **The cull ledger**: the issue tracker and its Grafana receiver are gone
+  (2026-08-25); nothing here re-creates an aggregation queue.
+
+## 8. Code map
+
+```text
+server/proliferate/
+├── integrations/sentry/{__init__,client,privacy}.py   init, capture helpers, closed catalog (TAG_VALIDATORS / EXTRA_VALIDATORS)
+├── middleware/logging.py                              JSON log formatter, release_id, correlation fan-in
+├── middleware/request_context.py                      ContextVars: the ID tuple + binders
+├── middleware/request_telemetry.py                    per-request Sentry tags, path-derived session binding, correlation → Sentry at teardown, user clear
+├── server/event_logging.py                            correlation-carrying structured event helper (misnamed — see gaps)
+└── server/cloud/provisioning_observability.py         provisioning telemetry (environments-owned emitter)
+server/infra/observability/
+├── grafana/production-alerts.json                     OLD workspace g-e532d030d8 (proliferate-ops) — five rules
+├── grafana/production-alerts-rebuild.json             NEW workspace g-48655e6419 (proliferate-ops-rebuild) — same five + wiring
+├── grafana/sli-alerts.json                            sign-in SLI rule (rebuild)
+├── grafana/production-overview-dashboard.json         the one dashboard
+└── honeycomb/product-sli-queries.json                 three SLI query specs (parked)
+scripts/ops/grafana-{alerting,client,rebuild-bootstrap,sli-alerts,metadata-*,receipts,credential-process}.mjs (+ tests)
+anyharness/crates/
+├── anyharness/src/telemetry.rs · proliferate-worker/src/logging.rs · proliferate-supervisor/src/logging.rs   Rust Sentry + scrubbers
+├── anyharness-lib/src/observability/mod.rs            named tracing targets
+├── proliferate-diagnostics-{protocol,client,collector}/   diagnostics plane; collector/src/export/{otlp.rs,policy.rs}
+apps/packages/product-client/src/domain/telemetry/scrub.ts · lib/domain/telemetry/events.ts   client scrubber + typed events
+apps/{desktop,web,mobile}/**/telemetry/**              per-surface Sentry adapters
+fixtures/contracts/rust-observability-v1/              diagnostics golden contract
+specs/OBSERVABILITY.md · specs/anyharness/observability.md · specs/frontend/telemetry.md   standards this spec governs
+guides/operating/production-alerts.md · guides/operating/analytics/sentry.md              operator procedures
+```
+
+## 9. Proof
+
+- `server/tests/unit/test_sentry_transport_privacy.py` — the closed catalog:
+  every tag/extra row, wrong-type rejection, attachment clearing, span-op
+  negatives. **Any change to the ID tuple changes this file.**
+- `server/tests/unit/test_request_telemetry_session_binding.py` — the
+  path-derived `session_id` binding: a `sessions/<uuid>` pair binds, a
+  non-UUID segment does not, a session-less path binds nothing.
+- `tracing_error_reaches_the_sentry_client` in AnyHarness, Worker, and
+  Supervisor — single `sentry-core` instance (the 2026-06 silent-drop
+  incident).
+- `scripts/ops/grafana-alerting.test.mjs`, `grafana-rebuild-bootstrap.test.mjs`,
+  `grafana-sli-alerts.test.mjs`, `grafana-client.inventory.*.test.mjs` —
+  rule allowlist, checksums, redaction of every console line, target lock.
+- `fixtures/contracts/rust-observability-v1/` consumers in Rust, Python, and
+  TS — diagnostics privacy rejections and limits.
+- `apps/packages/product-client/src/domain/telemetry/*.test.ts` — client
+  scrubber and route-id redaction.
+- Offline gates run in CI's repo-shape job: `node scripts/ops/grafana-alerting.mjs check`,
+  `python3 scripts/check_docs.py`.
+- Live acceptance (manual, recorded in the PR): one synthetic
+  `report_critical` in staging → Sentry issue tagged `critical_failure=true`
+  **and** rule `bfrmh7e7x2k8wd` fires to Slack; one proxied session request
+  → a Sentry event carrying `session_id`.
+
+## Current state (what is wired on `main`, 2026-08-25)
+
+```text
+server JSON logs ──► CloudWatch ──► Grafana rules ──► Slack / SNS email     (live; the only path that alerts)
+server + clients + runtime exceptions ──► Sentry                            (live; session_id NOT on server events before W1)
+runtime lifecycle records ──► diagnostics collector ──► Honeycomb (OTLP)    (dogfood only; SLIs never executed — no execute key)
+client typed events ──► PostHog / anonymous telemetry                       (analytics-owned)
+support reports ──► S3 + Slack receipt                                      (support-owned; no session link surfaced)
+```
+
+Jank carried honestly: two Grafana workspaces with the same five rules
+(OLD `proliferate-ops` delivers to Slack; NEW `proliferate-ops-rebuild`
+delivers to SNS email + Slack via `slack-apply`); `cloud/observability.py`
+has zero callers; `event_logging.py` is redaction/correlation logging, not
+event shipping; `workerDegraded` is computed and shown but never alerted;
+the 24K-LOC diagnostics plane is desktop-oriented; Desktop-native has no
+before-send scrubber.
+
+## Minimum tonight
+
+Goal: by tomorrow morning a person can open a broken session and see its
+story across Sentry, logs, and Honeycomb from one id, and every server
+Sentry event raised for a session says which session. Each PR is glue or
+config; none changes product state; none touches
+`server/proliferate/server/cloud/**` (PR-Ab in flight).
+
+| PR | Files | Change | Proof |
+| --- | --- | --- | --- |
+| **W1 — session id survives to Sentry and logs** | `integrations/sentry/privacy.py`, `middleware/request_telemetry.py`, `tests/unit/test_sentry_transport_privacy.py`, `tests/unit/test_request_telemetry_session_binding.py` | Admit the UUID-shaped correlation ids — `session_id`, `interaction_id`, `command_id`, `anyharness_workspace_id` — to `TAG_VALIDATORS` via `canonical_uuid` (non-UUID ids do not survive; `worker_id` and `external_sandbox_id` are not UUID-shaped and stay out). Bind `session_id` from the request path when a `sessions/<uuid>` pair appears (the gateway proxies runtime paths verbatim; the middleware sees them) so logs and Sentry carry it without touching `cloud/`. | Catalog rows flip to `survives=True`; the binding test proves a proxied path binds and a non-UUID segment does not; a request without a session binds nothing. |
+| **W2 — Honeycomb SLIs marked parked with named triggers** | `server/infra/observability/honeycomb/product-sli-queries.json` | Replace the narrative `status` strings with `status: PARKED` + `trigger` per SLI (session-create: "execute-capable key exists"; launch-selection: "first support burden from selection failures"; time-to-first-output: "latency becomes a sales objection"). | JSON validates; `grafana-alerting.mjs check` unaffected. |
+| **W3 — spec + standard aligned** | this README, `engineering/README.md` row | This document; the one-line index description; the standard's depth pointer already resolves. | `check_docs.py` green. |
+
+Blocked tonight by the `cloud/` freeze, queued for the morning after PR-Ab
+merges (each is one file and one test):
+
+- **W4 — `WORKER_DEGRADED` marker.** `cloud/workspaces/service.py::_worker_degraded`
+  logs a bounded marker (`cloud_target_id`, `cloud_sandbox_id`, `session_id`
+  if bound) on the false→true edge; the alerting spec decides whether it
+  becomes a rule. Closes the documented "nothing alerts on it" gap.
+- **W5 — gateway binds the tuple.** `cloud/gateway/**` calls
+  `with_correlation_context(session_id=…, cloud_target_id=…, cloud_sandbox_id=…)`
+  around the proxy, making W1's path heuristic redundant (keep the heuristic
+  as the fallback for non-proxied session routes).
+- **W6 — delete `cloud/observability.py`** (zero callers).
+
+## Target
+
+- **The session story page.** The runs-triage surface renders, for one
+  `session_id`: the checkpointed event log (turns, tool calls, results), the
+  Sentry issues tagged with it, the Honeycomb trace link, the CloudWatch
+  Logs Insights link, and the support reports citing it — five links built
+  from one id by one scheme. This is the page the fixing agent reads.
+- **Honeycomb as the SLI home.** The three SLIs run live in the `anyharness`
+  dataset once an execute-capable key exists; SLIs are defined *there*, and
+  Grafana keeps only *monitors* (infra rules + a burn-rate rule per SLI).
+  New SLIs proposed with the fleet: session-create success, time-to-first-
+  output, tool-call success by provider, run terminal outcome by definition.
+- **Sentry configured well.** `environment` from the closed four-value
+  catalog; `release` = component@version+sha12 on every emitter (already);
+  fingerprinting = exception type + catalog tags (already, server); tag
+  `session_id` on server, client, and runtime events; issue alerts route
+  through the alerting spec, never straight to a person.
+- **The runtime tags sessions.** AnyHarness's Sentry layer maps the
+  `session_id` span field onto the event tag so runtime ERRORs join the same
+  story (today runtime events carry org/user/sandbox/target only).
+- **Fleet markers** at the CP transition writer (`RUN_TERMINAL` with a
+  closed outcome enum, `SPAWN_LIMIT_BREACH`, `BUDGET_ENVELOPE_EXHAUSTED`) —
+  emitters land with the runs/api/billing builds; rules with the alerting
+  spec.
+- **One Grafana workspace.** Consolidate to the rebuild; the old workspace
+  is the rollback until a burn-in period passes, then retired with its JSON.
+
+> [!decision] PABLO DECIDES: canonical Grafana workspace.
+> Options: (a) `proliferate-ops-rebuild` (g-48655e6419) canonical, retire
+> `proliferate-ops` (g-e532d030d8) after a one-week burn-in with Slack
+> delivery re-verified on the rebuild; (b) keep both. Recommendation: (a) —
+> the rebuild has the SLI rule, the dashboard, and the `check/apply/verify`
+> tooling; two workspaces is the confusion tax the as-is analysis named.
+
+> [!decision] PABLO DECIDES: Honeycomb credentials.
+> The three SLIs are parked solely because neither available key can
+> execute queries (`HONEYCOMB_READ_KEY` 401, `HONEYCOMB_CONFIG_KEY` cannot
+> execute). Recommendation: mint one execute-capable key for the `anyharness`
+> dataset this week; the session-create SLI has real data waiting.
+
+> [!decision] PABLO DECIDES: the link scheme for the story.
+> Recommendation: the app session route is the canonical entry
+> (`/sessions/{id}` on the hosted app, once the CP registry exists — until
+> then the workspace deep link); Sentry link = tag search
+> `session_id:{id}` in the `proliferate-server` project; Honeycomb link =
+> saved query with `session_id = {id}`; CloudWatch = Logs Insights with
+> `filter session_id = "{id}"`. Encode the scheme once in a small server
+> helper the triage surface and the alerting runbooks both import.
+
+> [!decision] PABLO DECIDES: admit non-UUID session ids?
+> Runtime session ids are UUID v4 by default, but a client may supply its own
+> id on create (fixtures use `session-01`). Recommendation: no — the catalog
+> admits canonical UUIDs only; custom ids stay local-only. Bounded beats
+> complete for a vendor-bound tag.
+
+## Known gaps
+
+- [ ] L1 is target until W1 merges (admission + path binding); W5 adds
+      gateway binding after the `cloud/` freeze lifts.
+- [ ] `workerDegraded` never alerts (W4).
+- [ ] Runtime Sentry events carry no `session_id` tag (target: span-field →
+      tag mapping in `anyharness/src/telemetry.rs`).
+- [ ] Client Sentry events carry no active-session tag; product-client
+      `scrubTelemetryEvent` would need an allowlisted `session_id` tag
+      (client fork item).
+- [ ] Five specs have no Emits section at all (§4); `support` is the most
+      consequential — a human report cannot be joined to its session.
+- [ ] Two Grafana workspaces (ruling above).
+- [ ] Three Honeycomb SLIs parked (ruling above).
+- [ ] `cloud/observability.py` dead (W6); `event_logging.py` misnamed
+      (rename rides the Wave-2 server regroup, not a behavior PR).
+- [ ] Desktop-native lacks a before-send scrubber (pre-existing; do not
+      widen desktop-native telemetry until closed).
+- [ ] No cost-anomaly signal (E2B, AWS, LLM spend) — belongs to the alerting
+      spec once billing emits `BUDGET_*` markers.

--- a/specs/codebase/systems/engineering/testing/README.md
+++ b/specs/codebase/systems/engineering/testing/README.md
@@ -1,0 +1,332 @@
+# Testing and Linting
+
+Status: describes `main` for the tiers, the checkers, and the ratchets; the
+issue→test loop and the proof-coverage gate are target (※). Grade B — see
+[Known gaps](#known-gaps).
+
+Read before touching: [`specs/TESTING.md`](../../../../TESTING.md) (the per-PR
+standard — this spec does not restate it), [`lints/README.md`](../../../../../lints/README.md)
+(rules as data), `scripts/check_*.py`, `server/scripts/check_mypy_baseline.py`,
+`tests/intent/**`, `tests/release/**`, `fixtures/contracts/**`.
+
+## 1. Purpose
+
+Testing and linting is the cross-cutting system that decides **what a change
+must prove before it merges or ships, and proves it mechanically**. It owns no
+product state. It consumes every product and runtime spec's Proof section
+(the tests that pin that system's laws) and turns them into gates: the four
+tiers of [`TESTING.md`](../../../../TESTING.md), the rule records under
+`lints/`, the ratchets, and the checkers that read them.
+
+Two outcomes it exists for:
+
+- **Legibility of proof.** For any law in any spec, one can name the test that
+  pins it; for any production failure, one can name the test that now
+  prevents it. Both directions are links a machine can follow.
+- **The issue→test loop in one step.** A bug seen in a session replay, a
+  Sentry issue, or a Honeycomb query becomes a pinning test through one
+  convention — where it goes, what it is called, what it links to — so the
+  demo agent that triages production can close the loop without a human
+  deciding structure each time.
+
+Everything else (tiers, worlds, evidence) already exists and is better than
+its reputation; this spec names it, fences it, and adds the two missing
+links.
+
+## 2. Owned state
+
+All of it is data in the repository; nothing lives in a database.
+
+```text
+specs/TESTING.md · specs/TESTING/**            the tier contract and its depth
+specs/TESTING/core-release-scenario-manifest.json
+                                               machine-owned Tier 3/4 guarantee inventory
+lints/<owner>/*.toml                           rule records ([[rule]]), edge baselines ([[edge]])
+lints/<owner>/exceptions.toml                  grandfathered sites, one (path, site) per row
+lints/<owner>/ratchets.toml                    measured shrink-only debt (max_lines)
+server/scripts/mypy_baseline.json              the strict-mypy diagnostic census
+fixtures/contracts/**                          cross-language golden shapes (49 fixtures)
+tests/intent/**                                Tier 2 stack, fakes, specs (24)
+tests/release/**                               Tier 3/4 runner, worlds, scenarios (40), evidence schema
+apps/packages/product-client/qualification/**  browser-engine suites (scroll-physics, workflow-canvas)
+scripts/check_*.py (22) · scripts/lint_records.py
+                                               the enforcement engines
+※ the proof trailer in test files                the issue→test link (section 5, law 6)
+```
+
+Written only through ordinary PRs; the ledgers and baselines have one
+reader each (`lints/README.md` names it per record), and the constitution
+(founder review on net-new exceptions, on ratchet growth, on removing a
+pinning test) governs the writes.
+
+## 3. Public surface
+
+| Surface | What it is | Consumer |
+| --- | --- | --- |
+| The tier contract | [`TESTING.md`](../../../../TESTING.md): which state is real per tier, the gate rule, "deciding where a change's tests go" | every PR author, every spec's Proof section |
+| The gate commands | the deterministic list in TESTING.md's launch-option gate; per plane: `cargo test --workspace`, `cd server && uv run pytest -q`, `pnpm --filter <pkg> test`, `python3 scripts/check_*.py` | CI lanes (owned by the building loop), local pre-push |
+| Rule ids | `AH-*`, `SRV-*`, `FE-*`, `PROD-*` — citable forever, diagnostics generated from the record | PR descriptions, exception rows, prose docs (cite, never restate) |
+| Ratchet API | `--write-baseline` on `check_mypy_baseline.py`; `max_lines` rows in `ratchets.toml` read only by `check_max_lines.py` | the PR that shrinks debt (same PR updates the baseline) |
+| Edge-baseline API | `[[edge]]` rows in `fences.toml`; `--warn` = introduction mode, dropped to enforce | checkers `check_anyharness_fences.py`, `check_frontend_fences.py`, `check_manifests.py` |
+| The Proof-section contract | every system spec's `## 9. Proof` names real test paths (relative links, resolved by `check_docs.py`) | this system's coverage audit (section 4) |
+| ※ The proof trailer | a two-line trailer in a test's docstring/comment: `Spec:` and `Surfaced-by:` (section 5, law 6) | the triage agent, `check_proof_trailers.py`, spec Proof sections |
+| Contract fixtures | `fixtures/contracts/<name>/*.json` — producer asserts it produces, consumers assert they parse | Rust, Python, TypeScript Tier 1 suites |
+| Evidence | Tier 3/4 evidence JSON per scenario cell; ※ Tier E evidence per suite | delivery (release gate), runs/triage (target) |
+
+## 4. Consumes
+
+- **Every product and runtime spec's Proof section** — the input this system
+  gates on. Audit of the 30 specs under `specs/codebase/systems/{product,runtime}/`
+  on 2026-08-25 (paths resolved from the spec's own links):
+
+  | Proof section | Systems |
+  | --- | --- |
+  | Names real tests, all resolve | accounts, agent_auth, billing, chat, environments, github, integration_gateway, model_gateway, organizations, runs-triage, seam, sessions; runtime: desktop-host, harnesses, subagents, terminals, workspaces |
+  | Names tests via glob/brace patterns that `check_docs` cannot resolve (fine for a reader, invisible to a machine) | agent_auth (`route_auth/{…}_tests.rs`), automations (`domains/workflows/*_tests.rs`), onboarding and settings (`test_auth_flow*`), workspaces (`test:file-viewer` script name) |
+  | Names tests that do not exist at the stated path | billing (`BillingSettingsSurface.test.tsx`, `SidebarConsumptionCard.test.tsx`) |
+  | Prose only — zero test paths | api, runs, slack, support; runtime: artifacts |
+  | No Proof section (pre-anatomy docs) | agents (folder index), auth, clients, workflows |
+
+  A spec with an empty Proof section has unpinned laws; it is the testing
+  system's job to make that visible, and the owning system's job to fill it.
+- **Every spec's Emits section** — the event names a `Surfaced-by:` trailer
+  may cite. A system whose Emits is empty cannot be surfaced by production
+  telemetry; the observability spec lists those gaps.
+- **Observability** ([../observability/README.md](../observability/README.md))
+  — Sentry issue ids, the session id, and Honeycomb query names are the
+  identifiers the trailer links to.
+- **Building loop** — the CI lanes that run the gates (`ci.yml`,
+  `server-ci.yml`, `ci-heavy-lanes.yml`) and the merge-train protocol.
+- **Delivery** ([../delivery/README.md](../delivery/README.md)) — the release
+  train that consumes Tier 3/4 evidence and (※) Tier E evidence.
+
+## 5. Laws
+
+1. **The gate rule.** Merge gate = Tiers 1–2 only. No real LLM, no real
+   sandbox at merge; Stripe test mode is the one network exception. Tier 3/4
+   block releases; ※ Tier E (evals) blocks definition releases and pin bumps,
+   never merges. (Enforced by construction: the merge lanes have no provider
+   credentials; `ci-ok`'s drift guard fails when a job is added without a
+   `needs:` entry.)
+2. **Never delete or weaken a test to make CI green.** Removing a pinning
+   test is founder review. Tests die only in the same PR as their surface,
+   listed in that PR's grep-gates (deletion completeness).
+3. **Baselines equal reality exactly.** Edge baselines, exception ledgers,
+   and ratchets may only shrink; a stale row fails the same as a new
+   violation. Violations are named sites, never counts.
+4. **Rules are data.** A mechanical rule exists as a `[[rule]]` record with
+   an `enforced_by` checker that exists; prose cites the id. A ratchet table
+   with no reading checker enforces nothing (`lints/README.md`).
+5. **The postmortem rule.** Any bug caught at Tier 3/4 or in production gets
+   an answer to "which lower tier should have owned this," and that test
+   lands with the fix.
+6. **※ The issue→test loop is one step.** A regression test born from
+   production carries a trailer, in the test's docstring (Python), doc
+   comment (Rust), or leading block comment (TypeScript):
+
+   ```text
+   Spec: specs/codebase/systems/product/sessions/README.md#5-laws
+   Surfaced-by: sentry:PROLIFERATE-SERVER-1K3 · session:ses_01J…
+   ```
+
+   - **Where:** the tier "deciding where a change's tests go" gives (TESTING.md
+     steps 1–6), inside the owning system's test tree — never a central
+     `regressions/` folder (bugs are filed against the owning spec, not the
+     discovering surface).
+   - **Name:** `test_<law-in-words>_<surfaced-id>` — e.g.
+     `test_history_replay_stops_at_first_seq_hole_pro352`; Rust
+     `fn <law>_<id>()`; TypeScript `it("<law> (<id>)")`. The id is the
+     tracker/Sentry/session token, lowercased, non-alphanumerics dropped.
+   - **Links:** `Spec:` is a repo-relative path plus the heading anchor of
+     the law it pins; `Surfaced-by:` is one or more of
+     `sentry:<issue-short-id>`, `session:<session-id>`,
+     `honeycomb:<query-name>`, `PRO-<n>`, `pr:<number>`.
+   - **Checked:** ※ `scripts/check_proof_trailers.py` (rule `PROD-PROOF-001`)
+     validates every trailer it finds: the spec path exists, the anchor
+     exists (same resolver as `check_docs.py`), the `Surfaced-by:` tokens
+     match the grammar. Files without a trailer are not violations; the rule
+     is opt-in per test and becomes a ratchet ("count of trailered tests may
+     only grow") once the demo agent produces them.
+   - **Closes the loop:** the owning spec's Proof section gains the test in
+     the same PR (`check_docs` resolves the link), so a reader of the spec
+     sees the incident that pinned the law.
+7. **Real-LLM tests assert outcomes, not transcripts.**
+8. **No wall-clock day boundaries in assertions.** A test asserts by the
+   event's own timestamp, never by "today" — the 00:00–00:05 UTC flake of
+   `test_usage_timeseries_kind_filter_excludes_other_meter` (fixed #2224) is
+   the incident. ※ lint candidate `SRV-TEST-001`.
+9. **Migrations ship a reversible downgrade or pin their own revision.** An
+   irreversible `NotImplementedError` downgrade breaks the head-to-history
+   downgrade test for everyone after it; the two sanctioned shapes are a
+   structure-recreating downgrade or a test pinned to its own revision.
+   Revision ids are verified unique across all in-flight branches before
+   merge (two forks minted `d7e8f9a0b1c2` on the same day).
+10. **Local parallelism is bounded; CI is authoritative.** Local Postgres at
+    default `max_locks_per_transaction` exhausts under `pytest -n 4` and reds
+    unrelated suites; run `-n 2` or sequential locally, and treat a mass
+    local red as environmental until CI agrees.
+11. **A review gate needs a completed independent refuter.** Adversarial
+    review counts only when at least one fresh-context refuter ran to
+    completion; an inline pass is a fallback, not a pass (session-limit kills
+    on 2026-08-25 produced "reviews" that never finished).
+
+## 6. Emits
+
+- `ci-ok` / `server-ci-ok` rollups (one per workflow; a job outside the
+  `needs:` list fails the drift guard) — consumed by branch protection.
+- Rule diagnostics generated from the record (`<ID>: <rule> — <alternative>`)
+  — consumed by PR authors and the triage agent.
+- Ratchet deltas (`max_lines`, mypy census) in the PR diff — consumed by the
+  founder-review rule.
+- Tier 3/4 evidence JSON per scenario cell (`tests/release/`) — consumed by
+  delivery.
+- ※ The proof-coverage report: per system, laws with/without a pinning test,
+  trailered tests, unresolvable Proof links — consumed by the spec pass and
+  the observability gap list.
+- ※ Tier E evidence per suite `{score, recall, precision, cost}` — consumed by
+  definition releases and the public benchmark projection.
+
+## 7. Fences
+
+- **Building loop** owns `.github/workflows/**`, change detection, the merge
+  train, branch protection, and lane budgets. This spec states what a lane
+  must run and what gates; it never edits a workflow.
+- **Delivery** ([../delivery/README.md](../delivery/README.md)) owns the
+  release train, candidate promotion, and the template/catalog lanes; Tier
+  3/4 are its inputs, not its property.
+- **Observability** ([../observability/README.md](../observability/README.md))
+  owns event names, Sentry configuration, and the session-id correlation
+  key; this spec only links to them.
+- **Product and runtime systems** own their tests: a system's behavior tests
+  live with the system and are named in its Proof section (Organization
+  Standard amendment). This spec audits; it never relocates.
+- **Native tools** (Clippy, tsc, Ruff, rustfmt, mypy config) are outside the
+  rule records today — `lints/native-tools.md` is the ledger.
+- **Support** (`specs/codebase/systems/product/support/`) owns the capture of
+  a user-reported bug; this spec owns what happens once it becomes a test.
+
+## 8. Code map
+
+```text
+specs/
+├── TESTING.md                                   the standard (unchanged by this spec)
+└── TESTING/                                     depth: worlds, contracts, manifest, manual QA
+lints/
+├── README.md · native-tools.md
+├── anyharness/  server/  frontend/  product/    rule records, exceptions, ratchets, edge baselines
+scripts/
+├── lint_records.py                              record loader (id uniqueness, enforced_by exists)
+├── check_docs.py                                link + anchor resolver (Proof links ride on it)
+├── check_manifests.py · check_anyharness_fences.py · check_frontend_fences.py
+│                                                edge-baseline checkers (warn → enforce, PR below)
+├── check_max_lines.py                           the only reader of ratchets.toml
+├── check_*_boundaries.py · check_*_structure.py · check_migration_heads.py · …
+└── ※ check_proof_trailers.py                     PROD-PROOF-001
+server/scripts/
+├── check_mypy_baseline.py · mypy_baseline.json  strict-mypy census, --compare-ref origin/main
+fixtures/contracts/                              49 golden shapes
+tests/intent/                                    Tier 2 (stack/, fakes/, specs/)
+tests/release/                                   Tier 3/4 runner, scenarios, evidence
+apps/packages/product-client/qualification/      scroll-physics, workflow-canvas
+anyharness/tests/                                runtime standalone suite (13 files; CI home: agent-runtime-compat.yml, dispatch)
+```
+
+## 9. Proof
+
+- [scripts/test_check_manifests.py](../../../../../scripts/test_check_manifests.py),
+  [scripts/test_check_anyharness_fences.py](../../../../../scripts/test_check_anyharness_fences.py),
+  [scripts/test_check_frontend_fences.py](../../../../../scripts/test_check_frontend_fences.py)
+  — baseline-equals-reality in both directions.
+- [server/tests/unit/test_mypy_baseline_checker.py](../../../../../server/tests/unit/test_mypy_baseline_checker.py)
+  — census identity, shrink-only, stale-baseline failure.
+- [scripts/test_check_docs.py](../../../../../scripts/test_check_docs.py) —
+  link and anchor resolution the Proof-section contract depends on.
+- [scripts/ci-cd/core-release-scenario-manifest.test.mjs](../../../../../scripts/ci-cd/core-release-scenario-manifest.test.mjs)
+  — manifest ↔ contract parity.
+- `scripts/ci-cd/*.test.mjs` (`ci-cd-config` job) — rollup drift guard and
+  workflow census.
+- ※ `scripts/test_check_proof_trailers.py` — trailer grammar, anchor
+  resolution, opt-in semantics.
+
+## Minimum tonight
+
+Small, cull-grade PRs that make the system legible for tomorrow's triage.
+Each is independently revertible.
+
+1. **Flip the three fence checkers from warn to enforce.** All three already
+   pass in enforce mode on `main` (verified 2026-08-25: manifests,
+   anyharness fences, frontend fences each report "matches reality
+   exactly"). Change: drop `--warn` from three `ci.yml` steps; update the
+   three record-file headers that say "introduced in warn mode." Proof: the
+   repo-shape job green; the three checker unit suites unchanged.
+2. **The proof trailer + its checker.** `scripts/check_proof_trailers.py`
+   with `PROD-PROOF-001` in `lints/product/proof.toml`, unit tests, a
+   repo-shape step. Opt-in (no baseline to build), so it lands green and is
+   ready the moment the triage agent writes its first trailered test.
+3. **Proof-section fixes in the owning specs** (one docs PR): the two
+   billing paths that do not resolve; convert the four glob patterns to
+   explicit links. Prose-only Proof sections (api, runs, slack, support,
+   artifacts) get a `> [!warning] unpinned` callout naming the laws without
+   tests — visible debt, not silent.
+
+Deliberately **not** tonight: change detection, re-gating the demoted lanes,
+`nightly-checks.yml`, Tier E machinery, the mypy identity change. Those are
+the building-loop spec's and this spec's Target.
+
+## Target
+
+- **Proof-coverage gate.** `check_docs.py` (or a sibling) fails a system spec
+  whose `## 9. Proof` has zero resolvable test links, with an
+  exception-ledger row per grandfathered spec that shrinks to zero.
+- **Trailer ratchet.** Count of trailered regression tests may only grow;
+  the triage agent's output is measured by it.
+- **Tier E (evals)** as specified in the raw draft: `tests/evals/` runner as
+  a client of the public `/v1` API, outcome-matching scorers, checked-in
+  baselines, gating definition releases and catalog pin bumps — never
+  merges. Lands after the `/v1` run verbs.
+- **Runtime standalone suite gets a home.** `anyharness/tests` (13 files)
+  runs nowhere automatically; it belongs in the nightly lane the building
+  loop spec designs.
+- **Tier 2 returns to a cadence** (nightly or per-seam-PR) once change
+  detection exists; until then it is dispatch-only by the 2026-08 cull.
+- **Native tools into records**: Clippy/Ruff/tsc/mypy configs get rule ids
+  per `lints/native-tools.md`.
+
+## Decisions
+
+> [!decision] PABLO DECIDES: mypy baseline identity across file moves.
+> `DiagnosticIdentity` is `(path, code, message)`, so a pure move reports the
+> moved diagnostics as growth (failure mode 7; precedents #1656, #2222 were
+> admin-merged with a proven census). Options: (a) keep path identity and
+> ritualize the admin-merge with an exact census in the PR body; (b) add a
+> `--moved old=new` rename map argument the PR supplies; (c) identity on
+> `(module basename, code, message)` — looser, tolerates moves, tolerates
+> duplicates less well. Recommendation: (b) — explicit, auditable, no loss of
+> strictness; the sweep waves (moves without behavior change) will hit this
+> weekly.
+
+> [!decision] PABLO DECIDES: the trailer becomes a ratchet when?
+> Recommendation: the day the triage agent lands its first trailered test —
+> ratchet from 1, never from 0.
+
+> [!decision] PABLO DECIDES: `self-hosting.spec.ts` and the self-host battery.
+> Parked (tagged out of gating, kept) vs culled. Recommendation: parked —
+> self-host is deprioritized, not ruled dead; the smoke stays on `push:main`.
+
+> [!decision] PABLO DECIDES: Tier E gates only releases, never merges —
+> confirm (forced by law 1 as written; changing it is a seam change with the
+> building loop).
+
+## Known gaps
+
+- [ ] The proof trailer and `check_proof_trailers.py` do not exist (PR 2
+      above).
+- [ ] Fence checkers run in warn mode in CI though their baselines are exact
+      (PR 1 above).
+- [ ] Five specs have prose-only Proof sections; four legacy docs have none
+      (section 4 table).
+- [ ] `anyharness/tests` has no automatic CI route.
+- [ ] No Tier 2 lane runs on any cadence since the cull.
+- [ ] Law 8 has no lint; law 9's cross-branch revision-id check is manual.
+- [ ] `server/tests/e2e` (20 files) reaches CI only via hand dispatch of
+      `make test-cloud-e2b`.


### PR DESCRIPTION
Engineering-system spec: **observability** (`specs/codebase/systems/engineering/observability/README.md` rewritten in the 9-section anatomy; `sentry.md` stays as a sub-doc). Drafted by the observability fork, landed by the coordinator. Stacked on the testing spec PR (shares the engineering index).

Encodes the 2026-08-25 rulings: cross-cutting (owns no product state); the **LEGIBILITY law** — one session story keyed by `session_id`, machine-legible names, ids, links; Sentry + Grafana + Honeycomb + support stack cross-linked from one id; non-noisy alerting fenced to the alerting spec.

- Emits audit of all 30 product/runtime specs: **5 empty** (agents, auth, clients, support, workflows), 13 product-shaped — the "invisible in production" table.
- Laws L1–L10 (legibility, machine-legible names, three surfaces, closed catalog, cross-link from one id, emit-on-threshold, one capture, signals die with surfaces, record-is-replay, issue→test).
- **Load-bearing finding:** server ContextVars for `session_id` / `interaction_id` / `command_id` / `worker_id` exist but nothing binds them, and the closed Sentry catalog explicitly rejects them — **no server Sentry event carries a session id today.** W1 (separate stacked PR) fixes admission + path binding without touching `cloud/`.
- Minimum tonight W1–W3; W4–W6 blocked by the `cloud/` freeze (PR-Ab). Target section.
- **PABLO DECIDES** (4): canonical Grafana workspace → recommend rebuild; Honeycomb execute key; link scheme; non-UUID session ids → recommend no.

Observability delta of this PR: none (docs only).
Proposed `specs/README.md` index line: `- [Observability](codebase/systems/engineering/observability/README.md) — the legible session story: one session_id across Sentry, logs → Grafana, Honeycomb.`

Proof: `check_docs.py` green. Inline adversarial review (every path claim verified against `origin/main`); one independent refuter still owed before merge per the building-loop law.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
