### PR TITLE
feat(support): customer-loop minimum-tonight wiring

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_report.yml
+++ b/.github/ISSUE_TEMPLATE/support_report.yml
@@ -1,0 +1,84 @@
+name: Support Report
+description: Triage a customer support report (opened from the Slack receipt's "File issue" link)
+title: "[Support]: "
+labels: ["support:report", "release:fix"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Pointers only, never content. Do not paste the report body, diagnostics,
+        attachments, prompts, tool output, S3 keys, or presigned URLs here. Read
+        the private bundle through `guides/debugging/support-reports.md`; run the
+        loop through `guides/operating/support-loop.md`.
+  - type: input
+    id: report_id
+    attributes:
+      label: Report ID
+      description: The `support_report` id from the Slack receipt.
+    validations:
+      required: true
+  - type: input
+    id: release
+    attributes:
+      label: Client release
+      description: The `client_release_id` from the receipt (blank if the client did not send one).
+    validations:
+      required: false
+  - type: input
+    id: sessions
+    attributes:
+      label: Session IDs
+      description: Session ids the reporter bound, comma-separated (the join key for replay, Sentry, and Honeycomb).
+    validations:
+      required: false
+  - type: input
+    id: sentry_query
+    attributes:
+      label: Sentry query
+      description: Paste into Sentry search to find every server event tagged with this report.
+      placeholder: support_report_id:<report id>
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary (redacted)
+      description: The receipt's redacted one-line summary, at most. No verbatim report text.
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - bug
+        - feature
+    validations:
+      required: true
+  - type: dropdown
+    id: urgent
+    attributes:
+      label: Urgent
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Owning system
+      description: The system whose law is broken (file against the owner, not the surface the reporter saw). Matches `area:*` labels.
+      options:
+        - not sure yet
+        - desktop
+        - anyharness
+        - sdk
+        - server
+        - cloud
+        - product
+        - website
+        - docs
+        - release
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,8 @@
 
 ## Support and attribution (optional)
 
+<!-- If this PR fixes a `support:report` issue: `Closes #<N> · pinning test: <path>` -->
+
 - [ ] No report, user, or support IDs or private source data appear in this
   PR.
 

--- a/guides/operating/README.md
+++ b/guides/operating/README.md
@@ -20,6 +20,7 @@ under [`../deploying/`](../deploying/).
 | Triage Worker enrollment, heartbeat, or version convergence after checking AnyHarness independently | [Worker enrollment failure](worker-enrollment-failure.md) |
 | Prepare for break-glass access, secret rotation, support-bundle handling, or audit closeout | [Operator security posture](operator-security-posture.md) |
 | Understand, reproduce, or roll back the six production Grafana alert-rule identities | [Production alerts](production-alerts.md) |
+| Run a customer support report from Slack receipt to fixed, tested, and reporter-notified | [Support loop](support-loop.md) |
 | Provision, rotate, revoke, audit, or manually verify the scheduled agent catalog probe | [Catalog Probe](catalog-probe.md) |
 | Add/change gateway models, add a provider, bump the LiteLLM image pin, or rotate gateway provider keys | [Gateway Models](gateway-models.md) |
 | Bump a harness version, review the nightly probe PR, change a harness definition, or roll back a catalog update | [Agent Catalog Update](agent-catalog-update.md) |

--- a/guides/operating/support-loop.md
+++ b/guides/operating/support-loop.md
@@ -1,0 +1,74 @@
+# Support loop
+
+Status: authoritative operator procedure for the
+[customer loop](../../specs/codebase/systems/engineering/customer-loop/README.md).
+The contract lives in that spec; this page is the step-by-step.
+
+```text
+receipt → issue → read the bundle → find the owning spec → fix + pinning test → notify → close
+```
+
+Applies to the hosted deployment. Self-managed deployments that set
+`SUPPORT_SLACK_WEBHOOK_URL` get the same receipt and can run the same loop
+against their own tracker.
+
+## Required tools and permissions
+
+- Slack access to the support receipt channel.
+- `gh` authenticated against `proliferate-ai/proliferate` with issue write.
+- For step 3 only: the private-bundle read permissions described in
+  [`../debugging/support-reports.md`](../debugging/support-reports.md).
+- Sentry access for the relevant projects.
+
+## Procedure
+
+1. **Receipt.** Every completed report posts one Slack receipt. It carries
+   the report id, kind, urgent/notify flags, `Release`, `Sessions`, `Sentry`
+   pairs, a `Sentry query`, and a `File issue` link. If any of those is
+   missing, the source was missing on the report (fields are absent, never
+   blank) — see failure modes below.
+2. **Issue.** Click `File issue`. It opens a prefilled
+   `support_report.yml` issue carrying the label `support:report`. Fill in
+   the owning-system dropdown once you know it; leave the summary redacted.
+   A report is *triaged* only once this issue exists (or the receipt thread
+   records a deliberate decline). Duplicate of an open issue → comment the
+   report id on the existing issue and close the new one as duplicate.
+3. **Read the bundle.** Follow
+   [`../debugging/support-reports.md`](../debugging/support-reports.md).
+   Paste pointers (ids, links) into the issue; never content.
+4. **Find the owning spec.** Locate the broken law under
+   `specs/codebase/systems/`. Set the issue's `area:*` label to the owner,
+   not the surface the reporter saw.
+5. **Fix + pinning test.** The fix PR body's "Support and attribution" line
+   reads `Closes #<N> · pinning test: <path>`. The test's name or docstring
+   carries the issue number (`…_regression_issue_<N>` or `# proof: #<N>`).
+6. **Notify.** If the receipt said `Notify requested: Yes`, email the
+   reporter at `outreach_email ?? account_email` after the fix ships, and
+   comment `notified <date>` on the issue. No automated outreach exists;
+   the product never claims it notified anyone.
+7. **Close.** Close the issue only after step 6 (or when notify was not
+   requested).
+
+## Verification
+
+- `gh issue list --label support:report --state open` is the triage queue.
+- A closed `support:report` issue has a linked merged PR and, when notify
+  was requested, a `notified <date>` comment.
+- Weekly: counts of captured (Slack receipts) / triaged (issues opened) /
+  fixed (closed with PR) / notified.
+
+## Failure modes
+
+| Symptom | First response |
+| --- | --- |
+| Receipt has no `Release` | Client did not send `clientReleaseId` (`support_report_require_client_release` is off). Recover the version from `diagnostics.json` in the bundle. |
+| Receipt has no `Sessions` | Reporter did not bind a session (report from Settings/sidebar, not a chat). Use the `Sentry query` and the request id instead. |
+| No receipt at all | `SUPPORT_SLACK_WEBHOOK_URL` unset or Slack delivery failed — both log at ERROR to Sentry with `support_report_id`. The report is still durable; find it by id. |
+| `File issue` link opens an empty form | Template renamed or field ids changed; the link is built in `server/proliferate/server/support/domain/message.py` and must match `.github/ISSUE_TEMPLATE/support_report.yml`. |
+
+## Secrets policy
+
+Shared rules from [`README.md`](README.md) apply. Additionally: an issue is
+public to everyone with repo access — report ids, session ids, and Sentry
+event ids are allowed; report text, diagnostics, attachments, S3 keys, and
+presigned URLs are not.

--- a/server/proliferate/server/support/domain/message.py
+++ b/server/proliferate/server/support/domain/message.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from urllib.parse import urlencode
+
+# Interim intake for the customer loop (specs/codebase/systems/engineering/
+# customer-loop): a prefilled GitHub issue-form link on the Slack receipt.
+# Field ids must match .github/ISSUE_TEMPLATE/support_report.yml.
+SUPPORT_ISSUE_REPO = "proliferate-ai/proliferate"
+SUPPORT_ISSUE_TEMPLATE = "support_report.yml"
+_RECEIPT_LIST_LIMIT = 5
 
 
 @dataclass(frozen=True)
@@ -72,6 +80,10 @@ def build_support_report_plan(
     context: Mapping[str, object] | None = None,
     correlation: Mapping[str, object] | None = None,
     request_id: str | None = None,
+    client_release_id: str | None = None,
+    session_ids: Sequence[str] | None = None,
+    sentry_events: Sequence[Mapping[str, object]] | None = None,
+    summary: str | None = None,
 ) -> SupportMessagePlan:
     payload_context = context or {}
     payload_correlation = correlation or {}
@@ -105,6 +117,27 @@ def build_support_report_plan(
     _append_list_field(fields, "Cloud targets", payload_correlation.get("cloudTargetIds"))
     _append_context_field(fields, "Request ID", request_id)
 
+    # Customer-loop join keys (pointers only, never content): the receipt must
+    # be one step from triage without a database query.
+    sentry_pairs = _sentry_pairs(sentry_events)
+    _append_context_field(fields, "Release", client_release_id)
+    _append_list_field(fields, "Sessions", list(session_ids or []))
+    _append_list_field(fields, "Sentry", sentry_pairs)
+    fields.append(SupportMessageField("Sentry query", f"support_report_id:{report_id}"))
+    fields.append(
+        SupportMessageField(
+            "File issue",
+            build_support_issue_url(
+                report_id=report_id,
+                client_release_id=client_release_id,
+                session_ids=session_ids,
+                summary=summary,
+                kind=kind,
+                urgent=urgent,
+            ),
+        )
+    )
+
     title = "*:rotating_light: URGENT support report*" if urgent else "*New support report*"
     fallback_prefix = "URGENT support report" if urgent else "Support report"
     return SupportMessagePlan(
@@ -113,6 +146,51 @@ def build_support_report_plan(
         fields=tuple(fields),
         title=title,
     )
+
+
+def build_support_issue_url(
+    *,
+    report_id: str,
+    client_release_id: str | None = None,
+    session_ids: Sequence[str] | None = None,
+    summary: str | None = None,
+    kind: str = "bug",
+    urgent: bool = False,
+) -> str:
+    """Prefilled GitHub issue-form link for the customer loop's interim intake.
+
+    Carries pointers only: ids, the release, and the already-redacted summary.
+    Absent sources are omitted from the query string, never sent blank.
+    """
+
+    params: list[tuple[str, str]] = [
+        ("template", SUPPORT_ISSUE_TEMPLATE),
+        ("title", f"[Support]: {report_id}"),
+        ("report_id", report_id),
+    ]
+    if client_release_id:
+        params.append(("release", client_release_id))
+    if session_ids:
+        shown = session_ids[:_RECEIPT_LIST_LIMIT]
+        params.append(("sessions", ", ".join(str(item) for item in shown)))
+    params.append(("sentry_query", f"support_report_id:{report_id}"))
+    if summary:
+        params.append(("summary", summary))
+    params.append(("kind", "feature" if kind == "feature" else "bug"))
+    params.append(("urgent", "yes" if urgent else "no"))
+    return f"https://github.com/{SUPPORT_ISSUE_REPO}/issues/new?{urlencode(params)}"
+
+
+def _sentry_pairs(sentry_events: Sequence[Mapping[str, object]] | None) -> list[str]:
+    pairs: list[str] = []
+    for item in sentry_events or []:
+        if not isinstance(item, Mapping):
+            continue
+        project = item.get("project")
+        event_id = item.get("eventId")
+        if project and event_id:
+            pairs.append(f"{project}:{event_id}")
+    return pairs
 
 
 def _append_context_field(
@@ -146,7 +224,7 @@ def _append_list_field(
 ) -> None:
     if not isinstance(value, list) or not value:
         return
-    rendered = ", ".join(str(item) for item in value[:5])
-    if len(value) > 5:
-        rendered = f"{rendered}, +{len(value) - 5} more"
+    rendered = ", ".join(str(item) for item in value[:_RECEIPT_LIST_LIMIT])
+    if len(value) > _RECEIPT_LIST_LIMIT:
+        rendered = f"{rendered}, +{len(value) - _RECEIPT_LIST_LIMIT} more"
     fields.append(SupportMessageField(label, rendered))

--- a/server/proliferate/server/support/notifications.py
+++ b/server/proliferate/server/support/notifications.py
@@ -79,6 +79,10 @@ async def notify_support_report(
     urgent: bool = False,
     notify_me: bool = False,
     correlation: dict[str, object] | None,
+    client_release_id: str | None = None,
+    session_ids: list[str] | None = None,
+    sentry_events: list[dict[str, object]] | None = None,
+    summary: str | None = None,
 ) -> bool:
     webhook_url = settings.support_slack_webhook_url.strip()
     if not webhook_url:
@@ -110,6 +114,10 @@ async def notify_support_report(
         context=context,
         correlation=correlation,
         request_id=get_request_id(),
+        client_release_id=client_release_id,
+        session_ids=session_ids,
+        sentry_events=sentry_events,
+        summary=summary,
     )
     blocks = build_mrkdwn_message_blocks(
         title=plan.title,

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -490,6 +490,9 @@ async def _complete_db_backed_report(
         },
     )
     if should_notify:
+        correlation = support_report_correlation_record(completed_report)
+        raw_session_ids = correlation.get("sessionIds")
+        raw_sentry_events = completed_report.telemetry_refs.get("sentryEvents")
         delivered = await notify_support_report(
             sender_email=sender_email,
             sender_display_name=sender_display_name,
@@ -503,7 +506,19 @@ async def _complete_db_backed_report(
             credit_name=completed_report.credit_name,
             urgent=completed_report.urgent,
             notify_me=completed_report.notify_me,
-            correlation=support_report_correlation_record(completed_report),
+            correlation=correlation,
+            client_release_id=completed_report.client_release_id,
+            session_ids=(
+                [str(item) for item in raw_session_ids]
+                if isinstance(raw_session_ids, list)
+                else None
+            ),
+            sentry_events=(
+                [item for item in raw_sentry_events if isinstance(item, dict)]
+                if isinstance(raw_sentry_events, list)
+                else None
+            ),
+            summary=completed_report.tracker_summary,
         )
         if delivered:
             await support_reports.mark_report_slack_notified(db, report_id=completed_report.id)

--- a/server/tests/unit/test_support_message_plan.py
+++ b/server/tests/unit/test_support_message_plan.py
@@ -1,0 +1,112 @@
+"""Customer-loop receipt contract (specs/codebase/systems/engineering/customer-loop, §9).
+
+The Slack receipt must be one step from triage: release id, bound session ids,
+Sentry pairs, the Sentry query, and a prefilled file-an-issue link — and never
+S3 keys, presigned URLs, or the report body. Absent sources are absent, not
+blank.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+from proliferate.server.support.domain.message import (
+    SUPPORT_ISSUE_TEMPLATE,
+    build_support_issue_url,
+    build_support_report_plan,
+)
+
+
+def _plan(**overrides: object):
+    kwargs: dict[str, object] = {
+        "sender_name": "Support Tester",
+        "sender_email": "support@example.com",
+        "message": "Chat froze after the second turn.",
+        "report_id": "report_123",
+        "internal_url": None,
+        "diagnostics_included": True,
+        "attachment_count": 1,
+    }
+    kwargs.update(overrides)
+    return build_support_report_plan(**kwargs)  # type: ignore[arg-type]
+
+
+def test_receipt_carries_join_keys_when_present() -> None:
+    plan = _plan(
+        client_release_id="desktop-1.4.2",
+        session_ids=["sess_a", "sess_b"],
+        sentry_events=[
+            {"project": "server", "eventId": "abc123"},
+            {"project": "desktop", "eventId": "def456"},
+            {"project": "broken"},  # missing eventId → dropped
+        ],
+        summary="Chat froze after the second turn.",
+    )
+    field_map = {field.label: field.value for field in plan.fields}
+
+    assert field_map["Release"] == "desktop-1.4.2"
+    assert field_map["Sessions"] == "sess_a, sess_b"
+    assert field_map["Sentry"] == "server:abc123, desktop:def456"
+    assert field_map["Sentry query"] == "support_report_id:report_123"
+
+    url = urlsplit(field_map["File issue"])
+    assert url.netloc == "github.com"
+    assert url.path == "/proliferate-ai/proliferate/issues/new"
+    query = parse_qs(url.query)
+    assert query["template"] == [SUPPORT_ISSUE_TEMPLATE]
+    assert query["report_id"] == ["report_123"]
+    assert query["release"] == ["desktop-1.4.2"]
+    assert query["sessions"] == ["sess_a, sess_b"]
+    assert query["sentry_query"] == ["support_report_id:report_123"]
+    assert query["summary"] == ["Chat froze after the second turn."]
+    assert query["kind"] == ["bug"]
+    assert query["urgent"] == ["no"]
+
+
+def test_receipt_omits_absent_sources_rather_than_blanking_them() -> None:
+    plan = _plan()
+    labels = [field.label for field in plan.fields]
+
+    assert "Release" not in labels
+    assert "Sessions" not in labels
+    assert "Sentry" not in labels
+    # The query and the issue link only need the report id, so they are always present.
+    assert "Sentry query" in labels
+    query = parse_qs(urlsplit(dict((f.label, f.value) for f in plan.fields)["File issue"]).query)
+    assert "release" not in query
+    assert "sessions" not in query
+    assert "summary" not in query
+
+
+def test_receipt_caps_lists_at_five() -> None:
+    plan = _plan(session_ids=[f"sess_{i}" for i in range(7)])
+    field_map = {field.label: field.value for field in plan.fields}
+
+    assert field_map["Sessions"] == "sess_0, sess_1, sess_2, sess_3, sess_4, +2 more"
+    query = parse_qs(urlsplit(field_map["File issue"]).query)
+    assert query["sessions"] == ["sess_0, sess_1, sess_2, sess_3, sess_4"]
+
+
+def test_issue_url_reflects_kind_and_urgency() -> None:
+    url = build_support_issue_url(report_id="report_9", kind="feature", urgent=True)
+    query = parse_qs(urlsplit(url).query)
+
+    assert query["kind"] == ["feature"]
+    assert query["urgent"] == ["yes"]
+    assert query["title"] == ["[Support]: report_9"]
+
+
+def test_receipt_never_leaks_storage_pointers_or_body() -> None:
+    body = "Full private report body that must stay out of the receipt fields."
+    plan = _plan(
+        message=body,
+        context={"source": "chat", "s3_prefix": "support/report_123"},
+        correlation={"primaryTenantId": "tenant_1"},
+        summary="Redacted summary.",
+    )
+    rendered = " ".join(f"{field.label}={field.value}" for field in plan.fields)
+
+    assert "support/report_123" not in rendered
+    assert "presigned" not in rendered.lower()
+    assert body not in rendered
+    assert "X-Amz" not in rendered

--- a/specs/codebase/systems/product/support/README.md
+++ b/specs/codebase/systems/product/support/README.md
@@ -24,7 +24,12 @@ laws-and-proof detail.
   Slack vendor leaves; the AnyHarness bounded session-window reads;
   capability `notifications` (Slack receipt); the Desktop diagnostics
   collector and export permit (owned by the desktop host seam).
-- **Emits:** Slack completion receipt (alerting projection only);
+- **Emits:** Slack completion receipt (alerting projection only; carries
+  the field set the
+  [customer loop](../../engineering/customer-loop/README.md) requires:
+  report id, kind/urgent/notify, `client_release_id`, bound session ids,
+  Sentry project/event pairs, the `support_report_id:<id>` Sentry query, and
+  a prefilled file-an-issue link);
   `desktop.support_snapshot.prepare|submit` lifecycles; `tracker_summary`
   and `client_release_id` projections on the row.
 - **Fences:** no issue triage, repair, release tracking or outreach (the


### PR DESCRIPTION
## Summary
Stacked on #2231 (customer loop spec). Implements its **Minimum tonight** items 1–4, nothing more:

1. **Receipt enrichment** — `build_support_report_plan` gains `Release`, `Sessions` (first 5), `Sentry` (project:eventId, first 5), `Sentry query` (`support_report_id:<id>`), and `File issue` (prefilled `support_report.yml` issue-form URL via new `build_support_issue_url`). `notify_support_report` / `complete` call site pass `client_release_id`, session ids from the correlation record, `telemetryRefs.sentryEvents`, and the redacted `tracker_summary`. Pointers only; absent sources are omitted, never blank. Runs inside the existing best-effort receipt call — capture is never blocked.
2. **Intake template** — `.github/ISSUE_TEMPLATE/support_report.yml` (labels `support:report` + `release:fix`; field ids match the URL builder).
3. **Runbook** — `guides/operating/support-loop.md` + index row.
4. **PR template** — closeout line comment under "Support and attribution".

Also amends product support's Emits line to name the consumed field set.

## Testing
- Tier 1: new `server/tests/unit/test_support_message_plan.py` (5 tests: join keys present, absent-not-blank, list cap, kind/urgency in URL, no storage pointers/body leak) + existing support domain tests — 24 passed.
- `ruff check/format` clean; mypy ratchet unchanged (384); check_docs (265 files), max-lines, server-boundaries, manifests, design-attribution all green.

## Observability
None — receipt is a projection; no new events or config.

## Founder ops (not in this PR)
- Create the `support:report` label in the repo (`gh label create support:report --color 0E8A16`).
- `gh api` smoke: open the receipt's `File issue` link once and confirm the form is prefilled.

## Support and attribution
- [x] No report, user, or support IDs or private source data appear in this PR.

Do not merge without Pablo's explicit ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)