### PR TITLE
feat(observability): runtime ERRORs carry the session_id tag

### DIFF
--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -142,6 +142,84 @@ fn sentry_event_filter(metadata: &tracing::Metadata<'_>) -> sentry_tracing::Even
     )
 }
 
+const SESSION_ID_SPAN_FIELD: &str = "session_id";
+
+/// Typed span extension: the validated `session_id` recorded at span creation
+/// by [`SessionIdSpanLayer`].
+struct SpanSessionId(String);
+
+struct SessionIdVisitor(Option<String>);
+
+impl tracing::field::Visit for SessionIdVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == SESSION_ID_SPAN_FIELD {
+            self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == SESSION_ID_SPAN_FIELD {
+            self.0 = Some(format!("{value:?}").trim_matches('"').to_string());
+        }
+    }
+}
+
+/// Only a canonical lowercase UUID leaves the process as a `session_id` tag;
+/// a client-supplied custom session id stays local (bounded beats complete
+/// for a vendor-bound tag).
+fn canonical_session_id(candidate: &str) -> Option<&str> {
+    let bytes = candidate.as_bytes();
+    if bytes.len() != 36 {
+        return None;
+    }
+    let canonical = bytes.iter().enumerate().all(|(index, byte)| match index {
+        8 | 13 | 18 | 23 => *byte == b'-',
+        _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
+    });
+    canonical.then_some(candidate)
+}
+
+/// Records the `session_id` span field into span extensions so the Sentry
+/// mapper can tag events without enabling blanket span-attribute inheritance
+/// (which stays off for privacy — only this one validated field crosses).
+struct SessionIdSpanLayer;
+
+impl<S> Layer<S> for SessionIdSpanLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: LayerContext<'_, S>,
+    ) {
+        let mut visitor = SessionIdVisitor(None);
+        attrs.record(&mut visitor);
+        let Some(candidate) = visitor.0 else { return };
+        let Some(valid) = canonical_session_id(&candidate) else {
+            return;
+        };
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(SpanSessionId(valid.to_string()));
+        }
+    }
+}
+
+/// The nearest enclosing span's validated `session_id`, if the event fired
+/// inside session work.
+fn session_id_for_event<S>(
+    event: &tracing::Event<'_>,
+    context: &LayerContext<'_, S>,
+) -> Option<String>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    let span = context.event_span(event)?;
+    span.scope()
+        .find_map(|span| span.extensions().get::<SpanSessionId>().map(|s| s.0.clone()))
+}
+
 fn sentry_event_mapper<S>(
     event: &tracing::Event<'_>,
     context: LayerContext<'_, S>,
@@ -172,6 +250,11 @@ where
         if is_runtime_incident {
             sentry_event.fingerprint =
                 Cow::Owned(vec![Cow::Borrowed(RUNTIME_INCIDENT_FINGERPRINT)]);
+        }
+        if let Some(session_id) = session_id_for_event(event, &context) {
+            sentry_event
+                .tags
+                .insert(SESSION_ID_SPAN_FIELD.to_string(), session_id);
         }
         mappings.push(sentry_tracing::EventMapping::Event(sentry_event));
     }
@@ -330,6 +413,7 @@ pub fn init(command: &Commands, activation: DesktopDiagnosticsActivation) -> Tel
 
     tracing_subscriber::registry()
         .with(console_layer)
