### PR TITLE
fix(litellm): add Claude 5 family to the gateway model list

### DIFF
--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -72,6 +72,26 @@ model_list:
       api_key: os.environ/ANTHROPIC_API_KEY
     model_info:
       access_groups: [claude, opencode]
+  # Claude 5 family (claude-sonnet-5 is Claude Code's current default; its
+  # absence 403'd every gateway launch — "key can only access models=['claude']").
+  - model_name: claude-sonnet-5
+    litellm_params:
+      model: anthropic/claude-sonnet-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
+  - model_name: claude-opus-5
+    litellm_params:
+      model: anthropic/claude-opus-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
+  - model_name: claude-fable-5
+    litellm_params:
+      model: anthropic/claude-fable-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
 
   # OpenAI. access_groups: codex is the direct-OpenAI harness; opencode again
   # composes additively (see above).


### PR DESCRIPTION
Pablo's first funded gateway launch failed: `403 key not allowed to access model. This key can only access models=['claude']. Tried to access claude-sonnet-5`.

Root cause: `server/litellm/config.yaml` is a model generation behind — it lists sonnet-4-5 / haiku-4-5 / opus-4-6 but none of the Claude 5 family, and `claude-sonnet-5` is Claude Code's current default. The proxy's access-group enforcement did its job on a stale list.

Adds `claude-sonnet-5`, `claude-opus-5`, `claude-fable-5` with the standard `[claude, opencode]` access groups (bare ids; Anthropic serves them). `test_litellm_config_access_groups` + `test_litellm_integration`: 27/27 locally with CI env.

Note on deploy: litellm ships via `release.yml` → `_deploy-litellm.yml`, so this lands on the next release run after merge.

Two follow-ups worth noting (not in this PR): the codex list looks similarly stale (gpt-5.2 era — codex's current default is newer), and `agent_gateway_verification_enabled` is off, which is exactly the drift-detector that would have caught this. Both are on the ai_gateway spec's build list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XM9Un7yY8v36SDUisKxo3