### PR TITLE
feat(observability): client events carry session_id; desktop-native gets its scrubber

### DIFF
--- a/apps/desktop/src-tauri/src/telemetry.rs
+++ b/apps/desktop/src-tauri/src/telemetry.rs
@@ -1,9 +1,18 @@
+use std::sync::Arc;
+
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 use crate::{
     desktop_telemetry_mode::{resolve_desktop_telemetry_mode, DesktopTelemetryMode},
     diagnostics_collector::producer::TauriDiagnosticsProducer,
 };
+
+mod scrub;
+
+use scrub::{scrub_breadcrumb, scrub_event, scrub_log};
+
+/// The single env-like Sentry tag preserved as bounded deployment identity.
+pub(crate) const RUNTIME_ENV_TAG: &str = "runtime_env";
 
 pub struct TelemetryGuards {
     _sentry: Option<sentry::ClientInitGuard>,
@@ -88,6 +97,10 @@ pub fn init(native_diagnostics: &TauriDiagnosticsProducer) -> TelemetryGuards {
                     1.0,
                 ),
                 attach_stacktrace: true,
+                send_default_pii: false,
+                before_send: Some(Arc::new(scrub_event)),
+                before_breadcrumb: Some(Arc::new(scrub_breadcrumb)),
+                before_send_log: Some(Arc::new(scrub_log)),
                 ..Default::default()
             },
         ))