+        .with(SessionIdSpanLayer)
         .with(sentry_tracing::layer().event_mapper(sentry_event_mapper))
         .with(diagnostics_layer)
         .with(file_sink.as_ref().map(|sink| {

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -35,6 +35,9 @@ use crate::{
 };
 
 mod scrub;
+mod session_tag;
+
+use session_tag::{session_id_for_event, SessionIdSpanLayer, SESSION_ID_SPAN_FIELD};
 
 const ANYHARNESS_TELEMETRY_MODE: &str = "hosted_product";
 const ANYHARNESS_RECORD_NAME_PREFIX: &str = "anyharness.";
@@ -140,84 +143,6 @@ fn sentry_event_filter(metadata: &tracing::Metadata<'_>) -> sentry_tracing::Even
         metadata.target(),
         sentry_tracing::default_event_filter(metadata),
     )
-}
-
-const SESSION_ID_SPAN_FIELD: &str = "session_id";
-
-/// Typed span extension: the validated `session_id` recorded at span creation
-/// by [`SessionIdSpanLayer`].
-struct SpanSessionId(String);
-
-struct SessionIdVisitor(Option<String>);
-
-impl tracing::field::Visit for SessionIdVisitor {
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        if field.name() == SESSION_ID_SPAN_FIELD {
-            self.0 = Some(value.to_string());
-        }
-    }
-
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        if field.name() == SESSION_ID_SPAN_FIELD {
-            self.0 = Some(format!("{value:?}").trim_matches('"').to_string());
-        }
-    }
-}
-
-/// Only a canonical lowercase UUID leaves the process as a `session_id` tag;
-/// a client-supplied custom session id stays local (bounded beats complete
-/// for a vendor-bound tag).
-fn canonical_session_id(candidate: &str) -> Option<&str> {
-    let bytes = candidate.as_bytes();
-    if bytes.len() != 36 {
-        return None;
-    }
-    let canonical = bytes.iter().enumerate().all(|(index, byte)| match index {
-        8 | 13 | 18 | 23 => *byte == b'-',
-        _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
-    });
-    canonical.then_some(candidate)
-}
-
-/// Records the `session_id` span field into span extensions so the Sentry
-/// mapper can tag events without enabling blanket span-attribute inheritance
-/// (which stays off for privacy — only this one validated field crosses).
-struct SessionIdSpanLayer;
-
-impl<S> Layer<S> for SessionIdSpanLayer
-where
-    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
-{
-    fn on_new_span(
-        &self,
-        attrs: &tracing::span::Attributes<'_>,
-        id: &tracing::span::Id,
-        ctx: LayerContext<'_, S>,
-    ) {
-        let mut visitor = SessionIdVisitor(None);
-        attrs.record(&mut visitor);
-        let Some(candidate) = visitor.0 else { return };
-        let Some(valid) = canonical_session_id(&candidate) else {
-            return;
-        };
-        if let Some(span) = ctx.span(id) {
-            span.extensions_mut().insert(SpanSessionId(valid.to_string()));
-        }
-    }
-}
-
-/// The nearest enclosing span's validated `session_id`, if the event fired
-/// inside session work.
-fn session_id_for_event<S>(
-    event: &tracing::Event<'_>,
-    context: &LayerContext<'_, S>,
-) -> Option<String>
-where
-    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
-{
-    let span = context.event_span(event)?;
-    span.scope()
-        .find_map(|span| span.extensions().get::<SpanSessionId>().map(|s| s.0.clone()))
 }
 
 fn sentry_event_mapper<S>(

--- a/anyharness/crates/anyharness/src/telemetry/session_tag.rs
+++ b/anyharness/crates/anyharness/src/telemetry/session_tag.rs
@@ -1,0 +1,168 @@
+//! The one span field that crosses into Sentry: a validated `session_id`.
+//!
+//! Span-attribute inheritance stays off in the Sentry layer for privacy;
+//! this module records the `session_id` span field into span extensions at
+//! creation and lets the event mapper tag each event with the nearest
+//! enclosing span's value. Nothing else crosses.
+
+use tracing::Subscriber;
+use tracing_subscriber::{layer::Context as LayerContext, registry::LookupSpan, Layer};
+
+pub(super) const SESSION_ID_SPAN_FIELD: &str = "session_id";
+
+/// Typed span extension: the validated `session_id` recorded at span creation
+/// by [`SessionIdSpanLayer`].
+struct SpanSessionId(String);
+
+struct SessionIdVisitor(Option<String>);
+
+impl tracing::field::Visit for SessionIdVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == SESSION_ID_SPAN_FIELD {
+            self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == SESSION_ID_SPAN_FIELD {
+            self.0 = Some(format!("{value:?}").trim_matches('"').to_string());
+        }
+    }
+}
+
+/// Only a canonical lowercase UUID leaves the process as a `session_id` tag;
+/// a client-supplied custom session id stays local (bounded beats complete
+/// for a vendor-bound tag).
+pub(super) fn canonical_session_id(candidate: &str) -> Option<&str> {
+    let bytes = candidate.as_bytes();
+    if bytes.len() != 36 {
+        return None;
+    }
+    let canonical = bytes.iter().enumerate().all(|(index, byte)| match index {
+        8 | 13 | 18 | 23 => *byte == b'-',
+        _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
+    });
+    canonical.then_some(candidate)
+}
+
+/// Records the `session_id` span field into span extensions so the Sentry
+/// mapper can tag events without enabling blanket span-attribute inheritance
+/// (which stays off for privacy — only this one validated field crosses).
+pub(super) struct SessionIdSpanLayer;
+
+impl<S> Layer<S> for SessionIdSpanLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: LayerContext<'_, S>,
+    ) {
+        let mut visitor = SessionIdVisitor(None);
+        attrs.record(&mut visitor);
+        let Some(candidate) = visitor.0 else { return };
+        let Some(valid) = canonical_session_id(&candidate) else {
+            return;
+        };
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut()
+                .insert(SpanSessionId(valid.to_string()));
+        }
+    }
+}
+
+/// The nearest enclosing span's validated `session_id`, if the event fired
+/// inside session work.
+pub(super) fn session_id_for_event<S>(
+    event: &tracing::Event<'_>,
+    context: &LayerContext<'_, S>,
+) -> Option<String>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    let span = context.event_span(event)?;
+    span.scope().find_map(|span| {
+        span.extensions()
+            .get::<SpanSessionId>()
+            .map(|s| s.0.clone())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{sentry_event_mapper, tests::sentry_test_options};
+    use super::{canonical_session_id, SessionIdSpanLayer};
+
+    const SESSION_UUID: &str = "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca";
+
+    fn session_tag_events(emit: impl FnOnce()) -> Vec<sentry::protocol::Event<'static>> {
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry()
+            .with(SessionIdSpanLayer)
+            .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
+        sentry::test::with_captured_events_options(
+            || tracing::subscriber::with_default(subscriber, emit),
+            sentry_test_options(),
+        )
+    }
+
+    #[test]
+    fn error_inside_session_span_carries_the_session_id_tag() {
+        // The field is recorded Display-style (`%id`) at the production call
+        // sites (domains/sessions/runtime, live/sessions/manager), so record it
+        // the same way here.
+        let events = session_tag_events(|| {
+            let id = SESSION_UUID.to_string();
+            let span = tracing::info_span!("session_work", session_id = %id);
+            let _guard = span.enter();
+            let inner = tracing::info_span!("nested_operation");
+            let _inner_guard = inner.enter();
+            tracing::error!("failure inside session work");
+        });
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].tags.get("session_id").map(String::as_str),
+            Some(SESSION_UUID),
+            "an ERROR inside a session span must carry the session_id tag"
+        );
+    }
+
+    #[test]
+    fn non_uuid_session_id_never_becomes_a_tag() {
+        let events = session_tag_events(|| {
+            let span = tracing::info_span!("session_work", session_id = "session-01");
+            let _guard = span.enter();
+            tracing::error!("failure inside custom-id session work");
+        });
+        assert_eq!(events.len(), 1);
+        assert!(
+            !events[0].tags.contains_key("session_id"),
+            "a client-supplied custom session id stays local-only"
+        );
+    }
+
+    #[test]
+    fn error_outside_any_session_span_stays_untagged() {
+        let events = session_tag_events(|| {
+            tracing::error!("failure outside session work");
+        });
+        assert_eq!(events.len(), 1);
+        assert!(!events[0].tags.contains_key("session_id"));
+    }
+
+    #[test]
+    fn canonical_session_id_admits_lowercase_uuid_only() {
+        assert_eq!(canonical_session_id(SESSION_UUID), Some(SESSION_UUID));
+        for rejected in [
+            "session-01",
+            "C3F1A8D2-5B47-4E19-9A6C-0D8E2F7B41CA",
+            "c3f1a8d25b474e199a6c0d8e2f7b41ca",
+            "",
+            "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca-extra",
+        ] {
+            assert_eq!(canonical_session_id(rejected), None, "{rejected}");
+        }
+    }
+}

