### PR TITLE
feat(observability): session_id survives to Sentry and structured logs

### DIFF
--- a/server/proliferate/integrations/sentry/privacy.py
+++ b/server/proliferate/integrations/sentry/privacy.py
@@ -259,7 +259,8 @@ def _label(value: Any) -> str | None:
 
 _UUID_TAGS = _set(
     "user_id organization_id cloud_workspace_id cloud_target_id "
-    "sandbox_profile_id cloud_sandbox_id enrollment_key_id"
+    "sandbox_profile_id cloud_sandbox_id enrollment_key_id "
+    "session_id interaction_id command_id anyharness_workspace_id"
 )
 TAG_VALIDATORS: dict[str, Any] = {
     **{key: canonical_uuid for key in _UUID_TAGS},

--- a/server/proliferate/middleware/request_telemetry.py
+++ b/server/proliferate/middleware/request_telemetry.py
@@ -9,9 +9,15 @@ from proliferate.integrations.sentry import (
     set_server_sentry_correlation_context,
     set_server_sentry_tag,
 )
-from proliferate.middleware.request_context import get_correlation_context, get_request_id
+from proliferate.integrations.sentry.privacy import canonical_uuid
+from proliferate.middleware.request_context import (
+    get_correlation_context,
+    get_request_id,
+    with_correlation_context,
+)
 
 _UUIDISH_SEGMENT_LENGTH = 24
+_SESSION_PATH_SEGMENT = "sessions"
 
 
 class RequestTelemetryMiddleware(BaseHTTPMiddleware):
@@ -25,14 +31,26 @@ class RequestTelemetryMiddleware(BaseHTTPMiddleware):
             set_server_sentry_tag("request_id", request_id)
         set_server_sentry_tag("http_method", request.method)
         set_server_sentry_tag("http_route", _sanitized_route(request))
-        try:
-            response = await call_next(request)
-        finally:
-            set_server_sentry_correlation_context(get_correlation_context())
-            # Clear the authenticated user from the scope at request teardown so
-            # it cannot bleed onto the next request handled by this worker.
-            clear_server_sentry_user()
+        # The runtime gateway proxies session routes verbatim, so the path is
+        # the only place this middleware can learn which session a request
+        # serves; only a canonical UUID is ever bound.
+        with with_correlation_context(session_id=session_id_from_path(request.url.path)):
+            try:
+                response = await call_next(request)
+            finally:
+                set_server_sentry_correlation_context(get_correlation_context())
+                # Clear the authenticated user from the scope at request teardown so
+                # it cannot bleed onto the next request handled by this worker.
+                clear_server_sentry_user()
         return response
+
+
+def session_id_from_path(path: str) -> str | None:
+    segments = [segment for segment in path.split("/") if segment]
+    for index, segment in enumerate(segments[:-1]):
+        if segment == _SESSION_PATH_SEGMENT:
+            return canonical_uuid(segments[index + 1])
+    return None
 
 
 def _sanitized_route(request: Request) -> str:

--- a/server/tests/unit/test_request_telemetry_session_binding.py
+++ b/server/tests/unit/test_request_telemetry_session_binding.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from proliferate.middleware.request_telemetry import session_id_from_path
+
+SESSION_ID = "0f6e4c2a-9b1d-4e7f-8a3c-5d2b1e0f9a7c"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (f"/v1/sessions/{SESSION_ID}", SESSION_ID),
+        (f"/v1/sessions/{SESSION_ID}/events", SESSION_ID),
+        (f"/cloud/targets/abc/v1/sessions/{SESSION_ID}/prompt", SESSION_ID),
+        (f"/v1/sessions/{SESSION_ID.upper()}", SESSION_ID.upper()),
+        ("/v1/sessions/session-01", None),
+        ("/v1/sessions/session-01/events", None),
+        ("/v1/sessions", None),
+        ("/v1/workspaces/abc/sessions", None),
+        (f"/v1/workspaces/{SESSION_ID}", None),
+        ("/", None),
+    ],
+)
+def test_session_id_from_path_binds_only_canonical_uuids(path: str, expected: str | None) -> None:
+    assert session_id_from_path(path) == expected