@@ -110,7 +123,7 @@ pub fn init(native_diagnostics: &TauriDiagnosticsProducer) -> TelemetryGuards {
     if telemetry.is_some() {
         sentry::configure_scope(|scope| {
             scope.set_tag("surface", "desktop_native");
-            scope.set_tag("runtime_env", "local");
+            scope.set_tag(RUNTIME_ENV_TAG, "local");
             if let Some(mode_tag) = telemetry_mode_tag(telemetry_mode) {
                 scope.set_tag("telemetry_mode", mode_tag);
             }

--- a/apps/desktop/src-tauri/src/telemetry/scrub.rs
+++ b/apps/desktop/src-tauri/src/telemetry/scrub.rs
@@ -1,0 +1,360 @@
+//! Scrubbing for Sentry payloads leaving the desktop native shell.
+//!
+//! Everything this process reports passes through here first: absolute paths,
+//! bearer tokens, URL query strings and any value under a sensitive-looking
+//! key are redacted before the event or log is handed to the transport.
+//! Mirrors the worker's scrubber (each binary carries its own copy, the
+//! established per-emitter pattern).
+
+use sentry::protocol::{Breadcrumb, Event, Frame, Log, LogEntry, Stacktrace, Value};
+
+use super::RUNTIME_ENV_TAG;
+
+fn scrub_text(value: &str) -> String {
+    redact_absolute_paths(&strip_query_segments(&redact_bearer_tokens(value)))
+}
+
+fn redact_bearer_tokens(value: &str) -> String {
+    let mut output = String::new();
+    let mut remaining = value;
+    while let Some(index) = remaining.find("Bearer ") {
+        output.push_str(&remaining[..index]);
+        output.push_str("[redacted-token]");
+        let token_start = index + "Bearer ".len();
+        let token_end = remaining[token_start..]
+            .find(char::is_whitespace)
+            .map(|offset| token_start + offset)
+            .unwrap_or(remaining.len());
+        remaining = &remaining[token_end..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn strip_query_segments(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let mut output = String::new();
+    let mut index = 0;
+    while index < chars.len() {
+        if chars[index] == '?' && preceding_token_is_urlish(&output) {
+            index += 1;
+            while index < chars.len()
+                && !chars[index].is_whitespace()
+                && !matches!(chars[index], '"' | '\'' | ')' | '<' | '>')
+            {
+                index += 1;
+            }
+            continue;
+        }
+        output.push(chars[index]);
+        index += 1;
+    }
+    output
+}
+
+fn preceding_token_is_urlish(value: &str) -> bool {
+    let token = value
+        .rsplit(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | '(' | '<' | '>'))
+        .next()
+        .unwrap_or_default();
+    token.contains("://")
+        || token.starts_with('/')
+        || token.starts_with("./")
+        || token.starts_with("../")
+}
+
+fn redact_absolute_paths(value: &str) -> String {
+    let mut output = String::new();
+    let mut index = 0;
+    while index < value.len() {
+        let rest = &value[index..];
+        if rest.starts_with("/Users/")
+            || rest.starts_with("/home/")
+            || rest.starts_with("/private/var/mobile/")
+            || rest.starts_with("/var/mobile/")
+            || rest.starts_with("/data/user/")
+            || rest.starts_with("/data/data/")
+            || starts_with_windows_path(rest)
+        {
+            output.push_str("[redacted-path]");
+            index += rest
+                .find(|ch: char| {
+                    ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | ')' | '<' | '>')
+                })
+                .unwrap_or(rest.len());
+            continue;
+        }
+        let ch = rest.chars().next().expect("non-empty rest");
+        output.push(ch);
+        index += ch.len_utf8();
+    }
+    output
+}
+
+fn starts_with_windows_path(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(drive) = chars.next() else {
+        return false;
+    };
+    if !drive.is_ascii_alphabetic() || chars.next() != Some(':') {
+        return false;
+    }
+    match chars.next() {
+        Some('\\') => true,
+        Some('/') => chars.next() != Some('/'),
+        _ => false,
+    }
+}
+
+fn sensitive_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    [
+        "authorization",
+        "cookie",
+        "token",
+        "secret",
+        "password",
+        "api_key",
+        "apikey",
+        "credential",
+        "prompt",
+        "content",
+        "stdout",
+        "stderr",
+        "request_body",
+        "body",
+        "env",
+        "file_path",
+        "path",
+        "query",
+        "search",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn scrub_value(value: &mut Value, key: Option<&str>) {
+    if key.is_some_and(sensitive_key) {
+        *value = Value::String("[redacted]".to_string());
+        return;
+    }
+
+    match value {
+        Value::String(text) => {
+            *text = scrub_text(text);
+        }
+        Value::Array(items) => {
+            for item in items {
+                scrub_value(item, None);
+            }
+        }
+        Value::Object(map) => {
+            for (entry_key, entry_value) in map {
+                scrub_value(entry_value, Some(entry_key));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scrub_optional_text(value: &mut Option<String>) {
+    if let Some(text) = value {
+        *text = scrub_text(text);
+    }
+}
+
+fn scrub_log_entry(logentry: &mut Option<LogEntry>) {
+    if let Some(logentry) = logentry {
+        logentry.message = scrub_text(&logentry.message);
+        for param in &mut logentry.params {
+            scrub_value(param, None);
+        }
+    }
+}
+
+fn scrub_frame(frame: &mut Frame) {
+    scrub_optional_text(&mut frame.filename);
+    scrub_optional_text(&mut frame.abs_path);
+    frame.context_line = None;
+    frame.pre_context.clear();
+    frame.post_context.clear();
+    frame.vars.clear();
+}
+
+fn scrub_stacktrace(stacktrace: &mut Option<Stacktrace>) {
+    if let Some(stacktrace) = stacktrace {
+        for frame in &mut stacktrace.frames {
+            scrub_frame(frame);
+        }
+    }
+}
+
+pub(super) fn scrub_breadcrumb(mut breadcrumb: Breadcrumb) -> Option<Breadcrumb> {
+    scrub_optional_text(&mut breadcrumb.message);
+    for (key, value) in &mut breadcrumb.data {
+        scrub_value(value, Some(key));
+    }
+    Some(breadcrumb)
+}
+
+pub(super) fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
+    scrub_optional_text(&mut event.message);
+    scrub_optional_text(&mut event.culprit);
+    scrub_optional_text(&mut event.transaction);
+    scrub_log_entry(&mut event.logentry);
+
+    if let Some(user) = &mut event.user {
+        user.email = None;
+        user.username = None;
+        user.ip_address = None;
+        user.other.clear();
+    }
+
+    if let Some(request) = &mut event.request {
+        if let Some(url) = &mut request.url {
+            url.set_query(None);
+            url.set_fragment(None);
+        }
+        request.data = None;
+        request.query_string = None;
+        request.cookies = None;
+        request.headers.clear();
+        request.env.clear();
+    }
+
+    for breadcrumb in &mut event.breadcrumbs.values {
+        scrub_optional_text(&mut breadcrumb.message);
+        for (key, value) in &mut breadcrumb.data {
+            scrub_value(value, Some(key));
+        }
+    }
+    for exception in &mut event.exception.values {
+        scrub_optional_text(&mut exception.value);
+        scrub_stacktrace(&mut exception.stacktrace);
+        scrub_stacktrace(&mut exception.raw_stacktrace);
+    }
+    scrub_stacktrace(&mut event.stacktrace);
+    if let Some(template) = &mut event.template {
+        scrub_optional_text(&mut template.filename);
+        scrub_optional_text(&mut template.abs_path);
+        template.context_line = None;
+        template.pre_context.clear();
+        template.post_context.clear();
+    }
+    for thread in &mut event.threads.values {
+        scrub_optional_text(&mut thread.name);
+        scrub_stacktrace(&mut thread.stacktrace);
+        scrub_stacktrace(&mut thread.raw_stacktrace);
+    }
+    for (key, value) in &mut event.extra {
+        scrub_value(value, Some(key));
+    }
+    for (key, value) in &mut event.tags {
+        if key == RUNTIME_ENV_TAG {
+            // Bounded deployment identity: the runtime-environment tag survives
+            // (allowed live value `e2b`). Every other env-like tag key still
+            // matches `sensitive_key` and stays redacted.
+            *value = scrub_text(value);
+        } else if sensitive_key(key) {
+            *value = "[redacted]".to_string();
+        } else {
+            *value = scrub_text(value);
+        }
+    }
+
+    Some(event)
+}
+
+pub(super) fn scrub_log(mut log: Log) -> Option<Log> {
+    log.body = scrub_text(&log.body);
+    for (key, attribute) in &mut log.attributes {
+        scrub_value(&mut attribute.0, Some(key));
+    }
+    Some(log)
+}
+
+#[cfg(test)]
+mod tests {
+    use sentry::protocol::{Event, Exception, Frame, Stacktrace, Value};
+
+    use super::scrub_event;
+
+    #[test]
+    fn sentry_event_scrubber_removes_paths_urls_and_bodies() {
+        let mut event = Event::new();
+        event.message = Some(
+            "failed at /home/proliferate/workspace/file.rs?code=secret Bearer abc123".to_string(),
+        );
+        event.extra.insert(
+            "body".to_string(),
+            Value::String("raw response".to_string()),
+        );
+        event.exception.values.push(Exception {
+            value: Some(
+                "request failed https://app.proliferate.com/auth/callback?code=abc&state=def"
+                    .to_string(),
+            ),
+            stacktrace: Some(Stacktrace {
+                frames: vec![Frame {
+                    abs_path: Some("/home/proliferate/app/main.rs".to_string()),
+                    context_line: Some("let token = secret;".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let scrubbed = scrub_event(event).expect("event should remain");
+
+        assert_eq!(
+            scrubbed.message.as_deref(),
+            Some("failed at [redacted-path] [redacted-token]")
+        );
+        assert_eq!(
+            scrubbed.extra["body"],
+            Value::String("[redacted]".to_string())
+        );
+        assert_eq!(
+            scrubbed.exception.values[0].value.as_deref(),
+            Some("request failed https://app.proliferate.com/auth/callback")
+        );
+        let frame = &scrubbed.exception.values[0]
+            .stacktrace
+            .as_ref()
+            .expect("stacktrace")
+            .frames[0];
+        assert_eq!(frame.abs_path.as_deref(), Some("[redacted-path]"));
+        assert!(frame.context_line.is_none());
+    }
+
+    #[test]
+    fn runtime_env_tag_survives_while_other_env_tags_are_redacted() {
+        let mut event = Event::new();
+        event
+            .tags
+            .insert("runtime_env".to_string(), "e2b".to_string());
+        event
+            .tags
+            .insert("deploy_env".to_string(), "prod".to_string());
+        event
+            .tags
+            .insert("environment_name".to_string(), "prod".to_string());
+
+        let scrubbed = scrub_event(event).expect("event should remain");
+
+        // Bounded deployment identity is preserved; other env-like tags are not.
+        assert_eq!(
+            scrubbed.tags.get("runtime_env").map(String::as_str),
+            Some("e2b")
+        );
+        assert_eq!(
+            scrubbed.tags.get("deploy_env").map(String::as_str),
+            Some("[redacted]")
+        );
+        assert_eq!(
+            scrubbed.tags.get("environment_name").map(String::as_str),
+            Some("[redacted]")
+        );
+    }
+}

--- a/apps/desktop/src/lib/integrations/telemetry/sentry.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/sentry.test.ts
@@ -166,6 +166,33 @@ describe("desktop sentry transport", () => {
     expect((scrubbed.tags as Record<string, unknown>).environment).toBe("[redacted]");
   });
 
+  it("setDesktopSentryTag sets values and clears the tag on an empty value", async () => {
+    const sentry = await loadSentryModule();
+
+    sentry.initializeDesktopSentry({
+      environment: "production",
+      release: "proliferate-desktop@test",
+      sentry: {
+        enabled: true,
+        dsn: "https://sentry.example/123",
+        tracesSampleRate: 1,
+        enableLogs: true,
+      },
+      apiBaseUrl: "https://app.proliferate.com/api",
+      telemetryMode: "hosted_product",
+    });
+
+    sentry.setDesktopSentryTag("session_id", "11111111-2222-4333-8444-555555555555");
+    expect(mocks.setTagMock).toHaveBeenLastCalledWith(
+      "session_id",
+      "11111111-2222-4333-8444-555555555555",
+    );
+
+    // The ProductTelemetry.setTag contract: an empty value clears the tag.
+    sentry.setDesktopSentryTag("session_id", "");
+    expect(mocks.setTagMock).toHaveBeenLastCalledWith("session_id", undefined);
+  });
+
   it("bounds cyclic and deep payloads at the Sentry scrubber entrypoints", async () => {
     const sentry = await loadSentryModule();
 

--- a/apps/desktop/src/lib/integrations/telemetry/sentry.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/sentry.ts
@@ -122,7 +122,9 @@ export function clearDesktopSentryUser(): void {
 
 export function setDesktopSentryTag(key: string, value: string): void {
   if (!sentryInitialized) return;
-  Sentry.setTag(key, value);
+  // An empty value clears the tag (the vendor drops tags set to undefined),
+  // per the ProductTelemetry.setTag contract.
+  Sentry.setTag(key, value === "" ? undefined : value);
 }
 
 export function addDesktopSentryBreadcrumb(

--- a/apps/packages/product-client/src/hooks/telemetry/lifecycle/telemetry-lifecycle.test.tsx
+++ b/apps/packages/product-client/src/hooks/telemetry/lifecycle/telemetry-lifecycle.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { act, render, fireEvent } from "@testing-library/react";
 import { Link, MemoryRouter } from "react-router-dom";
 
 import type {
@@ -12,8 +12,10 @@ import {
   makeTestProductHost,
   testAuthState,
 } from "#product/test/product-host-test-utils";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useTelemetryRouteViews } from "#product/hooks/telemetry/lifecycle/use-telemetry-route-views";
 import { useTelemetryAuthIdentity } from "#product/hooks/telemetry/lifecycle/use-telemetry-auth-identity";
+import { useTelemetrySessionSelection } from "#product/hooks/telemetry/lifecycle/use-telemetry-session-selection";
 
 function spyTelemetry(): ProductTelemetry {
   return {
@@ -79,6 +81,39 @@ describe("useTelemetryRouteViews", () => {
     expect(telemetry.track).toHaveBeenCalledTimes(3);
     fireEvent.click(getByText("workflows-run"));
     expect(telemetry.track).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("useTelemetrySessionSelection", () => {
+  function SessionHarness() {
+    useTelemetrySessionSelection();
+    return null;
+  }
+
+  it("tags the active session id and clears it when no session is open", () => {
+    const telemetry = spyTelemetry();
+    const host = makeTestProductHost({ overrides: { telemetry } });
+    render(
+      <ProductHostProvider host={host}>
+        <SessionHarness />
+      </ProductHostProvider>,
+    );
+
+    // Mount with no active session: the tag is explicitly cleared, never stale.
+    expect(telemetry.setTag).toHaveBeenCalledWith("session_id", "");
+
+    act(() => {
+      useSessionSelectionStore.setState({ activeSessionId: "11111111-2222-4333-8444-555555555555" });
+    });
+    expect(telemetry.setTag).toHaveBeenLastCalledWith(
+      "session_id",
+      "11111111-2222-4333-8444-555555555555",
+    );
+
+    act(() => {
+      useSessionSelectionStore.setState({ activeSessionId: null });
+    });
+    expect(telemetry.setTag).toHaveBeenLastCalledWith("session_id", "");
   });
 });
 

--- a/apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts
+++ b/apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts
@@ -3,6 +3,7 @@ import { useTelemetryAgentSeed } from "#product/hooks/telemetry/lifecycle/use-te
 import { useTelemetryOrganizationIdentity } from "#product/hooks/telemetry/lifecycle/use-telemetry-organization-identity";
 import { useTelemetryRouteViews } from "#product/hooks/telemetry/lifecycle/use-telemetry-route-views";
 import { useTelemetryRuntimeState } from "#product/hooks/telemetry/lifecycle/use-telemetry-runtime-state";
+import { useTelemetrySessionSelection } from "#product/hooks/telemetry/lifecycle/use-telemetry-session-selection";
 import { useTelemetryWorkspaceSelection } from "#product/hooks/telemetry/lifecycle/use-telemetry-workspace-selection";
 
 // Owns mounting app-wide telemetry lifecycle hooks. Does not own telemetry transport.
@@ -12,5 +13,6 @@ export function useTelemetryBootstrap() {
   useTelemetryOrganizationIdentity();
   useTelemetryRouteViews();
   useTelemetryRuntimeState();
+  useTelemetrySessionSelection();
   useTelemetryWorkspaceSelection();
 }

--- a/apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-session-selection.ts
+++ b/apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-session-selection.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from "react";
+import { useProductTelemetry } from "#product/hooks/telemetry/facade/use-product-telemetry";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+// Owns the active-session correlation tag: every client vendor event raised
+// while a session is open carries that session's id, joining the
+// one-session-one-story view (server and runtime carry the same tag). An
+// empty value clears the tag so events after close never cite a stale
+// session. Does not own session selection.
+export function useTelemetrySessionSelection() {
+  const activeSessionId = useSessionSelectionStore((state) => state.activeSessionId);
+  const telemetry = useProductTelemetry();
+  // Starts undefined (never a legal store value) so the mount always writes
+  // the tag state — including the explicit clear when no session is open.
+  const previousSessionIdRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (previousSessionIdRef.current === activeSessionId) return;
+    previousSessionIdRef.current = activeSessionId;
+    telemetry.setTag("session_id", activeSessionId ?? "");
+  }, [activeSessionId, telemetry]);
+}

--- a/apps/packages/product-client/src/host/product-host.ts
+++ b/apps/packages/product-client/src/host/product-host.ts
@@ -317,6 +317,7 @@ export interface ProductTelemetry {
   track(event: ProductEvent): void;
   captureException(error: unknown, context?: ErrorContext): void;
   setUser(user: ProductAuthUser | null): void;
+  /** Set a vendor scope tag. An empty value clears the tag. */
   setTag(key: string, value: string): void;
   /**
    * Host-owned route instrumentation. ProductClient calls this after shared

--- a/apps/web/src/browser/telemetry/web-telemetry.ts
+++ b/apps/web/src/browser/telemetry/web-telemetry.ts
@@ -80,7 +80,9 @@ export const webProductTelemetry: ProductTelemetry = {
   },
 
   setTag(key: string, value: string): void {
-    Sentry.setTag(key, value);
+    // An empty value clears the tag (the vendor drops tags set to undefined),
+    // per the ProductTelemetry.setTag contract.
+    Sentry.setTag(key, value === "" ? undefined : value);
   },
 
   routeChanged(change: ProductRouteChange): void {


### PR DESCRIPTION
## Summary

- **Client `session_id` tag**: a new product-client telemetry lifecycle hook (`useTelemetrySessionSelection`, mounted by the existing telemetry bootstrap) tags `session_id` from the session-selection store on every active-session change and clears it when no session is open — client exceptions now join the one-session-one-story view alongside server (#2238) and runtime (#2256) tags.
- **Bridge contract**: `ProductTelemetry.setTag` documents that an empty value clears the tag; the desktop and web adapters map empty → vendor unset (mobile's per-capture scope path is untouched).
- **Desktop-native scrubber**: the one Sentry emitter with no before-send scrubber gains the full scrub module (a copy of the worker's, matching the established per-binary scrubber pattern), plus `send_default_pii: false` and breadcrumb/log scrubbers.

## Testing

- Unit tier: new lifecycle test (tag set on session open, cleared on close, explicit clear on mount); desktop adapter clear-semantics test; the copied scrub module's tests run in the native crate (58 scrub tests green). `tsc --noEmit` clean on product-client, desktop, and web; web telemetry suite 35 passed.

## Observability

- Delta: client Sentry events gain the `session_id` tag (same closed vocabulary as server/runtime); desktop-native events are now scrubbed before send — previously the only unscrubbed emitter.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- `pnpm vitest run` on the three touched test files → 5 + 6 + 35 passed
- `cargo build -p proliferate` + `cargo test -p proliferate scrub` → green
- Note: an uncommitted `Cargo.lock` drift exists on `main` (crate versions bumped to 0.4.27 without a lock regen) — surfaced while building, deliberately not folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)