### PR TITLE
ci(building-loop): pr-open wrapper, cross-branch migration-id check, parallel-work procedure

### DIFF
--- a/guides/process/pull-requests.md
+++ b/guides/process/pull-requests.md
@@ -114,6 +114,44 @@ Current mechanical classification has three important edge cases:
 - Paths such as `cloud/sdk/**` match more than one area and block readiness
   until a human explicitly selects the correct affected label or labels.
 
+## Working In Parallel
+
+Many branches build from one `main` at once and one coordinator merges them
+serially. The laws are in the
+[Building Loop spec](../../specs/codebase/systems/engineering/building-loop/README.md);
+the procedure is:
+
+1. **Open with labels.** Use `node scripts/ci-cd/pr-open.mjs --release
+   release:<kind> --title "<type>(<scope>): <change>" --body-file <path>`;
+   it derives every `area:*` label from the diff against `origin/main` with
+   the same classifier the metadata check runs and opens the PR non-draft, so
+   the check never races the labels. Ambiguous paths fail and are named; pass
+   `--area` for the human choice.
+2. **No checks means conflict.** GitHub fires no `pull_request` workflow on a
+   PR that cannot merge into `main`. Rebase; do not close/reopen.
+3. **Regenerate, never hand-merge.** On a rebase conflict in
+   `cloud/sdk/src/generated/**`, `anyharness/sdk/src/generated/**`,
+   `uv.lock`, `Cargo.lock`, `lints/*/ratchets.toml`, or
+   `server/scripts/mypy_baseline.json`: take either side, run the generator
+   or measurement, commit its output.
+4. **Mint migration ids.** New alembic revisions use `alembic revision`'s
+   random id (or `python3 -c 'import uuid;print(uuid.uuid4().hex[:12])'`);
+   never type a sequence-shaped id. The coordinator runs
+   `scripts/ci-cd/check-migration-ids-across-branches.sh` before each merge.
+5. **Downgrades recreate structure**, or the head-to-history downgrade test
+   is pinned to the introducing revision — never skipped.
+6. **Workflow edits need the `workflow` token scope.** `gh auth status` must
+   list `workflow` before pushing a branch that adds or modifies
+   `.github/workflows/**` (deletions pass without it).
+7. **Only the owner pushes.** The coordinator asks; the branch owner rebases
+   and pushes. One merge train per repository; budget about ten minutes per
+   merge when generated files are involved.
+8. **Merge, then delete.** Delete a branch only after the merge API reports
+   success. A deleted head is recovered by recreating the ref at the PR's
+   head SHA and reopening.
+9. **Local Postgres is advisory.** Default local settings exhaust locks under
+   `pytest -n 4`; run `-n 2` or sequential. CI is authoritative.
+
 ## After Review
 
 When review changes the outcome or ownership, update the summary, proof,

