### PR TITLE
docs(delivery): freeze agent_auth slices 2 and 5

### DIFF
--- a/delivery/agent-auth/delivery-spec-slice-2-rotation-and-refusals.md
+++ b/delivery/agent-auth/delivery-spec-slice-2-rotation-and-refusals.md
@@ -1,0 +1,41 @@
+# Delivery specification — agent_auth slice 2: rotation & refusals (frozen)
+
+Chain position: slice 2 of the approved auth slice plan (0 funding ✅ → 1 mint & run ✅ PR #2254 → **2 rotation & refusals** → 3 ∥ 4 → 5 independent → 6). Evidence of record: the agent_auth system spec ([specs/systems/agent_auth/README.md](../../specs/systems/agent_auth/README.md) — §3 Flow 3's ladder, the Rotation-ownership ruling in §4 cell 2, the `LaunchRefusal` enum in §4) and slice 1's landed seat chain (branch `agent-auth-slice-1`, PR #2254). Builders implement from this document without re-deriving the architecture. **Base branch: `agent-auth-slice-1`** until #2254 merges; the PR retargets to main automatically at that merge.
+
+## Intent
+
+Many seats become a **pool**. A limit-hit seat cools and the next launch rotates past it without a human touching anything; when nothing can serve, the launch refuses **in words**. The `AGENT_ROUTE_SELECTION_MISSING` mystery-error class dies in this slice: every refusal a human can see is a typed reason with plain-English copy.
+
+## Acceptance gate (the merge bar — performed by Pablo, in the product)
+
+With two seats on the account, force a limit error on the serving seat (real or simulated) — the next session starts on seat 2 untouched, and the serving-now tag moves. Cool both — launching shows a sentence naming the earliest reset. Falsifier: `AGENT_ROUTE_SELECTION_MISSING` (or any bare error code) visible to a human anywhere in the product.
+
+## Scope
+
+Spec sections of record: agent_auth §3 Flow 3 (the resolve ladder with the seat arm complete) · §4 cell 1 (the limit-hit route, events) · §4 cell 2 (Rotation ownership: the runtime decides, the server supplies the pool) · §4 cell 3 (`reportSeatLimitHit`) · the design pass (serving-now / next-up tags, the rotate switch).
+
+- **Pool render**: `state_render.py` emits **every active seat** for a harness as `seat` sources, in vault order (slice 1 rendered the deduped pool already — this slice removes any single-seat cap and pins the ordering with a test). Contract fixture gains a multi-seat variant.
+- **Runtime rotation** (`route_auth/`): round-robin over the document's seat sources, skipping cooling ones; selection is runtime-local and deterministic (`last_served` per harness advances only on successful spawn). Per-seat cooling records `(seat_id, cooling_until)` persisted in the runtime's SQLite — a new small `seat_cooling` store that the slice-3 `status/` module will absorb; cooling survives restart.
+- **Cooling trigger**: a limit error observed in session output marks the serving seat cooling until the reset time the error carries (absent a parseable reset: the top of the next 5-hour window). Marking is runtime-local and never waits on the network.
+- **The typed refusal set, complete with copy** (§4's enum, exhaustively surfaced): `NoConfiguredSource` ("Claude Code isn't set up — pick a method in Settings") · `SourceUnsatisfied{reason}` (names the actual why: revoked key, out of credits) · `SeatCooling{seat, reset_at}` · `AllSeatsCooling{earliest_reset}` (names the earliest reset time). Every launch-path caller renders the words, never the variant name; exhaustiveness enforced at the surface (compile-time match, no catch-all).
+- **Fallback**: when the harness's profile carries a non-seat source besides the pool (gateway), an all-cooling pool falls through to it before refusing; the refusal fires only when nothing can serve.
+- **Limit-hit reporting**: courier `reportSeatLimitHit()` → `POST /seats/{key_id}/limit-hit` `{window, resetAt}`, fire-and-forget (cooling never waits on it); server logs `agent_seat_limit_hit` (and `agent_seat_rotated` on rotation). Events carry user, org, harness kind, seat id — never token material.
+- **The relaunch offer**: a session that dies on a limit error offers one-click relaunch (which lands on the next seat via the ordinary ladder).
+- **Pane**: serving-now / next-up tags per seat row and the per-harness rotate toggle (`agent_auth_harness_settings`, settings rider — **off pins the applied seat**, skipping rotation but not cooling). Transitional carry: the tags read `serving_seat_id` / `next_seat_id` / `cooling_until` surfaced on the existing local auth-state read path the pane consumes today; slice 3 moves them into the status document — build accordingly (one seam, no pane re-derivation).
+
+## Non-goals (deliberately out — later slices)
+
+The `status/` module, SSE stream, subscribe migration, `sequence`/`fingerprint` rename — **`revision` still ships on the wire** (slice 3) · usage meters and the probe loop (slice 4) · cross-machine cooling reconciliation (future; the limit-hit event is its feedstock) · org-owned pools (phase 2).
+
+## Proof
+
+- `limit_error_marks_seat_cooling_until_reset` — observed limit error → cooling record with the carried reset time.
+- `all_seats_cooling_falls_back_with_reason` — pool exhausted: falls to gateway when present, else `AllSeatsCooling` naming the earliest reset.
+- `rotation_skips_cooling_and_round_robins` — three seats, one cooling: launches alternate over the two active in document order.
+- `rotate_toggle_off_pins_applied_seat` — toggle off: the applied seat serves even when a later seat is fresher; cooling still refuses.
+- Typed-reason exhaustiveness on the launch surface (no catch-all arm; adding a variant breaks compile).
+- Multi-seat contract-fixture pin, both sides; existing suites green throughout.
+
+## Discharges
+
+Delta rows: rotation flow · refusals-in-words (the `AGENT_ROUTE_SELECTION_MISSING` class). Build list: the "rotation" and "typed launch refusals" children of the seats-v1 spine item.

--- a/delivery/agent-auth/delivery-spec-slice-5-gateway-hygiene.md
+++ b/delivery/agent-auth/delivery-spec-slice-5-gateway-hygiene.md
@@ -1,0 +1,38 @@
+# Delivery specification — agent_auth slice 5: gateway hygiene (frozen)
+
+Chain position: slice 5 of the approved auth slice plan — **independent of slices 2–4**, runs off `main` any time. Evidence of record: the ai_gateway system spec ([specs/systems/ai_gateway/README.md](../../specs/systems/ai_gateway/README.md)) and the fence-enforcement table in [agent_auth §0](../../specs/systems/agent_auth/README.md) (merged #2252). Builders implement from this document without re-deriving the architecture. **Base branch: `main`.**
+
+## Intent
+
+The ai_gateway system's code matches its spec: its own folder, its own manifest, its own fences — and the two live operational gaps close (verification off; the signup-grant miss that left the founder org unfunded for 8 days). Zero behavior change in the split itself; the behavior changes are the verification enable, the codex model refresh, and the zero-grant alert.
+
+## Acceptance gate (the merge bar — performed by Pablo, or demonstrated to him from CI + a staging run)
+
+`server/proliferate/server/ai_gateway/` exists with its own MANIFEST and every gateway suite green across the move. A deliberately wrong config.yaml model entry gets flagged `verification_status=misconfigured` (with its delta) within the verification interval. A fresh signup on a new GitHub identity lands with a nonzero credit balance — no admin grant. Falsifier: any gateway suite skipped or weakened to get the move green, or a fence/manifest checker exception added.
+
+## Scope
+
+Spec sections of record: ai_gateway §0 census (the `⇒ ai_gateway` files) · §4 Structure (the final tree) · §3 Flow 5 (verification) · agent_auth §0 fence-enforcement table (the server fence file + store locks land here) · agent_auth §4 cell 1 (the recomposed remainder).
+
+- **The code split** (move-only, zero behavior): the gateway files out of `server/proliferate/server/agent_auth/` — enrollment, free_credits, budget, usage_import, topups, verification, migration, signup_hook, worker, and api.py's `/agent-gateway` routes — into `server/proliferate/server/ai_gateway/` with its own `MANIFEST.toml`. The agent_auth remainder recomposes into `vault.py` / `state_render.py` / `seats.py` / `selection_rules.py` / api.py per the spec's cell-1 tree. Import sites updated mechanically; `git log --follow` must survive (moves, not delete+create).
+- **Fence teeth** (the enforcement table's two server rows): `lints/server/fences.toml` — server domain-import fence on the anyharness record shape (shrink-only edge baseline, measured at introduction), enforced by extending `check_server_boundaries.py` or a sibling checker wired into the Repo-shape CI job; plus `NamedStoreBoundary` locks for the agent-auth vault (`api_keys`) and selection stores — credential-bearing symbols owner-locked to `agent_auth`/`ai_gateway` modules.
+- **Verification on**: flip `agent_gateway_verification_enabled` default to true now that config.yaml is settled (#2249); the loop records `verification_status` per enrollment key, `misconfigured` carries the delta `{reason, models}` onto the capabilities read.
+- **Codex model refresh**: the gpt-5.2-era entries in config.yaml (mirror of #2249's claude fix — the same 403 is waiting on codex's current default model).
+- **The signup-grant miss**: find why `ensure_signup_enrollment` → free-credits granting never ran for the founder org (the enrollment row existed; no `free_signup` grant row was ever created). Fix the hole, and add the guard: an enrollment older than one hour whose org has zero grant rows raises an ops alert (log-based is acceptable; a worker-loop check is the spec-shaped home). Backfill check: a one-off sweep listing any other zero-grant orgs in prod.
+- **MANIFEST + atlas**: `check_manifests` green with the new folder; the ownership-atlas OWNERSHIP table gains the `server/ai_gateway/` region (edit `scripts/ownership-atlas/generate.py`, regenerate).
+
+## Non-goals (deliberately out)
+
+Per-run keys and envelopes (open ruling — ai_magic stays on direct endpoints) · any Rust or frontend move (Wave 3/4) · the seat_usage tables (slice 4) · retiring the transitional delta tables (that happens at convergence, not here).
+
+## Proof
+
+- Every existing `test_agent_gateway_*` suite green **unmodified** across the move (the move is proven by the tests not noticing it).
+- `test_litellm_config_access_groups.py` still pins the reviewed config.yaml, extended over the codex entries.
+- A verification-loop integration test: wrong access-group model on a key → `misconfigured` + delta within one loop tick; corrected config → status clears.
+- A signup-path test proving the grant row lands in the same flow as the enrollment row (regression for the founder-org miss), plus the zero-grant guard's unit test.
+- `lints/server/fences.toml` baseline equals reality at introduction (checker self-test), and the vault-store lock rejects an out-of-owner import in the checker's unit tests.
+
+## Discharges
+
+ai_gateway's delta table: the folder/manifest row, the verification-default row, the codex-models row, the signup-gap build item — everything except per-run keys. agent_auth: the fence-teeth build item's first two steps (store locks + server fence file; the Rust node stays with Wave 3).


### PR DESCRIPTION
Freezes the next two delivery specs off the approved slice map (Auth Slices, ruled 2026-08-26):

- **Slice 2 — rotation & refusals** (stacked on `agent-auth-slice-1` / PR #2254): pool render, runtime round-robin + persisted cooling, the complete typed `LaunchRefusal` set with copy (the `AGENT_ROUTE_SELECTION_MISSING` class dies), limit-hit reporting, serving/next tags + rotate toggle. Transitional carry named explicitly: tags ride the existing local read path until slice 3's status document.
- **Slice 5 — gateway hygiene** (independent, off `main`): the ai_gateway code split + own MANIFEST, `lints/server/fences.toml` + vault-store `NamedStoreBoundary` locks (the fence-enforcement table's server rows, #2252), verification enabled, codex model refresh, and the signup-grant-miss fix with a zero-grant alert.

Each carries the Pablo-performed acceptance gate, exact scope, non-goals, proof tests, and the delta rows it discharges — implementation charters for independent runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)