### PR TITLE
fix(agent-auth): un-gate composer integration health from cloud compute, fence cloudActive, name credit exhaustion

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -158,9 +158,14 @@ function HarnessAuthMethods({
     }
   }
 
-  const gatewayFailureReason = editor.gatewayLocked
-    ? gatewaySubtitle(capabilities, enrollment)
-    : null;
+  // Credits exhaustion is a failure reason even though the gateway is not
+  // "locked": the state renderer is withholding the virtual key, so a launch
+  // will fail closed. Naming it here is the honest surface for AA-3 — the
+  // runtime's own refusal is the generic AGENT_ROUTE_SELECTION_MISSING.
+  const gatewayFailureReason =
+    editor.gatewayLocked || capabilities?.creditsExhausted
+      ? gatewaySubtitle(capabilities, enrollment)
+      : null;
   const cardCount = gatewayCapable ? 3 : 2;
 
   // Flag-ON path (ADR agent-auth rung 6): render the runtime's DERIVED

--- a/apps/packages/product-client/src/copy/settings/agent-auth-copy.ts
+++ b/apps/packages/product-client/src/copy/settings/agent-auth-copy.ts
@@ -10,6 +10,12 @@ export function gatewaySubtitle(
   if (capabilities && !capabilities.gatewayEnabled) {
     return "Unavailable for your account";
   }
+  if (capabilities?.creditsExhausted) {
+    // AA-3: the server withholds the gateway key when the paying subject is
+    // out of LLM credits, and the runtime then refuses launches with a
+    // generic selection-missing error. Name the real reason here.
+    return "Out of LLM credits — gateway launches are paused until credits are added";
+  }
   if (enrollment?.syncStatus === "failed") {
     return enrollment.lastErrorCode
       ? `Enrollment failed (${enrollment.lastErrorCode})`

--- a/apps/packages/product-client/src/hooks/cloud/derived/use-composer-integrations-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/cloud/derived/use-composer-integrations-state.test.tsx
@@ -5,9 +5,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IntegrationHealthItem } from "@proliferate/cloud-sdk/client/integrations";
 import { useComposerIntegrationsState } from "#product/hooks/cloud/derived/use-composer-integrations-state";
 
+// File default is the shipped production posture: cloud COMPUTE disabled,
+// user signed in, control plane reachable. Integration health is a
+// control-plane feature and must stay live in exactly this posture (IG-1,
+// delivery/triage/2026-08-25-integrations-agent-auth.md) — every test below
+// doubles as the regression guard against re-coupling to cloud compute.
 const mocks = vi.hoisted(() => ({
   useIntegrationHealth: vi.fn(),
-  cloudActive: true,
+  authStatus: "authenticated" as string,
+  controlPlaneReachable: true,
 }));
 
 vi.mock("#product/hooks/access/cloud/integrations/use-integration-health", () => ({
@@ -15,7 +21,15 @@ vi.mock("#product/hooks/access/cloud/integrations/use-integration-health", () =>
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
-  useCloudAvailabilityState: () => ({ cloudActive: mocks.cloudActive }),
+  useCloudAvailabilityState: () => ({
+    authStatus: mocks.authStatus,
+    controlPlaneReachable: mocks.controlPlaneReachable,
+    // The shipped launch posture: compute off. The hook must not read these,
+    // but the mock carries them so a re-coupling regression sees the same
+    // values production does and fails the query-enabled assertions below.
+    cloudComputeEnabled: false,
+    cloudActive: false,
+  }),
 }));
 
 vi.mock("#product/hooks/organizations/facade/use-active-organization", () => ({
@@ -50,7 +64,8 @@ function stubHealth(items: IntegrationHealthItem[] | undefined) {
 
 afterEach(() => {
   vi.clearAllMocks();
-  mocks.cloudActive = true;
+  mocks.authStatus = "authenticated";
+  mocks.controlPlaneReachable = true;
 });
 
 describe("useComposerIntegrationsState", () => {
@@ -96,8 +111,32 @@ describe("useComposerIntegrationsState", () => {
     });
   });
 
-  it("disables the query when cloud is inactive", () => {
-    mocks.cloudActive = false;
+  it("keeps the health query live with cloud compute disabled", () => {
+    // The IG-1 regression: gating on cloudActive disabled this query for
+    // every signed-in production user. The file-default mock is exactly that
+    // posture (compute off, authenticated, reachable) — the query must run.
+    stubHealth([]);
+    renderHook(() => useComposerIntegrationsState());
+
+    expect(mocks.useIntegrationHealth).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it("disables the query when signed out", () => {
+    mocks.authStatus = "anonymous";
+    stubHealth([]);
+    renderHook(() => useComposerIntegrationsState());
+
+    expect(mocks.useIntegrationHealth).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("disables the query when the control plane is unreachable", () => {
+    mocks.controlPlaneReachable = false;
     stubHealth([]);
     renderHook(() => useComposerIntegrationsState());
 

--- a/apps/packages/product-client/src/hooks/cloud/derived/use-composer-integrations-state.ts
+++ b/apps/packages/product-client/src/hooks/cloud/derived/use-composer-integrations-state.ts
@@ -31,10 +31,21 @@ const HEALTH_REFRESH_INTERVAL_MS = 5 * 60_000;
  * connect/reconnect actions, which live in the settings pane.
  */
 export function useComposerIntegrationsState(): ComposerIntegrationsModel {
-  const { cloudActive } = useCloudAvailabilityState();
+  const { authStatus, controlPlaneReachable } = useCloudAvailabilityState();
   const { activeOrganizationId } = useActiveOrganization();
+  // Control-plane gate, NOT a cloud-compute gate. Integration health is a
+  // control-plane feature: the settings pane already reaches it through the
+  // `authGate`, and integration_gateway § 5 requires health to roll up into
+  // the composer BEFORE anything runs. The previous `cloudActive =
+  // cloudComputeEnabled && authenticated` coupling folded in the
+  // CLOUD_COMPUTE_TEMPORARILY_DISABLED kill switch, so the composer control
+  // was hidden for every signed-in production user while settings showed
+  // connected/needs-reauth providers. Same decoupling as
+  // `shouldSyncLocalAuthState` (lib/domain/agents/local-auth-state.ts), the
+  // settings `authGate` (render-settings-section.tsx, ADR FM6/Q9), and #2133.
+  const authReady = authStatus === "authenticated" && controlPlaneReachable;
   const healthQuery = useIntegrationHealth(activeOrganizationId, {
-    enabled: cloudActive,
+    enabled: authReady,
     refetchInterval: HEALTH_REFRESH_INTERVAL_MS,
     refetchOnWindowFocus: true,
   });

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -2605,6 +2605,11 @@ export interface components {
             publicBaseUrl: string | null;
             /** Enrollmentstatus */
             enrollmentStatus: string;
+            /**
+             * Creditsexhausted
+             * @default false
+             */
+            creditsExhausted: boolean;
             /** Verifications */
             verifications?: components["schemas"]["AgentGatewayVerificationVerdict"][];
         };

--- a/lints/frontend/fences.toml
+++ b/lints/frontend/fences.toml
@@ -344,3 +344,148 @@ to = "host"
 [[edge]]
 from = "test"
 to = "lib"
+
+# ---------------------------------------------------------------------------
+# FE-FENCE-002: cloud-compute gate consumption allowlist.
+# ---------------------------------------------------------------------------
+
+[[rule]]
+id = "FE-FENCE-002"
+title = "cloud-compute gate tokens are consumed only by declared consumers"
+owner = "frontend"
+status = "law"
+enforced_by = "scripts/check_frontend_fences.py"
+mode = "lint"
+scope = "apps/packages/product-client/src/**"
+
+rule = """A non-test product-client source file may reference `cloudActive` or
+`cloudComputeEnabled` (in code — comments and string literals do not count)
+only if it is declared in the [[cloud_gate_consumer]] baseline below; the
+baseline may only shrink. Test files are exempt (they mock the gate)."""
+alternative = """A control-plane feature (auth, integrations, settings panes,
+anything that talks to the server but not to a sandbox) must gate on
+`authStatus === "authenticated" && controlPlaneReachable` from
+`useCloudAvailabilityState()` instead — the decoupling `shouldSyncLocalAuthState`,
+the settings `authGate`, #2133, and IG-1 all applied. Only a genuinely
+compute-gated surface (cloud workspaces, repo environments, billing) may join
+the baseline, and joining it is a constitution amendment: flag it in the PR
+description and stop for founder review."""
+why = """`cloudActive = cloudComputeEnabled && authenticated` folds in the
+CLOUD_COMPUTE_TEMPORARILY_DISABLED launch kill switch, so it is false for every
+signed-in production user. A control-plane feature that gates on it is dead in
+production. That regression shipped four separate times (shouldSyncLocalAuthState,
+the settings authGate, #2133, IG-1 — see
+delivery/triage/2026-08-25-integrations-agent-auth.md); this baseline makes the
+fifth a visible amendment instead of a silent outage."""
+
+[rule.example]
+bad = """`const { cloudActive } = useCloudAvailabilityState();` gating an
+integrations or auth surface in a file outside the baseline"""
+good = """`const authReady = authStatus === "authenticated" && controlPlaneReachable;`
+for control-plane features; `cloudActive` only in a declared compute-gated consumer"""
+
+# ---------------------------------------------------------------------------
+# FE-FENCE-002 consumer baseline: the measured non-test files whose CODE
+# references a gate token at rule introduction (2026-08-25, IG-1 fixed in the
+# same PR). Permissive by construction, shrink-only; the checker fails on an
+# undeclared consumer AND on a stale row.
+# ---------------------------------------------------------------------------
+
+[[cloud_gate_consumer]]
+path = "components/cloud/CloudGuard.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/feedback/HarnessUpdateToastPresenter.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/panes/BillingPane.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/panes/repo/RepoActionsPane.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/panes/repo/RepoCloudGate.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/panes/repo/RepoConfigurePane.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/panes/repo/RepoEnvironmentPane.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/panes/repo/RepoScopeStates.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/screen/SettingsScreen.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/settings/screen/render-settings-section.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/workspace/repo-setup/CloudRepoActionDialogHost.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/workspace/shell/sidebar/MainSidebar.tsx"
+
+[[cloud_gate_consumer]]
+path = "components/workspace/shell/sidebar/main-sidebar-test-harness.tsx"
+
+[[cloud_gate_consumer]]
+path = "hooks/cloud/derived/use-cloud-availability-state.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/cloud/facade/use-cloud-billing.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/home/derived/use-home-next-repository-selection.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/home/derived/use-home-next-state.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/home/facade/use-home-screen.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/settings/derived/use-settings-repositories.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/settings/workflows/use-cloud-repo-environment-editor.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/workspaces/cache/use-workspace-collections-cache.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/workspaces/cache/use-workspace-selection-cache.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/workspaces/cache/use-workspaces.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/workspaces/derived/use-sidebar-shortcut-targets.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/workspaces/derived/use-workspace-sidebar-state.ts"
+
+[[cloud_gate_consumer]]
+path = "hooks/workspaces/workflows/use-sidebar-repo-availability-actions.ts"
+
+[[cloud_gate_consumer]]
+path = "lib/domain/capabilities/app-capabilities.ts"
+
+[[cloud_gate_consumer]]
+path = "lib/domain/workspaces/cloud/cloud-workspace-creation.ts"
+
+[[cloud_gate_consumer]]
+path = "lib/domain/workspaces/cloud/workspace-availability-commands.ts"
+
+[[cloud_gate_consumer]]
+path = "lib/domain/workspaces/sidebar/sidebar-groups.ts"
+
+[[cloud_gate_consumer]]
+path = "lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts"
+
+[[cloud_gate_consumer]]
+path = "lib/domain/workspaces/sidebar/sidebar-workspace-items.ts"
+
+[[cloud_gate_consumer]]
+path = "pages/WorkspacesPage.tsx"

--- a/scripts/check_frontend_fences.py
+++ b/scripts/check_frontend_fences.py
@@ -12,6 +12,15 @@ of `apps/packages/product-client/src` may import which. One record under
   construction, shrink-only afterwards. A new edge and a stale baseline row
   are both failures, so the baseline always equals reality exactly.
 
+- FE-FENCE-002: the cloud-compute gate tokens (`cloudActive`,
+  `cloudComputeEnabled`) may appear only in non-test source files declared in
+  the `[[cloud_gate_consumer]]` baseline of the same record file. The same
+  regression — a control-plane feature wrongly coupled to the cloud-compute
+  kill switch — was fixed four separate times (`shouldSyncLocalAuthState`,
+  the settings `authGate`, #2133, IG-1); this rule makes the fifth attempt a
+  visible amendment instead of a silent production outage. Comments and
+  string literals do not count; test files are exempt (they mock the gate).
+
 `--warn` reports everything and exits 0: the checker's non-blocking
 introduction mode, dropped when the baseline is ready to enforce.
 """
@@ -20,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import posixpath
+import re
 import sys
 import tomllib
 from dataclasses import dataclass
@@ -32,12 +42,21 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import lint_records  # noqa: E402  (path shim must precede the import)
-from scripts.frontend_imports import collect_module_specifiers  # noqa: E402
+from scripts.frontend_imports import (  # noqa: E402
+    collect_module_specifiers,
+    tokenize_typescript,
+)
 
 CHECKER = "scripts/check_frontend_fences.py"
 PC_SRC_RELATIVE = ("apps", "packages", "product-client", "src")
 FENCES_RECORD_RELATIVE = ("lints", "frontend", "fences.toml")
 EDGE_RULE = "FE-FENCE-001"
+GATE_RULE = "FE-FENCE-002"
+# The cloud-compute gate tokens. `cloudActive = cloudComputeEnabled &&
+# authenticated` folds in the CLOUD_COMPUTE_TEMPORARILY_DISABLED kill switch,
+# so a control-plane feature that consumes either token is dead for every
+# production user while the switch is on.
+GATE_TOKEN_RE = re.compile(r"\b(cloudActive|cloudComputeEnabled)\b")
 ALIAS_PREFIX = "#product/"
 SELF_PACKAGE_PREFIX = "@proliferate/product-client/"
 INTERNAL_SUBPATH = "internal/"
@@ -64,11 +83,12 @@ class Violation:
     lineno: int
     site: str
     detail: str
+    rule_id: str = EDGE_RULE
 
     def format(self) -> str:
         """The record-generated diagnostic: rule, alternative, record path."""
         return lint_records.render_diagnostic(
-            RULES.rule(EDGE_RULE),
+            RULES.rule(self.rule_id),
             f"{self.relative_path}:{self.lineno}",
             self.detail,
         )
@@ -89,6 +109,50 @@ def load_edge_baseline(root: Path) -> set[tuple[str, str]]:
             )
         edges.add((entry["from"], entry["to"]))
     return edges
+
+
+def load_cloud_gate_baseline(root: Path) -> set[str]:
+    """The declared cloud-gate consumer set (paths relative to src).
+
+    Tolerates a missing record file (the fabricated trees in unit tests) —
+    the edge loader on the same file already fails a real run loudly.
+    """
+    path = root.joinpath(*FENCES_RECORD_RELATIVE)
+    if not path.is_file():
+        return set()
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    consumers: set[str] = set()
+    for entry in data.get("cloud_gate_consumer", []):
+        if "path" not in entry:
+            raise SystemExit(
+                f"{CHECKER}: {path}: [[cloud_gate_consumer]] entry missing path: {entry}"
+            )
+        consumers.add(entry["path"])
+    return consumers
+
+
+def is_test_relative_path(src_relative: str) -> bool:
+    """Test files may mock the gate tokens freely; the fence governs
+    shipped source only."""
+    parts = src_relative.split("/")
+    name = parts[-1]
+    return (
+        "__tests__" in parts
+        or "test" in parts
+        or ".test." in name
+        or ".stories." in name
+    )
+
+
+def code_only_lines(text: str, *, jsx: bool) -> list[str]:
+    """The file's lines with comments and string literals blanked, so a
+    token mention in a doc comment or a log key never counts as consumption."""
+    masked = ["\n" if char == "\n" else " " for char in text]
+    for token in tokenize_typescript(text, jsx=jsx):
+        if token.kind == "string":
+            continue
+        masked[token.start : token.end] = text[token.start : token.end]
+    return "".join(masked).splitlines()
 
 
 def resolve_target_top(
@@ -125,19 +189,24 @@ class ScanResult:
     violations: list[Violation]
     stale_edges: set[tuple[str, str]]
     edges_seen: set[tuple[str, str]]
+    stale_gate_consumers: set[str]
+    gate_consumers_seen: set[str]
 
 
 def collect_violations(
     root: Path | None = None,
     baseline: set[tuple[str, str]] | None = None,
+    gate_baseline: set[str] | None = None,
 ) -> ScanResult:
-    """Scan product-client against the directory-edge baseline."""
+    """Scan product-client against the directory-edge and cloud-gate baselines."""
     base = Path(root).resolve() if root is not None else REPO_ROOT
     src = base.joinpath(*PC_SRC_RELATIVE)
     if not src.is_dir():
         raise SystemExit(f"{CHECKER}: missing package tree {src}")
     if baseline is None:
         baseline = load_edge_baseline(base)
+    if gate_baseline is None:
+        gate_baseline = load_cloud_gate_baseline(base)
     tops = {
         entry.name
         for entry in src.iterdir()
@@ -145,12 +214,14 @@ def collect_violations(
     }
     violations: list[Violation] = []
     edges_seen: set[tuple[str, str]] = set()
+    gate_consumers_seen: set[str] = set()
 
     for top in sorted(tops):
         for path in sorted((src / top).rglob("*")):
             if path.suffix not in SOURCE_SUFFIXES or not path.is_file():
                 continue
             relative = path.relative_to(base).as_posix()
+            src_relative = path.relative_to(src).as_posix()
             source_dir = PurePosixPath(path.relative_to(src).parent.as_posix())
             text = path.read_text(encoding="utf-8")
             for statement in collect_module_specifiers(path, text):
@@ -169,7 +240,37 @@ def collect_violations(
                         )
                     )
 
-    return ScanResult(violations, baseline - edges_seen, edges_seen)
+            if is_test_relative_path(src_relative):
+                continue
+            file_hits = False
+            for lineno, line in enumerate(
+                code_only_lines(text, jsx=path.suffix == ".tsx"), start=1
+            ):
+                match = GATE_TOKEN_RE.search(line)
+                if match is None:
+                    continue
+                if not file_hits and src_relative not in gate_baseline:
+                    violations.append(
+                        Violation(
+                            relative,
+                            lineno,
+                            match.group(0),
+                            f"undeclared cloud-gate consumer: {match.group(0)!r} "
+                            f"outside the [[cloud_gate_consumer]] baseline",
+                            rule_id=GATE_RULE,
+                        )
+                    )
+                file_hits = True
+            if file_hits:
+                gate_consumers_seen.add(src_relative)
+
+    return ScanResult(
+        violations,
+        baseline - edges_seen,
+        edges_seen,
+        gate_baseline - gate_consumers_seen,
+        gate_consumers_seen,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -187,6 +288,10 @@ def main(argv: list[str] | None = None) -> int:
         f"lints/frontend/fences.toml: stale [[edge]] {source} -> {target} — "
         f"no import crosses that directory edge any more; remove the row"
         for (source, target) in sorted(result.stale_edges)
+    ] + [
+        f"lints/frontend/fences.toml: stale [[cloud_gate_consumer]] {path} — "
+        f"the file no longer consumes a cloud-gate token; remove the row"
+        for path in sorted(result.stale_gate_consumers)
     ]
 
     problems = len(violations) + len(stale_edge_reports)

--- a/scripts/test_check_frontend_fences.py
+++ b/scripts/test_check_frontend_fences.py
@@ -16,6 +16,7 @@ class FenceTestCase(unittest.TestCase):
         self,
         files: dict[str, str],
         baseline: set[tuple[str, str]],
+        gate_baseline: set[str] | None = None,
     ) -> check_module.ScanResult:
         """`files` keys are paths relative to product-client/src."""
         with tempfile.TemporaryDirectory() as directory:
@@ -24,7 +25,11 @@ class FenceTestCase(unittest.TestCase):
                 path = root / SRC_RELATIVE / name
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(content, encoding="utf-8")
-            return check_module.collect_violations(root=root, baseline=baseline)
+            return check_module.collect_violations(
+                root=root,
+                baseline=baseline,
+                gate_baseline=gate_baseline if gate_baseline is not None else set(),
+            )
 
 
 class EdgeBaselineTest(FenceTestCase):
@@ -168,6 +173,89 @@ class SelfPackageExportTest(FenceTestCase):
         )
         self.assertEqual(result.edges_seen, {("hooks", "stores")})
         self.assertEqual(result.violations, [])
+
+
+class CloudGateBaselineTest(FenceTestCase):
+    def test_undeclared_gate_consumer_fails(self) -> None:
+        result = self.scan(
+            {
+                "hooks/use-thing.ts": (
+                    "export function useThing(cloudActive: boolean) {\n"
+                    "  return cloudActive;\n"
+                    "}\n"
+                ),
+            },
+            baseline=set(),
+        )
+        gate = [v for v in result.violations if v.rule_id == check_module.GATE_RULE]
+        self.assertEqual(len(gate), 1)
+        self.assertEqual(
+            gate[0].relative_path, f"{SRC_RELATIVE}/hooks/use-thing.ts"
+        )
+        self.assertIn("undeclared cloud-gate consumer", gate[0].detail)
+        self.assertIn("record:", gate[0].format())
+
+    def test_declared_gate_consumer_is_clean(self) -> None:
+        result = self.scan(
+            {
+                "hooks/use-thing.ts": "export const x = cloudComputeEnabled;\n",
+            },
+            baseline=set(),
+            gate_baseline={"hooks/use-thing.ts"},
+        )
+        self.assertEqual(result.violations, [])
+        self.assertEqual(result.gate_consumers_seen, {"hooks/use-thing.ts"})
+        self.assertEqual(result.stale_gate_consumers, set())
+
+    def test_comment_and_string_mentions_do_not_count(self) -> None:
+        result = self.scan(
+            {
+                "hooks/use-thing.ts": (
+                    "// the old cloudActive coupling was removed here\n"
+                    "/* cloudComputeEnabled folds in the kill switch */\n"
+                    'const key = "cloudActive";\n'
+                    "export const x = key;\n"
+                ),
+            },
+            baseline=set(),
+        )
+        self.assertEqual(result.violations, [])
+        self.assertEqual(result.gate_consumers_seen, set())
+
+    def test_test_files_are_exempt(self) -> None:
+        result = self.scan(
+            {
+                "hooks/use-thing.test.ts": "export const x = cloudActive;\n",
+                "hooks/__tests__/fixture.ts": "export const y = cloudActive;\n",
+            },
+            baseline=set(),
+        )
+        self.assertEqual(result.violations, [])
+        self.assertEqual(result.gate_consumers_seen, set())
+
+    def test_stale_gate_row_is_reported(self) -> None:
+        result = self.scan(
+            {
+                "hooks/use-thing.ts": "export const x = 1;\n",
+            },
+            baseline=set(),
+            gate_baseline={"hooks/use-thing.ts"},
+        )
+        self.assertEqual(result.violations, [])
+        self.assertEqual(result.stale_gate_consumers, {"hooks/use-thing.ts"})
+
+    def test_one_violation_per_undeclared_file(self) -> None:
+        result = self.scan(
+            {
+                "hooks/use-thing.ts": (
+                    "export const a = cloudActive;\n"
+                    "export const b = cloudComputeEnabled;\n"
+                ),
+            },
+            baseline=set(),
+        )
+        gate = [v for v in result.violations if v.rule_id == check_module.GATE_RULE]
+        self.assertEqual(len(gate), 1)
 
 
 class WarnModeTest(unittest.TestCase):

--- a/server/proliferate/server/agent_auth/api.py
+++ b/server/proliferate/server/agent_auth/api.py
@@ -261,7 +261,12 @@ async def get_agent_gateway_capabilities_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
 ) -> AgentGatewayCapabilitiesResponse:
-    gateway_enabled, public_base_url, enrollment_status = await service.get_capabilities(
+    (
+        gateway_enabled,
+        public_base_url,
+        enrollment_status,
+        credits_exhausted,
+    ) = await service.get_capabilities(
         db,
         user_id=user.id,
     )
@@ -270,6 +275,7 @@ async def get_agent_gateway_capabilities_endpoint(
         gateway_enabled=gateway_enabled,
         public_base_url=public_base_url,
         enrollment_status=enrollment_status,
+        credits_exhausted=credits_exhausted,
         verifications=[verification_verdict_payload(record) for record in verdicts],
     )
 

--- a/server/proliferate/server/agent_auth/models.py
+++ b/server/proliferate/server/agent_auth/models.py
@@ -223,6 +223,12 @@ class AgentGatewayCapabilitiesResponse(AgentGatewayBaseModel):
     gateway_enabled: bool = Field(alias="gatewayEnabled")
     public_base_url: str | None = Field(alias="publicBaseUrl")
     enrollment_status: str = Field(alias="enrollmentStatus")
+    # Additive AA-3 surface: True exactly when the state renderer is
+    # withholding gateway keys for this user's paying subject (credit
+    # exhausted or unfunded), so the client can say "out of credits" instead
+    # of the runtime's generic selection-missing refusal. Defaulted so older
+    # callers constructing the model are unaffected.
+    credits_exhausted: bool = Field(default=False, alias="creditsExhausted")
     # Additive FR-3 surface: per-harness gateway-enablement verdicts for the
     # governing enrollment. Empty until the verification loop records one.
     verifications: list[AgentGatewayVerificationVerdict] = Field(

--- a/server/proliferate/server/agent_auth/service.py
+++ b/server/proliferate/server/agent_auth/service.py
@@ -40,7 +40,10 @@ from proliferate.db.store.billing import list_entitlements
 from proliferate.db.store.billing_subscriptions import list_subscriptions
 from proliferate.db.store.organizations import list_organizations_for_user
 from proliferate.lib.infra.time.wall_clock import utcnow
-from proliferate.server.agent_auth.budget import get_gateway_enrollment_for_user
+from proliferate.server.agent_auth.budget import (
+    get_gateway_enrollment_for_user,
+    is_gateway_budget_available,
+)
 from proliferate.server.agent_auth.selection_rules import (
     SelectionRuleError,
     validate_auth_selection_set,
@@ -497,20 +500,29 @@ async def get_capabilities(
     db: AsyncSession,
     *,
     user_id: UUID,
-) -> tuple[bool, str | None, str]:
-    """Return (gateway_enabled, public_base_url, enrollment_status).
+) -> tuple[bool, str | None, str, bool]:
+    """Return (gateway_enabled, public_base_url, enrollment_status, credits_exhausted).
 
     Reports the status of the enrollment that actually governs this user's
     gateway sessions (``get_gateway_enrollment_for_user``). Reading the
     personal enrollment unconditionally would show "synced" to a user whose
     governing org enrollment is still pending (or the reverse), so the UI's
     readiness signal and the key the renderer hands out would disagree.
+
+    ``credits_exhausted`` is the negation of the exact predicate the state
+    renderer withholds gateway keys on (:func:`is_gateway_budget_available`),
+    so the settings surface names the true reason for a refused gateway
+    launch instead of the runtime's generic
+    ``AGENT_ROUTE_SELECTION_MISSING`` (AA-3,
+    delivery/triage/2026-08-25-integrations-agent-auth.md). Sharing the
+    predicate is the point: the flag and the withheld key can never disagree.
     """
     enrollment = await get_gateway_enrollment_for_user(db, user_id)
     return (
         settings.agent_gateway_enabled,
         settings.agent_gateway_litellm_public_base_url or None,
         enrollment.sync_status if enrollment is not None else _ENROLLMENT_STATUS_NONE,
+        not await is_gateway_budget_available(db, user_id),
     )
 
 

--- a/server/proliferate/server/agent_auth/service.py
+++ b/server/proliferate/server/agent_auth/service.py
@@ -40,10 +40,8 @@ from proliferate.db.store.billing import list_entitlements
 from proliferate.db.store.billing_subscriptions import list_subscriptions
 from proliferate.db.store.organizations import list_organizations_for_user
 from proliferate.lib.infra.time.wall_clock import utcnow
-from proliferate.server.agent_auth.budget import (
-    get_gateway_enrollment_for_user,
-    is_gateway_budget_available,
-)
+from proliferate.server.agent_auth import budget
+from proliferate.server.agent_auth.budget import get_gateway_enrollment_for_user
 from proliferate.server.agent_auth.selection_rules import (
     SelectionRuleError,
     validate_auth_selection_set,
@@ -503,26 +501,16 @@ async def get_capabilities(
 ) -> tuple[bool, str | None, str, bool]:
     """Return (gateway_enabled, public_base_url, enrollment_status, credits_exhausted).
 
-    Reports the status of the enrollment that actually governs this user's
-    gateway sessions (``get_gateway_enrollment_for_user``). Reading the
-    personal enrollment unconditionally would show "synced" to a user whose
-    governing org enrollment is still pending (or the reverse), so the UI's
-    readiness signal and the key the renderer hands out would disagree.
-
-    ``credits_exhausted`` is the negation of the exact predicate the state
-    renderer withholds gateway keys on (:func:`is_gateway_budget_available`),
-    so the settings surface names the true reason for a refused gateway
-    launch instead of the runtime's generic
-    ``AGENT_ROUTE_SELECTION_MISSING`` (AA-3,
-    delivery/triage/2026-08-25-integrations-agent-auth.md). Sharing the
-    predicate is the point: the flag and the withheld key can never disagree.
+    Status comes from the GOVERNING (never personal) enrollment, and
+    ``credits_exhausted`` negates the renderer's key-withholding predicate
+    (``is_gateway_budget_available``) — UI and render never disagree (AA-3).
     """
     enrollment = await get_gateway_enrollment_for_user(db, user_id)
     return (
         settings.agent_gateway_enabled,
         settings.agent_gateway_litellm_public_base_url or None,
         enrollment.sync_status if enrollment is not None else _ENROLLMENT_STATUS_NONE,
-        not await is_gateway_budget_available(db, user_id),
+        not await budget.is_gateway_budget_available(db, user_id),
     )
 
 

--- a/server/tests/integration/test_agent_auth_org_member_gateway.py
+++ b/server/tests/integration/test_agent_auth_org_member_gateway.py
@@ -409,6 +409,40 @@ async def test_org_member_state_render_uses_org_enrollment_key(
 
 
 @pytest.mark.asyncio
+async def test_capabilities_reports_credits_exhausted_when_renderer_withholds(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """AA-3: the capabilities flag and the withheld key can never disagree.
+
+    ``get_capabilities`` computes ``credits_exhausted`` from the same
+    predicate the renderer withholds keys on, so the settings surface names
+    "out of credits" exactly when a gateway launch would fail closed with
+    the runtime's generic ``AGENT_ROUTE_SELECTION_MISSING``. Granting credit
+    must flip both back together.
+    """
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_default_org_budget_usd", "0")
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+    org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+
+    _, _, _, credits_exhausted = await gateway_service.get_capabilities(
+        db_session, user_id=user_id
+    )
+    assert credits_exhausted is True
+    assert await is_gateway_budget_available(db_session, user_id) is False
+
+    await _grant(db_session, billing_subject_id=org_enrollment.billing_subject_id, amount="50")
+    _, _, _, credits_exhausted = await gateway_service.get_capabilities(
+        db_session, user_id=user_id
+    )
+    assert credits_exhausted is False
+    assert await is_gateway_budget_available(db_session, user_id) is True
+
+
+@pytest.mark.asyncio
 async def test_every_gateway_key_reader_resolves_the_same_enrollment(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
@@ -451,7 +485,7 @@ async def test_every_gateway_key_reader_resolves_the_same_enrollment(
     assert org_key.virtual_key_id != personal_key.virtual_key_id
 
     # get_capabilities / get_enrollment report the governing enrollment.
-    _, _, status = await gateway_service.get_capabilities(db_session, user_id=user_id)
+    _, _, status, _ = await gateway_service.get_capabilities(db_session, user_id=user_id)
     assert status == governing.sync_status
     reported = await gateway_service.get_enrollment(db_session, user_id=user_id)
     assert reported.id == governing.id


### PR DESCRIPTION
## Summary

Implements the three approved fixes from the triage ledger `delivery/triage/2026-08-25-integrations-agent-auth.md`. Change buckets: **bug** (IG-1), **system change on the client fences** (FE-FENCE-002), **spec gap** (AA-3).

### IG-1 — composer integrations control un-hidden (bug)
`use-composer-integrations-state.ts` gated the shared integration-health query on `cloudActive`, which folds in `CLOUD_COMPUTE_TEMPORARILY_DISABLED` — so the composer's integrations control (plug/count, "Linear needs re-authentication") was hidden for **every signed-in production user**, defeating integration_gateway § 5 ("health rolls up into readiness before anything runs"). Now gated on `authStatus === "authenticated" && controlPlaneReachable` — the same decoupling as `shouldSyncLocalAuthState`, the settings `authGate`, and #2133. The vitest file's default posture is now the shipped one (compute off): the old "disables the query when cloud is inactive" pin codified the bug and is replaced with signed-out / unreachable / compute-disabled-stays-live pins.

### FE-FENCE-002 — the cloudActive fence (system change)
This same regression shipped **four separate times** (`shouldSyncLocalAuthState`, settings `authGate`, #2133, IG-1). New rule in `check_frontend_fences.py` + `lints/frontend/fences.toml`: the gate tokens `cloudActive`/`cloudComputeEnabled` may appear in code (comments/strings excluded, tests exempt) only in files declared in the `[[cloud_gate_consumer]]` baseline — seeded with the **33 measured** legitimate consumers on this branch, shrink-only, stale rows fail. **Enforce mode from birth** (baseline == reality, checker green). Six new unit tests. Joining the baseline is a constitution amendment per the record's `alternative`.

### AA-3 — honest out-of-credits (spec gap)
Credit exhaustion surfaced as the runtime's generic `AGENT_ROUTE_SELECTION_MISSING`. `GET /agent-gateway/capabilities` now carries additive `creditsExhausted`, computed from the **exact predicate the state renderer withholds gateway keys on** (`is_gateway_budget_available`) — flag and withheld key can never disagree. The gateway card in `HarnessAuthSection` names "Out of LLM credits — gateway launches are paused until credits are added". Integration test pins agreement both directions (exhausted → flag on; grant → flag off). SDK regenerated (additive field).

**Known scope limit:** the launch-failure toast still carries the runtime's generic code — renaming it end to end needs the `state.json` rider + a runtime error code (cross-plane contract change; belongs to the model_gateway rebuild). The settings pane — where the user actually acts — now names the true reason.

## Testing
- `tests/integration/test_agent_auth_org_member_gateway.py`: **11/11** (sequential, incl. the new agreement pin; fixed the 3→4 tuple unpack in the divergence-guard test)
- agent_auth unit suites: **54/54** · mypy ratchet vs origin/main: **passed (333)** · ruff check/format: clean
- product-client: touched vitest suites **112/112** (composer state, harness pane/auth section, copy); `tsc --noEmit` clean
- `check_frontend_fences.py`: **OK, enforce mode** · fence unit tests **18/18** · `check_frontend_boundaries.py`, `check_manifests.py`: passed

## Adversarial self-review (inline)
- **Leak check (un-gating):** the composer control renders control-plane health only; the runtime's gateway MCP injection is independent of cloud compute (ledger's verified-not-broken list); signed-out/unreachable still hides (pinned). Connect/reconnect actions stay in the settings pane behind `authGate`. No compute surface exposed.
- **Fence reality:** measured 33 consumers with the checker itself (comment-only mentions in the five previously-fixed files correctly drop off); bidirectional exactness enforced. Scope is product-client only — `apps/desktop/src` and `apps/web/src` have zero non-test consumers (verified by grep), so no gap today.
- **Every-path check (AA-3):** settings surface covered; launch toast documented as out of scope above — no client copy exists for `AGENT_ROUTE_SELECTION_MISSING` to rewrite without new plumbing.

Cross-references: triage ledger entries IG-1, AA-3, and "The class, not the instances"; #2133 (pattern), #2217/#2223 (fence checker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