--- a/scripts/ci-cd/check-migration-ids-across-branches.sh
+++ b/scripts/ci-cd/check-migration-ids-across-branches.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Cross-branch alembic revision-id collision check (building-loop law:
+# "Alembic revision ids are minted, not authored"). SRV-MIGRATE-2 proves
+# uniqueness inside one tree; this proves it across every remote branch, so a
+# coordinator runs it before each merge on the train.
+#
+# Exit 1 if any revision id appears in two or more branches with DIFFERENT
+# file contents (the same migration carried by several branches is fine).
+set -euo pipefail
+
+remote="${1:-origin}"
+git fetch --quiet --prune "$remote"
+
+declare -A id_to_blob   # revision id -> first blob sha seen
+declare -A id_to_ref    # revision id -> branch that introduced that blob
+collisions=0
+
+while IFS= read -r ref; do
+  # Only migration modules; revision id is the module-level `revision = "..."`.
+  while IFS=$'\t' read -r blob path; do
+    [[ -z "$blob" ]] && continue
+    rev="$(git cat-file -p "$blob" | sed -nE 's/^revision(: str)? = "([^"]+)".*/\2/p' | head -1)"
+    [[ -z "$rev" ]] && continue
+    if [[ -n "${id_to_blob[$rev]:-}" && "${id_to_blob[$rev]}" != "$blob" ]]; then
+      echo "COLLISION revision=$rev  ${id_to_ref[$rev]}  vs  $ref ($path)" >&2
+      collisions=$((collisions + 1))
+    else
+      id_to_blob[$rev]="$blob"
+      id_to_ref[$rev]="$ref"
+    fi
+  done < <(git ls-tree -r "$ref" -- server/alembic/versions \
+             | awk '$4 ~ /\.py$/ {print $3 "\t" $4}')
+done < <(git for-each-ref --format='%(refname:short)' "refs/remotes/$remote/")
+
+if (( collisions > 0 )); then
+  echo "$collisions alembic revision id collision(s) across $remote branches." >&2
+  exit 1
+fi
+echo "No alembic revision id collisions across $remote branches."

--- a/scripts/ci-cd/pr-open.mjs
+++ b/scripts/ci-cd/pr-open.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Open a pull request with its metadata already satisfied.
+//
+// Building-loop law: the metadata gate (validate-pr-metadata.mjs) re-derives
+// area labels from the final diff, so a PR opened without them is red until
+// someone applies them by hand — and a red seconds after opening is usually a
+// label race. This wrapper derives the area:* labels from the branch's diff
+// against the base with the same classifier the gate uses
+// (deriveAreaExpectation), validates title + labels locally with the same
+// function CI runs, and only then shells out to `gh pr create` non-draft.
+//
+// Usage:
+//   node scripts/ci-cd/pr-open.mjs --release release:maintenance \
+//     --title "docs(specs): ..." --body-file /path/body.md \
+//     [--area area:sdk ...] [--base main] [--draft] [--dry-run]
+//
+// Ambiguous paths (e.g. cloud/sdk/** → area:cloud | area:sdk) are not guessed:
+// the command fails and names them; pass --area for the human choice.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import {
+  ALLOWED_AREA_LABELS,
+  ALLOWED_RELEASE_LABELS,
+  deriveAreaExpectation,
+  validatePullRequestMetadata,
+} from "./pr-metadata.mjs";
+
+export function parseArgs(argv) {
+  const parsed = {
+    release: "",
+    title: "",
+    bodyFile: "",
+    areas: [],
+    base: "main",
+    draft: false,
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) throw new Error(`Missing value for ${arg}`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "--release":
+        parsed.release = next();
+        break;
+      case "--title":
+        parsed.title = next();
+        break;
+      case "--body-file":
+        parsed.bodyFile = next();
+        break;
+      case "--area":
+        parsed.areas.push(next());
+        break;
+      case "--base":
+        parsed.base = next();
+        break;
+      case "--draft":
+        parsed.draft = true;
+        break;
+      case "--dry-run":
+        parsed.dryRun = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Resolve the label set for a PR from its changed paths plus explicit choices.
+ * Pure: no git, no gh. Returns `{ labels, errors }`; a non-empty `errors`
+ * means the PR must not be opened as-is.
+ */
+export function resolveLabels({ changedFiles, release, explicitAreas = [], title }) {
+  const errors = [];
+  const { required, ambiguous } = deriveAreaExpectation(changedFiles);
+  const areas = new Set([...required, ...explicitAreas]);
+
+  for (const area of explicitAreas) {
+    if (!ALLOWED_AREA_LABELS.includes(area)) errors.push(`Unknown area label: ${area}.`);
+  }
+  if (!ALLOWED_RELEASE_LABELS.includes(release)) {
+    errors.push(
+      `--release must be one of: ${ALLOWED_RELEASE_LABELS.join(", ")} (got ${release || "nothing"}).`,
+    );
+  }
+
+  const unresolved = ambiguous.filter(({ candidates }) => !candidates.some((c) => areas.has(c)));
+  if (unresolved.length > 0) {
+    const detail = unresolved.map(({ path, candidates }) => `${path} -> ${candidates.join(" | ")}`);
+    errors.push(`Ambiguous area for: ${detail.join("; ")}. Pass --area to choose.`);
+  }
+
+  const labels = [release, ...[...areas].sort()].filter(Boolean);
+  errors.push(...validatePullRequestMetadata({ title, labels, changedFiles }));
+  return { labels, errors: [...new Set(errors)] };
+}
+
+function changedFilesAgainst(base) {
+  const merged = execFileSync("git", ["merge-base", `origin/${base}`, "HEAD"], {
+    encoding: "utf8",
+  }).trim();
+  const out = execFileSync("git", ["diff", "--name-only", `${merged}...HEAD`], {
+    encoding: "utf8",
+  });
+  return out.split("\n").filter(Boolean);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.title || !args.bodyFile || !args.release) {
+    console.error("Required: --release, --title, --body-file.");
+    process.exitCode = 2;
+    return;
+  }
+  execFileSync("git", ["fetch", "--quiet", "origin", args.base]);
+  const changedFiles = changedFilesAgainst(args.base);
+  if (changedFiles.length === 0) {
+    console.error(`No changes against origin/${args.base}; nothing to open.`);
+    process.exitCode = 2;
+    return;
+  }
+  const { labels, errors } = resolveLabels({
+    changedFiles,
+    release: args.release,
+    explicitAreas: args.areas,
+    title: args.title,
+  });
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  readFileSync(args.bodyFile, "utf8"); // fail early on a bad path
+  const ghArgs = [
+    "pr",
+    "create",
+    "--base",
+    args.base,
+    "--title",
+    args.title,
+    "--body-file",
+    args.bodyFile,
+    "--label",
+    labels.join(","),
+  ];
+  if (args.draft) ghArgs.push("--draft");
+  console.log(`labels: ${labels.join(", ")} (from ${changedFiles.length} changed path(s))`);
+  if (args.dryRun) {
+    console.log(`dry-run: gh ${ghArgs.join(" ")}`);
+    return;
+  }
+  execFileSync("gh", ghArgs, { stdio: "inherit" });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/ci-cd/pr-open.test.mjs
+++ b/scripts/ci-cd/pr-open.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseArgs, resolveLabels } from "./pr-open.mjs";
+
+const title = "docs(specs): engineering system spec — building loop";
+
+test("derives every required area from the diff and prefixes the release label", () => {
+  const { labels, errors } = resolveLabels({
+    changedFiles: [
+      "specs/codebase/systems/engineering/building-loop/README.md",
+      "scripts/ci-cd/pr-open.mjs",
+    ],
+    release: "release:maintenance",
+    title,
+  });
+  assert.deepEqual(errors, []);
+  assert.deepEqual(labels, ["release:maintenance", "area:docs", "area:release"]);
+});
+
+test("refuses to guess an ambiguous path and names it", () => {
+  const { errors } = resolveLabels({
+    changedFiles: ["cloud/sdk/src/generated/openapi.ts"],
+    release: "release:fix",
+    title: "fix(sdk): regenerate types",
+  });
+  assert.ok(
+    errors.some((e) => e.includes("cloud/sdk/src/generated/openapi.ts -> area:cloud | area:sdk")),
+  );
+});
+
+test("an explicit --area resolves the ambiguity", () => {
+  const { labels, errors } = resolveLabels({
+    changedFiles: ["cloud/sdk/src/generated/openapi.ts"],
+    release: "release:fix",
+    explicitAreas: ["area:sdk"],
+    title: "fix(sdk): regenerate types",
+  });
+  assert.deepEqual(errors, []);
+  assert.deepEqual(labels, ["release:fix", "area:sdk"]);
+});
+
+test("runs the same title/label validation CI runs", () => {
+  const { errors } = resolveLabels({
+    changedFiles: ["specs/README.md"],
+    release: "release:docs",
+    title: "not a conventional title",
+  });
+  assert.ok(errors.some((e) => e.startsWith("PR title must match")));
+});
+
+test("rejects an unknown release label", () => {
+  const { errors } = resolveLabels({
+    changedFiles: ["specs/README.md"],
+    release: "release:bogus",
+    title,
+  });
+  assert.ok(errors.some((e) => e.startsWith("--release must be one of")));
+});
+
+test("parseArgs collects repeated --area and flags", () => {
+  const parsed = parseArgs([
+    "--release",
+    "release:maintenance",
+    "--title",
+    title,
+    "--body-file",
+    "/tmp/body.md",
+    "--area",
+    "area:sdk",
+    "--area",
+    "area:cloud",
+    "--dry-run",
+  ]);
+  assert.equal(parsed.release, "release:maintenance");
+  assert.deepEqual(parsed.areas, ["area:sdk", "area:cloud"]);
+  assert.equal(parsed.dryRun, true);
+  assert.equal(parsed.draft, false);
+  assert.equal(parsed.base, "main");
+});


### PR DESCRIPTION
## Summary

Minimum-tonight items 1–3 of the Building Loop spec (stacked on the spec PR):

- `scripts/ci-cd/pr-open.mjs` — opens a PR with its `area:*` labels derived
  from the diff by the same `deriveAreaExpectation` the metadata gate runs,
  validated locally with `validatePullRequestMetadata`, then `gh pr create`
  non-draft. Ambiguous paths fail and are named; `--area` is the human
  choice. Kills the label race that reddened five of six cull PRs.
- `scripts/ci-cd/check-migration-ids-across-branches.sh` — fails on an
  alembic revision id carried by two remote branches with different content.
  SRV-MIGRATE-2 proves uniqueness in one tree only; two forks collided on
  `d7e8f9a0b1c2` today. Coordinator runs it before each merge.
- `guides/process/pull-requests.md` — "Working In Parallel" procedure: no
  checks = conflict, regenerate-not-hand-merge, minted migration ids,
  `workflow` scope, owner-only pushes, merge-then-delete, local Postgres
  advisory.

Bucket: **system change** (building loop) — no product code; no workflow
files touched.

## Testing

- `node --test scripts/ci-cd/*.test.mjs` (CI's `ci-cd-config` invocation) —
  6 new tests in `pr-open.test.mjs`: derivation, ambiguity refusal, explicit
  `--area`, title validation, release-label validation, arg parsing.
- `bash scripts/ci-cd/check-migration-ids-across-branches.sh` on current
  remotes — output recorded in Verification.
- This PR was opened with `pr-open.mjs` itself.

## Observability

- none

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body,
  and readiness.

## Verification

- (paste `node --test` summary and the migration-id script output)