--- a/anyharness/crates/anyharness/src/telemetry/tests.rs
+++ b/anyharness/crates/anyharness/src/telemetry/tests.rs
@@ -3,11 +3,10 @@ use std::{collections::BTreeMap, sync::Arc};
 use sentry::protocol::{Breadcrumb, Context as SentryContext, SpanId, TraceId, User, Value};
 
 use super::{
-    anyharness_target_mappings, canonical_session_id, default_release, log_path_for_command,
-    runtime_home_from_install, runtime_home_from_serve, scrub, sentry_event_filter,
-    sentry_event_filter_for_target, sentry_event_mapper, sentry_scope_tags, sentry_user_from_id,
-    stamped_git_sha, suppresses_legacy_file_sink, BundledActivation, SessionIdSpanLayer,
-    RUNTIME_INCIDENT_FINGERPRINT,
+    anyharness_target_mappings, default_release, log_path_for_command, runtime_home_from_install,
+    runtime_home_from_serve, scrub, sentry_event_filter, sentry_event_filter_for_target,
+    sentry_event_mapper, sentry_scope_tags, sentry_user_from_id, stamped_git_sha,
+    suppresses_legacy_file_sink, BundledActivation, RUNTIME_INCIDENT_FINGERPRINT,
 };
 use crate::{
     cli::Commands,
@@ -20,7 +19,7 @@ use anyharness_lib::observability::{
 use proliferate_diagnostics_client::ResolvedRecordName;
 use proliferate_diagnostics_protocol::v1::types::{DetailedKindV1, StandardStreamV1};
 
-fn sentry_test_options() -> sentry::ClientOptions {
+pub(super) fn sentry_test_options() -> sentry::ClientOptions {
     sentry::ClientOptions {
         release: Some("anyharness@test".into()),
         environment: Some("test".into()),
@@ -70,77 +69,6 @@ fn tracing_error_reaches_the_sentry_client() {
         .fingerprint
         .iter()
         .all(|part| part.as_ref() != RUNTIME_INCIDENT_FINGERPRINT));
-}
-
-const SESSION_UUID: &str = "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca";
-
-fn session_tag_events(emit: impl FnOnce()) -> Vec<sentry::protocol::Event<'static>> {
-    use tracing_subscriber::layer::SubscriberExt;
-    let subscriber = tracing_subscriber::registry()
-        .with(SessionIdSpanLayer)
-        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
-    sentry::test::with_captured_events_options(
-        || tracing::subscriber::with_default(subscriber, emit),
-        sentry_test_options(),
-    )
-}
-
-#[test]
-fn error_inside_session_span_carries_the_session_id_tag() {
-    // The field is recorded Display-style (`%id`) at the production call
-    // sites (domains/sessions/runtime, live/sessions/manager), so record it
-    // the same way here.
-    let events = session_tag_events(|| {
-        let id = SESSION_UUID.to_string();
-        let span = tracing::info_span!("session_work", session_id = %id);
-        let _guard = span.enter();
-        let inner = tracing::info_span!("nested_operation");
-        let _inner_guard = inner.enter();
-        tracing::error!("failure inside session work");
-    });
-    assert_eq!(events.len(), 1);
-    assert_eq!(
-        events[0].tags.get("session_id").map(String::as_str),
-        Some(SESSION_UUID),
-        "an ERROR inside a session span must carry the session_id tag"
-    );
-}
-
-#[test]
-fn non_uuid_session_id_never_becomes_a_tag() {
-    let events = session_tag_events(|| {
-        let span = tracing::info_span!("session_work", session_id = "session-01");
-        let _guard = span.enter();
-        tracing::error!("failure inside custom-id session work");
-    });
-    assert_eq!(events.len(), 1);
-    assert!(
-        !events[0].tags.contains_key("session_id"),
-        "a client-supplied custom session id stays local-only"
-    );
-}
-
-#[test]
-fn error_outside_any_session_span_stays_untagged() {
-    let events = session_tag_events(|| {
-        tracing::error!("failure outside session work");
-    });
-    assert_eq!(events.len(), 1);
-    assert!(!events[0].tags.contains_key("session_id"));
-}
-
-#[test]
-fn canonical_session_id_admits_lowercase_uuid_only() {
-    assert_eq!(canonical_session_id(SESSION_UUID), Some(SESSION_UUID));
-    for rejected in [
-        "session-01",
-        "C3F1A8D2-5B47-4E19-9A6C-0D8E2F7B41CA",
-        "c3f1a8d25b474e199a6c0d8e2f7b41ca",
-        "",
-        "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca-extra",
-    ] {
-        assert_eq!(canonical_session_id(rejected), None, "{rejected}");
-    }
 }
 
 fn emit_ordinary_error_inside_span() -> (TraceId, SpanId) {

--- a/anyharness/crates/anyharness/src/telemetry/tests.rs
+++ b/anyharness/crates/anyharness/src/telemetry/tests.rs
@@ -3,10 +3,11 @@ use std::{collections::BTreeMap, sync::Arc};
 use sentry::protocol::{Breadcrumb, Context as SentryContext, SpanId, TraceId, User, Value};
 
 use super::{
-    anyharness_target_mappings, default_release, log_path_for_command, runtime_home_from_install,
-    runtime_home_from_serve, scrub, sentry_event_filter, sentry_event_filter_for_target,
-    sentry_event_mapper, sentry_scope_tags, sentry_user_from_id, stamped_git_sha,
-    suppresses_legacy_file_sink, BundledActivation, RUNTIME_INCIDENT_FINGERPRINT,
+    anyharness_target_mappings, canonical_session_id, default_release, log_path_for_command,
+    runtime_home_from_install, runtime_home_from_serve, scrub, sentry_event_filter,
+    sentry_event_filter_for_target, sentry_event_mapper, sentry_scope_tags, sentry_user_from_id,
+    stamped_git_sha, suppresses_legacy_file_sink, BundledActivation, SessionIdSpanLayer,
+    RUNTIME_INCIDENT_FINGERPRINT,
 };
 use crate::{
     cli::Commands,
@@ -69,6 +70,77 @@ fn tracing_error_reaches_the_sentry_client() {
         .fingerprint
         .iter()
         .all(|part| part.as_ref() != RUNTIME_INCIDENT_FINGERPRINT));
+}
+
+const SESSION_UUID: &str = "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca";
+
+fn session_tag_events(emit: impl FnOnce()) -> Vec<sentry::protocol::Event<'static>> {
+    use tracing_subscriber::layer::SubscriberExt;
+    let subscriber = tracing_subscriber::registry()
+        .with(SessionIdSpanLayer)
+        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
+    sentry::test::with_captured_events_options(
+        || tracing::subscriber::with_default(subscriber, emit),
+        sentry_test_options(),
+    )
+}
+
+#[test]
+fn error_inside_session_span_carries_the_session_id_tag() {
+    // The field is recorded Display-style (`%id`) at the production call
+    // sites (domains/sessions/runtime, live/sessions/manager), so record it
+    // the same way here.
+    let events = session_tag_events(|| {
+        let id = SESSION_UUID.to_string();
+        let span = tracing::info_span!("session_work", session_id = %id);
+        let _guard = span.enter();
+        let inner = tracing::info_span!("nested_operation");
+        let _inner_guard = inner.enter();
+        tracing::error!("failure inside session work");
+    });
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].tags.get("session_id").map(String::as_str),
+        Some(SESSION_UUID),
+        "an ERROR inside a session span must carry the session_id tag"
+    );
+}
+
+#[test]
+fn non_uuid_session_id_never_becomes_a_tag() {
+    let events = session_tag_events(|| {
+        let span = tracing::info_span!("session_work", session_id = "session-01");
+        let _guard = span.enter();
+        tracing::error!("failure inside custom-id session work");
+    });
+    assert_eq!(events.len(), 1);
+    assert!(
+        !events[0].tags.contains_key("session_id"),
+        "a client-supplied custom session id stays local-only"
+    );
+}
+
+#[test]
+fn error_outside_any_session_span_stays_untagged() {
+    let events = session_tag_events(|| {
+        tracing::error!("failure outside session work");
+    });
+    assert_eq!(events.len(), 1);
+    assert!(!events[0].tags.contains_key("session_id"));
+}
+
+#[test]
+fn canonical_session_id_admits_lowercase_uuid_only() {
+    assert_eq!(canonical_session_id(SESSION_UUID), Some(SESSION_UUID));
+    for rejected in [
+        "session-01",
+        "C3F1A8D2-5B47-4E19-9A6C-0D8E2F7B41CA",
+        "c3f1a8d25b474e199a6c0d8e2f7b41ca",
+        "",
+        "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca-extra",
+    ] {
+        assert_eq!(canonical_session_id(rejected), None, "{rejected}");
+    }
 }
 
 fn emit_ordinary_error_inside_span() -> (TraceId, SpanId) {


### PR DESCRIPTION
## Summary

- Runtime `error!` events now carry a `session_id` Sentry tag when they fire inside session work, joining runtime failures to the one-session-one-story view (server side landed in #2238). Mechanism: a dedicated `SessionIdSpanLayer` validates the existing `session_id` span field at span creation (canonical lowercase UUID only — client-supplied custom ids stay local-only per the vendor-bound-ids ruling) and stores it in span extensions; the Sentry event mapper reads the nearest enclosing span's value onto the event. Span-attribute inheritance stays **off** — no other span field crosses, so no privacy widening.

## Testing

- Unit tier: 4 new tests in `telemetry/tests.rs` — Display-recorded UUID lands as the tag (nested span), custom id never becomes a tag, span-free errors stay untagged, canonical-UUID validator matrix. 24 telemetry tests pass; clippy adds zero warnings on the changed files.

## Observability

- Delta: one new admitted Sentry tag on runtime events (`session_id`), already in the scrubber's safe-key list. No new event, no new emitter.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- `cargo test -p anyharness telemetry` → 24 passed
- `cargo clippy -p anyharness` → no findings in `src/telemetry*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)