### PR TITLE
ci(repo-shape): enforce fence and manifest checkers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,20 +100,20 @@ jobs:
           python3 -m unittest scripts/test_check_anyharness_boundaries.py
           python3 scripts/check_anyharness_boundaries.py
 
-      - name: Check AnyHarness domain fences (warn mode)
+      - name: Check AnyHarness domain fences
         run: |
           python3 -m unittest scripts/test_check_anyharness_fences.py
-          python3 scripts/check_anyharness_fences.py --warn
+          python3 scripts/check_anyharness_fences.py
 
-      - name: Check frontend directory fences (warn mode)
+      - name: Check frontend directory fences
         run: |
           python3 -m unittest scripts/test_check_frontend_fences.py
-          python3 scripts/check_frontend_fences.py --warn
+          python3 scripts/check_frontend_fences.py
 
-      - name: Check system manifests (warn mode)
+      - name: Check system manifests
         run: |
           python3 -m unittest scripts/test_check_manifests.py
-          python3 scripts/check_manifests.py --warn
+          python3 scripts/check_manifests.py
 
       - name: Check session mutation admission
         run: python3 scripts/check_session_mutation_admission.py

--- a/lints/anyharness/fences.toml
+++ b/lints/anyharness/fences.toml
@@ -2,7 +2,8 @@
 # may reference which (the layer order is boundaries.toml's job; this file owns
 # the domain→domain edge set). Enforced by scripts/check_anyharness_fences.py,
 # introduced in warn mode by the cull-sweep Wave 0
-# (delivery/cull-sweep/delivery-spec-wave0-manifests-and-checkers.md).
+# (delivery/cull-sweep/delivery-spec-wave0-manifests-and-checkers.md) and
+# enforcing since 2026-08-25 (testing system spec, minimum-tonight PR 1).
 #
 # The [[edge]] tables below are AH-FENCE-001's baseline: the measured
 # domain→domain reference graph at fence introduction — permissive by

--- a/lints/frontend/fences.toml
+++ b/lints/frontend/fences.toml
@@ -3,7 +3,8 @@
 # product-client.toml's job; this file owns the directory→directory edge set).
 # Enforced by scripts/check_frontend_fences.py, introduced in warn mode by the
 # cull-sweep Wave 0
-# (delivery/cull-sweep/delivery-spec-wave0-manifests-and-checkers.md).
+# (delivery/cull-sweep/delivery-spec-wave0-manifests-and-checkers.md) and
+# enforcing since 2026-08-25 (testing system spec, minimum-tonight PR 1).
 #
 # The [[edge]] tables below are FE-FENCE-001's baseline: the measured
 # directory→directory import graph at fence introduction — permissive by

--- a/lints/product/manifests.toml
+++ b/lints/product/manifests.toml
@@ -2,7 +2,8 @@
 # owns / public surface / allowed importers / spec link (Organization Standard
 # rule 2). Enforced by scripts/check_manifests.py over the server plane,
 # introduced in warn mode by the cull-sweep Wave 0
-# (delivery/cull-sweep/delivery-spec-wave0-manifests-and-checkers.md). The
+# (delivery/cull-sweep/delivery-spec-wave0-manifests-and-checkers.md), enforcing
+# since 2026-08-25 (testing system spec, minimum-tonight PR 1). The
 # runtime and client planes do not carry manifests yet; their fence checkers
 # (check_anyharness_fences.py, check_frontend_fences.py) hold their
 # boundaries at the folder grain instead.


### PR DESCRIPTION
Minimum-tonight item 1 of the testing spec (stacked on #2234): the three new repo-shape checkers move from **warn** to **enforce**.

- `.github/workflows/ci.yml` — `--warn` dropped from the AnyHarness fence, frontend fence, and system-manifest steps; step names lose "(warn mode)".
- `lints/anyharness/fences.toml`, `lints/frontend/fences.toml`, `lints/product/manifests.toml` — header comment: enforcing since 2026-08-25.

Proof (run by the coordinator on this branch): all three checkers pass in enforce mode — `check_anyharness_fences.py` "fence baseline and ledger match reality exactly", `check_frontend_fences.py` "fence baseline matches reality exactly", `check_manifests.py` "every manifest present, valid, and reality-exact" — and their unit-test modules are OK. Any future drift now fails CI instead of warning; the fence ledgers are the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