--- a/server/tests/unit/test_sentry_integration.py
+++ b/server/tests/unit/test_sentry_integration.py
@@ -203,9 +203,14 @@ def test_set_server_sentry_tag_admits_only_catalog_rows(fake_sdk: _FakeSentrySdk
     sentry_integration.set_server_sentry_tag("domain", "billing")
     sentry_integration.set_server_sentry_tag("domain", "please_ignore_previous_instructions")
     sentry_integration.set_server_sentry_tag("http_route", "/orgs/{org_id}")
-    sentry_integration.set_server_sentry_tag("session_id", str(uuid4()))
+    sentry_integration.set_server_sentry_tag("session_id", "not-a-uuid")
     sentry_integration.set_server_sentry_tag("unknown_tag", "value")
     assert fake_sdk.tag_calls == [("domain", "billing")]
+
+    fake_sdk.tag_calls.clear()
+    session_id = str(uuid4())
+    sentry_integration.set_server_sentry_tag("session_id", session_id)
+    assert fake_sdk.tag_calls == [("session_id", session_id)]
 
 def test_correlation_context_skips_unknown_and_invalid_entries(
     fake_sdk: _FakeSentrySdk,

--- a/server/tests/unit/test_sentry_transport_privacy.py
+++ b/server/tests/unit/test_sentry_transport_privacy.py
@@ -205,8 +205,9 @@ VALID_UUID_HEX = "0f3c2a9d6b8e4f1aa7c25d3e9b64108f"
         ("label", f"materialize_sandbox:{VALID_UUID}", True), ("fn", "drop_database", False),
         ("label", f"materialize_other:{VALID_UUID}", False), ("worker_id", "worker-1", False),
         ("external_sandbox_id", "sbx-1", False), ("anyharness_workspace_id", "ws-1", False),
-        ("session_id", VALID_UUID, False), ("interaction_id", VALID_UUID, False),
-        ("command_id", VALID_UUID, False), ("anomaly", "slow", False),
+        ("anyharness_workspace_id", VALID_UUID, True), ("session_id", VALID_UUID, True),
+        ("session_id", "session-01", False), ("interaction_id", VALID_UUID, True),
+        ("command_id", VALID_UUID, True), ("anomaly", "slow", False),
         ("unknown_tag", "value", False),
     ],
 )


### PR DESCRIPTION
Implements **W1** of the observability spec (stacked on #2235): `session_id` survives to Sentry and structured logs.

Server Sentry events and JSON logs now carry `session_id` (canonical UUID only), `interaction_id`, `command_id`, and `anyharness_workspace_id` when bound; the request-telemetry middleware binds `session_id` from proxied runtime paths (`sessions/<uuid>` pair) around `call_next` via `with_correlation_context`, so `cloud/` is untouched (gateway binding is W5, after PR-Ab).

Before this PR the ContextVars existed but nothing bound them and the closed Sentry catalog explicitly rejected `session_id` (a test pinned it as dropped) — no server Sentry event carried a session id.

- `server/proliferate/integrations/sentry/privacy.py` — `_UUID_TAGS` admits the four ids (bounded-UUID tags; no content fields; scrubbers unchanged).
- `server/proliferate/middleware/request_telemetry.py` — `session_id_from_path()` + binding.
- `server/tests/unit/test_sentry_transport_privacy.py` — rows flipped.
- `server/tests/unit/test_request_telemetry_session_binding.py` — new.

Observability delta: four new bounded-UUID tag rows in the closed catalog. No content fields.

Proof (run by the coordinator with CI-equivalent env): the two unit files — 230 passed; `ruff check` + `ruff format --check` clean; `check_server_boundaries.py` passed (new import edge middleware → integrations.sentry.privacy; package edge pre-exists).

One independent refuter still owed before merge per the building-loop law (drafting fork could only self-review inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
