### PR TITLE
feat(observability): runtime log homes + cloud JSON mode for worker, supervisor, anyharness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,6 +4370,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "file-rotate",
  "proliferate-runtime-update-protocol",
  "reqwest 0.12.28",
  "sentry",
@@ -4382,6 +4383,7 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -4392,6 +4394,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "file-rotate",
  "fs2",
  "proliferate-diagnostics-client",
  "proliferate-diagnostics-protocol",
@@ -4408,6 +4411,7 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -6881,6 +6885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6890,12 +6904,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-appender = "0.2.4"
 file-rotate = "0.8.0"
 sentry = { version = "0.48.2", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "release-health", "reqwest", "rustls"] }

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -33,10 +33,13 @@ use crate::{
     file_logging::create_file_log_sink,
 };
 
+mod log_format;
 mod scrub;
 mod session_tag;
 
 use session_tag::{session_id_for_event, SessionIdSpanLayer, SESSION_ID_SPAN_FIELD};
+
+use log_format::{log_format_from_env, LogFormat};
 
 const ANYHARNESS_TELEMETRY_MODE: &str = "hosted_product";
 const ANYHARNESS_RECORD_NAME_PREFIX: &str = "anyharness.";
@@ -315,7 +318,19 @@ pub fn init(command: &Commands, activation: DesktopDiagnosticsActivation) -> Tel
             }
         });
 
-    let console_layer = tracing_subscriber::fmt::layer().with_filter(env_filter_from_env());
+    // One format decision per process, applied to every fmt sink: JSON when a
+    // machine is the reader (cloud runtime env), human text locally.
+    let log_format = log_format_from_env();
+    let console_layer: Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync> = match log_format
+    {
+        LogFormat::Json => tracing_subscriber::fmt::layer()
+            .json()
+            .with_filter(env_filter_from_env())
+            .boxed(),
+        LogFormat::Text => tracing_subscriber::fmt::layer()
+            .with_filter(env_filter_from_env())
+            .boxed(),
+    };
 
     let (diagnostics_layer, diagnostics) = match installation {
         Some(installation) => {
@@ -341,10 +356,20 @@ pub fn init(command: &Commands, activation: DesktopDiagnosticsActivation) -> Tel
         .with(sentry_tracing::layer().event_mapper(sentry_event_mapper))
         .with(diagnostics_layer)
         .with(file_sink.as_ref().map(|sink| {
-            tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .with_writer(sink.writer.clone())
-                .with_filter(env_filter_from_env())
+            let layer: Box<dyn Layer<_> + Send + Sync> = match log_format {
+                LogFormat::Json => tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_ansi(false)
+                    .with_writer(sink.writer.clone())
+                    .with_filter(env_filter_from_env())
+                    .boxed(),
+                LogFormat::Text => tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(sink.writer.clone())
+                    .with_filter(env_filter_from_env())
+                    .boxed(),
+            };
+            layer
         }))
         .init();
 

--- a/anyharness/crates/anyharness/src/telemetry/log_format.rs
+++ b/anyharness/crates/anyharness/src/telemetry/log_format.rs
@@ -1,0 +1,69 @@
+//! Log output format selection (grafana-logging spec: "one record shape").
+//!
+//! Production log lines are read by machines (CloudWatch → Grafana), local
+//! lines are read by a person. The same decision applies to every sink a
+//! process installs. Mirrored in proliferate-worker and proliferate-supervisor —
+//! keep the three copies identical.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+/// Read the process-wide format decision from the environment.
+pub fn log_format_from_env() -> LogFormat {
+    decide(
+        std::env::var("PROLIFERATE_LOG_FORMAT").ok().as_deref(),
+        std::env::var("PROLIFERATE_RUNTIME_ENV").ok().as_deref(),
+    )
+}
+
+/// Pure decision: an explicit `PROLIFERATE_LOG_FORMAT` (`json` | `text`) wins;
+/// otherwise a non-`local` `PROLIFERATE_RUNTIME_ENV` (a cloud machine — the
+/// reader is a log pipeline, not a person) selects JSON, and local stays
+/// human-readable text. Unrecognized explicit values are ignored rather than
+/// trusted.
+pub fn decide(explicit: Option<&str>, runtime_env: Option<&str>) -> LogFormat {
+    match explicit.map(str::trim) {
+        Some("json") => return LogFormat::Json,
+        Some("text") => return LogFormat::Text,
+        _ => {}
+    }
+    match runtime_env.map(str::trim) {
+        None | Some("") | Some("local") => LogFormat::Text,
+        Some(_) => LogFormat::Json,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decide, LogFormat};
+
+    #[test]
+    fn local_and_unset_stay_text() {
+        assert_eq!(decide(None, None), LogFormat::Text);
+        assert_eq!(decide(None, Some("local")), LogFormat::Text);
+        assert_eq!(decide(None, Some("")), LogFormat::Text);
+        assert_eq!(decide(None, Some("  local  ")), LogFormat::Text);
+    }
+
+    #[test]
+    fn cloud_runtime_env_selects_json() {
+        assert_eq!(decide(None, Some("e2b")), LogFormat::Json);
+        assert_eq!(decide(None, Some("production")), LogFormat::Json);
+    }
+
+    #[test]
+    fn explicit_format_wins_over_runtime_env() {
+        assert_eq!(decide(Some("text"), Some("e2b")), LogFormat::Text);
+        assert_eq!(decide(Some("json"), Some("local")), LogFormat::Json);
+        assert_eq!(decide(Some("json"), None), LogFormat::Json);
+    }
+
+    #[test]
+    fn unrecognized_explicit_value_is_ignored() {
+        assert_eq!(decide(Some("yaml"), None), LogFormat::Text);
+        assert_eq!(decide(Some("yaml"), Some("e2b")), LogFormat::Json);
+    }
+}

--- a/anyharness/crates/proliferate-supervisor/Cargo.toml
+++ b/anyharness/crates/proliferate-supervisor/Cargo.toml
@@ -25,6 +25,8 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-appender.workspace = true
+file-rotate.workspace = true
 
 [dev-dependencies]
 sentry = { workspace = true, features = ["test"] }

--- a/anyharness/crates/proliferate-supervisor/src/config.rs
+++ b/anyharness/crates/proliferate-supervisor/src/config.rs
@@ -91,7 +91,7 @@ fn default_update_poll_interval_seconds() -> u64 {
     15
 }
 
-fn supervisor_state_dir() -> PathBuf {
+pub(crate) fn supervisor_state_dir() -> PathBuf {
     dirs_fallback_home().join(".proliferate").join("supervisor")
 }
 

--- a/anyharness/crates/proliferate-supervisor/src/logging.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging.rs
@@ -3,6 +3,12 @@ use std::sync::Arc;
 use sentry::protocol::{Breadcrumb, Event, Frame, Log, LogEntry, Stacktrace, Value};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
+mod file_sink;
+mod format;
+
+use file_sink::{create_file_log_sink, FileLogSink};
+use format::{log_format_from_env, LogFormat};
+
 const TARGET_SENTRY_DSN_ENV: &str = "PROLIFERATE_TARGET_SENTRY_DSN";
 const TARGET_SENTRY_ENVIRONMENT_ENV: &str = "PROLIFERATE_TARGET_SENTRY_ENVIRONMENT";
 // Component-specific emergency override. The shared
@@ -17,6 +23,7 @@ const RUNTIME_ENV_TAG: &str = "runtime_env";
 
 pub struct TelemetryGuards {
     _sentry: Option<sentry::ClientInitGuard>,
+    _file_log: Option<FileLogSink>,
 }
 
 fn env_or_default(key: &str, default: &str) -> String {
@@ -364,11 +371,50 @@ pub fn init() -> TelemetryGuards {
         ))
     });
 
-    let console_layer = tracing_subscriber::fmt::layer().with_filter(env_filter_from_env());
+    // One format decision per process, applied to every fmt sink: JSON when a
+    // machine is the reader (cloud runtime env), human text locally.
+    let log_format = log_format_from_env();
+    let console_layer: Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync> = match log_format
+    {
+        LogFormat::Json => tracing_subscriber::fmt::layer()
+            .json()
+            .with_filter(env_filter_from_env())
+            .boxed(),
+        LogFormat::Text => tracing_subscriber::fmt::layer()
+            .with_filter(env_filter_from_env())
+            .boxed(),
+    };
+    let file_log = match create_file_log_sink(&supervisor_log_path()) {
+        Ok(sink) => Some(sink),
+        Err(error) => {
+            eprintln!("[proliferate-supervisor] file logging disabled: {error}");
+            None
+        }
+    };
+    let file_layer = file_log.as_ref().map(|sink| {
+        let layer: Box<dyn Layer<_> + Send + Sync> = match log_format {
+            LogFormat::Json => tracing_subscriber::fmt::layer()
+                .json()
+                .with_ansi(false)
+                .with_writer(sink.writer.clone())
+                .with_filter(env_filter_from_env())
+                .boxed(),
+            LogFormat::Text => tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(sink.writer.clone())
+                .with_filter(env_filter_from_env())
+                .boxed(),
+        };
+        layer
+    });
     let _ = tracing_subscriber::registry()
         .with(console_layer)
         .with(sentry_tracing::layer())
+        .with(file_layer)
         .try_init();
+    if let Some(sink) = &file_log {
+        tracing::debug!(log_file = %sink.path.display(), "local file logging active");
+    }
 
     if telemetry.is_some() {
         sentry::configure_scope(|scope| {
@@ -400,7 +446,19 @@ pub fn init() -> TelemetryGuards {
         });
     }
 
-    TelemetryGuards { _sentry: telemetry }
+    TelemetryGuards {
+        _sentry: telemetry,
+        _file_log: file_log,
+    }
+}
+
+/// The supervisor's log home: `<state dir>/logs/supervisor.log`
+/// (`~/.proliferate/supervisor/logs/`). One known place per process so the
+/// local tail can interleave every runtime log.
+fn supervisor_log_path() -> std::path::PathBuf {
+    crate::config::supervisor_state_dir()
+        .join("logs")
+        .join("supervisor.log")
 }
 
 #[cfg(test)]

--- a/anyharness/crates/proliferate-supervisor/src/logging/file_sink.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging/file_sink.rs
@@ -1,0 +1,100 @@
+//! Rotating local log file sink. Master copy:
+//! `anyharness/crates/anyharness/src/file_logging.rs` — this is the same
+//! bounded writer (10 MiB × 5 rotations, non-blocking) so every runtime
+//! process leaves its logs in a known home for the local debugging story
+//! (grafana-logging spec: "the homes").
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
+use tracing_appender::{
+    non_blocking,
+    non_blocking::{NonBlocking, WorkerGuard},
+};
+
+const MAX_LOG_BYTES: usize = 10 * 1024 * 1024;
+const MAX_ROTATED_FILES: usize = 5;
+
+#[derive(Debug)]
+pub struct FileLogSink {
+    pub writer: NonBlocking,
+    pub _guard: WorkerGuard,
+    pub path: PathBuf,
+}
+
+fn build_rotating_writer(log_path: &Path) -> Result<FileRotate<AppendCount>, String> {
+    let Some(parent) = log_path.parent() else {
+        return Err(format!(
+            "Log path {} has no parent directory",
+            log_path.display()
+        ));
+    };
+
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("Failed to create {}: {error}", parent.display()))?;
+
+    Ok(FileRotate::new(
+        log_path,
+        AppendCount::new(MAX_ROTATED_FILES),
+        ContentLimit::Bytes(MAX_LOG_BYTES),
+        Compression::None,
+        None,
+    ))
+}
+
+pub fn create_file_log_sink(log_path: &Path) -> Result<FileLogSink, String> {
+    let writer = build_rotating_writer(log_path)?;
+    let (writer, guard) = non_blocking(writer);
+    Ok(FileLogSink {
+        writer,
+        _guard: guard,
+        path: log_path.to_path_buf(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path(file_name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("proliferate-supervisor-file-sink-{unique}"))
+            .join(file_name)
+    }
+
+    #[test]
+    fn rotating_writer_creates_file_on_first_write() {
+        let path = temp_path("supervisor.log");
+        let mut writer = build_rotating_writer(&path).expect("writer should be created");
+        writeln!(writer, "hello supervisor").expect("write should succeed");
+        writer.flush().expect("flush should succeed");
+
+        let contents = fs::read_to_string(&path).expect("log file should exist");
+        assert!(contents.contains("hello supervisor"));
+
+        fs::remove_dir_all(path.parent().expect("temp dir should exist"))
+            .expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn create_file_log_sink_errors_when_parent_is_not_directory() {
+        let parent = temp_path("blocked-parent");
+        fs::create_dir_all(parent.parent().expect("temp dir should exist"))
+            .expect("parent dir should exist");
+        fs::write(&parent, "not a dir").expect("blocking file should be created");
+        let log_path = parent.join("supervisor.log");
+
+        let error = create_file_log_sink(&log_path).expect_err("sink creation should fail");
+        assert!(error.contains("Failed to create"));
+
+        fs::remove_dir_all(parent.parent().expect("temp dir should exist"))
+            .expect("cleanup should succeed");
+    }
+}

--- a/anyharness/crates/proliferate-supervisor/src/logging/format.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging/format.rs
@@ -1,0 +1,69 @@
+//! Log output format selection (grafana-logging spec: "one record shape").
+//!
+//! Production log lines are read by machines (CloudWatch → Grafana), local
+//! lines are read by a person. The same decision applies to every sink a
+//! process installs. Mirrored in proliferate-worker and anyharness —
+//! keep the three copies identical.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+/// Read the process-wide format decision from the environment.
+pub fn log_format_from_env() -> LogFormat {
+    decide(
+        std::env::var("PROLIFERATE_LOG_FORMAT").ok().as_deref(),
+        std::env::var("PROLIFERATE_RUNTIME_ENV").ok().as_deref(),
+    )
+}
+
+/// Pure decision: an explicit `PROLIFERATE_LOG_FORMAT` (`json` | `text`) wins;
+/// otherwise a non-`local` `PROLIFERATE_RUNTIME_ENV` (a cloud machine — the
+/// reader is a log pipeline, not a person) selects JSON, and local stays
+/// human-readable text. Unrecognized explicit values are ignored rather than
+/// trusted.
+pub fn decide(explicit: Option<&str>, runtime_env: Option<&str>) -> LogFormat {
+    match explicit.map(str::trim) {
+        Some("json") => return LogFormat::Json,
+        Some("text") => return LogFormat::Text,
+        _ => {}
+    }
+    match runtime_env.map(str::trim) {
+        None | Some("") | Some("local") => LogFormat::Text,
+        Some(_) => LogFormat::Json,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decide, LogFormat};
+
+    #[test]
+    fn local_and_unset_stay_text() {
+        assert_eq!(decide(None, None), LogFormat::Text);
+        assert_eq!(decide(None, Some("local")), LogFormat::Text);
+        assert_eq!(decide(None, Some("")), LogFormat::Text);
+        assert_eq!(decide(None, Some("  local  ")), LogFormat::Text);
+    }
+
+    #[test]
+    fn cloud_runtime_env_selects_json() {
+        assert_eq!(decide(None, Some("e2b")), LogFormat::Json);
+        assert_eq!(decide(None, Some("production")), LogFormat::Json);
+    }
+
+    #[test]
+    fn explicit_format_wins_over_runtime_env() {
+        assert_eq!(decide(Some("text"), Some("e2b")), LogFormat::Text);
+        assert_eq!(decide(Some("json"), Some("local")), LogFormat::Json);
+        assert_eq!(decide(Some("json"), None), LogFormat::Json);
+    }
+
+    #[test]
+    fn unrecognized_explicit_value_is_ignored() {
+        assert_eq!(decide(Some("yaml"), None), LogFormat::Text);
+        assert_eq!(decide(Some("yaml"), Some("e2b")), LogFormat::Json);
+    }
+}

--- a/anyharness/crates/proliferate-worker/Cargo.toml
+++ b/anyharness/crates/proliferate-worker/Cargo.toml
@@ -29,6 +29,8 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-appender.workspace = true
+file-rotate.workspace = true
 proliferate-diagnostics-protocol.workspace = true
 
 [dev-dependencies]

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use proliferate_diagnostics_client::{
@@ -6,8 +7,12 @@ use proliferate_diagnostics_client::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
+mod file_sink;
+mod format;
 mod scrub;
 
+use file_sink::{create_file_log_sink, FileLogSink};
+use format::{log_format_from_env, LogFormat};
 use scrub::{scrub_breadcrumb, scrub_event, scrub_log};
 
 const TARGET_SENTRY_DSN_ENV: &str = "PROLIFERATE_TARGET_SENTRY_DSN";
@@ -26,6 +31,7 @@ const WORKER_RECORD_NAME_PREFIX: &str = "desktop_worker.";
 pub struct TelemetryGuards {
     _sentry: Option<sentry::ClientInitGuard>,
     diagnostics: Option<DiagnosticsProducerGuard>,
+    _file_log: Option<FileLogSink>,
 }
 
 impl TelemetryGuards {
@@ -144,12 +150,51 @@ pub fn init(activation: DesktopDiagnosticsActivation) -> TelemetryGuards {
         }
         None => (None, None),
     };
-    let console_layer = tracing_subscriber::fmt::layer().with_filter(env_filter_from_env());
+    // One format decision per process, applied to every fmt sink: JSON when a
+    // machine is the reader (cloud runtime env), human text locally.
+    let log_format = log_format_from_env();
+    let console_layer: Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync> = match log_format
+    {
+        LogFormat::Json => tracing_subscriber::fmt::layer()
+            .json()
+            .with_filter(env_filter_from_env())
+            .boxed(),
+        LogFormat::Text => tracing_subscriber::fmt::layer()
+            .with_filter(env_filter_from_env())
+            .boxed(),
+    };
+    let file_log = match create_file_log_sink(&worker_log_path()) {
+        Ok(sink) => Some(sink),
+        Err(error) => {
+            eprintln!("[proliferate-worker] file logging disabled: {error}");
+            None
+        }
+    };
+    let file_layer = file_log.as_ref().map(|sink| {
+        let layer: Box<dyn Layer<_> + Send + Sync> = match log_format {
+            LogFormat::Json => tracing_subscriber::fmt::layer()
+                .json()
+                .with_ansi(false)
+                .with_writer(sink.writer.clone())
+                .with_filter(env_filter_from_env())
+                .boxed(),
+            LogFormat::Text => tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(sink.writer.clone())
+                .with_filter(env_filter_from_env())
+                .boxed(),
+        };
+        layer
+    });
     let _ = tracing_subscriber::registry()
         .with(console_layer)
         .with(sentry_tracing::layer())
         .with(diagnostics_layer)
+        .with(file_layer)
         .try_init();
+    if let Some(sink) = &file_log {
+        tracing::debug!(log_file = %sink.path.display(), "local file logging active");
+    }
 
     if telemetry.is_some() {
         sentry::configure_scope(|scope| {
@@ -184,7 +229,20 @@ pub fn init(activation: DesktopDiagnosticsActivation) -> TelemetryGuards {
     TelemetryGuards {
         _sentry: telemetry,
         diagnostics,
+        _file_log: file_log,
     }
+}
+
+/// The worker's log home: `<home>/.proliferate/worker/logs/worker.log`,
+/// beside its config (`default_config_path`). One known place per process
+/// so the local tail can interleave every runtime log.
+fn worker_log_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".proliferate")
+        .join("worker")
+        .join("logs")
+        .join("worker.log")
 }
 
 /// Record naming for this component: no rewritten targets, so every
@@ -279,6 +337,55 @@ mod tests {
     fn sentry_user_absent_for_blank_or_missing() {
         assert!(sentry_user_from_id(None).is_none());
         assert!(sentry_user_from_id(Some("   ")).is_none());
+    }
+
+    #[test]
+    fn json_mode_emits_one_parseable_json_line_per_event() {
+        // Cloud mode's contract with CloudWatch/Grafana (grafana-logging
+        // spec): one event = one JSON line, fields addressable by name. A
+        // machine reader must never have to parse human text.
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().expect("buffer lock").extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let writer = buffer.clone();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_ansi(false)
+                .with_writer(move || writer.clone()),
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(
+                session_id = "0191d1f0-0000-7000-8000-000000000000",
+                outcome = "succeeded",
+                "json mode probe"
+            );
+        });
+
+        let bytes = buffer.0.lock().expect("buffer lock").clone();
+        let text = String::from_utf8(bytes).expect("utf8 log output");
+        let line = text.lines().next().expect("one log line emitted");
+        let value: serde_json::Value = serde_json::from_str(line).expect("log line parses as JSON");
+        let fields = &value["fields"];
+        assert_eq!(fields["message"], "json mode probe");
+        assert_eq!(fields["session_id"], "0191d1f0-0000-7000-8000-000000000000");
+        assert_eq!(fields["outcome"], "succeeded");
+        assert!(value["timestamp"].is_string(), "timestamp present");
+        assert_eq!(value["level"], "INFO");
     }
 
     #[test]

--- a/anyharness/crates/proliferate-worker/src/logging/file_sink.rs
+++ b/anyharness/crates/proliferate-worker/src/logging/file_sink.rs
@@ -1,0 +1,100 @@
+//! Rotating local log file sink. Master copy:
+//! `anyharness/crates/anyharness/src/file_logging.rs` — this is the same
+//! bounded writer (10 MiB × 5 rotations, non-blocking) so every runtime
+//! process leaves its logs in a known home for the local debugging story
+//! (grafana-logging spec: "the homes").
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
+use tracing_appender::{
+    non_blocking,
+    non_blocking::{NonBlocking, WorkerGuard},
+};
+
+const MAX_LOG_BYTES: usize = 10 * 1024 * 1024;
+const MAX_ROTATED_FILES: usize = 5;
+
+#[derive(Debug)]
+pub struct FileLogSink {
+    pub writer: NonBlocking,
+    pub _guard: WorkerGuard,
+    pub path: PathBuf,
+}
+
+fn build_rotating_writer(log_path: &Path) -> Result<FileRotate<AppendCount>, String> {
+    let Some(parent) = log_path.parent() else {
+        return Err(format!(
+            "Log path {} has no parent directory",
+            log_path.display()
+        ));
+    };
+
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("Failed to create {}: {error}", parent.display()))?;
+
+    Ok(FileRotate::new(
+        log_path,
+        AppendCount::new(MAX_ROTATED_FILES),
+        ContentLimit::Bytes(MAX_LOG_BYTES),
+        Compression::None,
+        None,
+    ))
+}
+
+pub fn create_file_log_sink(log_path: &Path) -> Result<FileLogSink, String> {
+    let writer = build_rotating_writer(log_path)?;
+    let (writer, guard) = non_blocking(writer);
+    Ok(FileLogSink {
+        writer,
+        _guard: guard,
+        path: log_path.to_path_buf(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path(file_name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("proliferate-worker-file-sink-{unique}"))
+            .join(file_name)
+    }
+
+    #[test]
+    fn rotating_writer_creates_file_on_first_write() {
+        let path = temp_path("worker.log");
+        let mut writer = build_rotating_writer(&path).expect("writer should be created");
+        writeln!(writer, "hello worker").expect("write should succeed");
+        writer.flush().expect("flush should succeed");
+
+        let contents = fs::read_to_string(&path).expect("log file should exist");
+        assert!(contents.contains("hello worker"));
+
+        fs::remove_dir_all(path.parent().expect("temp dir should exist"))
+            .expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn create_file_log_sink_errors_when_parent_is_not_directory() {
+        let parent = temp_path("blocked-parent");
+        fs::create_dir_all(parent.parent().expect("temp dir should exist"))
+            .expect("parent dir should exist");
+        fs::write(&parent, "not a dir").expect("blocking file should be created");
+        let log_path = parent.join("worker.log");
+
+        let error = create_file_log_sink(&log_path).expect_err("sink creation should fail");
+        assert!(error.contains("Failed to create"));
+
+        fs::remove_dir_all(parent.parent().expect("temp dir should exist"))
+            .expect("cleanup should succeed");
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/logging/format.rs
+++ b/anyharness/crates/proliferate-worker/src/logging/format.rs
@@ -1,0 +1,69 @@
+//! Log output format selection (grafana-logging spec: "one record shape").
+//!
+//! Production log lines are read by machines (CloudWatch → Grafana), local
+//! lines are read by a person. The same decision applies to every sink a
+//! process installs. Mirrored in proliferate-supervisor and anyharness —
+//! keep the three copies identical.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+/// Read the process-wide format decision from the environment.
+pub fn log_format_from_env() -> LogFormat {
+    decide(
+        std::env::var("PROLIFERATE_LOG_FORMAT").ok().as_deref(),
+        std::env::var("PROLIFERATE_RUNTIME_ENV").ok().as_deref(),
+    )
+}
+
+/// Pure decision: an explicit `PROLIFERATE_LOG_FORMAT` (`json` | `text`) wins;
+/// otherwise a non-`local` `PROLIFERATE_RUNTIME_ENV` (a cloud machine — the
+/// reader is a log pipeline, not a person) selects JSON, and local stays
+/// human-readable text. Unrecognized explicit values are ignored rather than
+/// trusted.
+pub fn decide(explicit: Option<&str>, runtime_env: Option<&str>) -> LogFormat {
+    match explicit.map(str::trim) {
+        Some("json") => return LogFormat::Json,
+        Some("text") => return LogFormat::Text,
+        _ => {}
+    }
+    match runtime_env.map(str::trim) {
+        None | Some("") | Some("local") => LogFormat::Text,
+        Some(_) => LogFormat::Json,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decide, LogFormat};
+
+    #[test]
+    fn local_and_unset_stay_text() {
+        assert_eq!(decide(None, None), LogFormat::Text);
+        assert_eq!(decide(None, Some("local")), LogFormat::Text);
+        assert_eq!(decide(None, Some("")), LogFormat::Text);
+        assert_eq!(decide(None, Some("  local  ")), LogFormat::Text);
+    }
+
+    #[test]
+    fn cloud_runtime_env_selects_json() {
+        assert_eq!(decide(None, Some("e2b")), LogFormat::Json);
+        assert_eq!(decide(None, Some("production")), LogFormat::Json);
+    }
+
+    #[test]
+    fn explicit_format_wins_over_runtime_env() {
+        assert_eq!(decide(Some("text"), Some("e2b")), LogFormat::Text);
+        assert_eq!(decide(Some("json"), Some("local")), LogFormat::Json);
+        assert_eq!(decide(Some("json"), None), LogFormat::Json);
+    }
+
+    #[test]
+    fn unrecognized_explicit_value_is_ignored() {
+        assert_eq!(decide(Some("yaml"), None), LogFormat::Text);
+        assert_eq!(decide(Some("yaml"), Some("e2b")), LogFormat::Json);
+    }
+}


### PR DESCRIPTION
Block-2 logging ruling, runtime half: **every process writes to a known home; machines read JSON, people read text.**

- **Worker + supervisor file sinks** (new): bounded rotating files (10 MiB × 5, non-blocking) at `~/.proliferate/worker/logs/worker.log` and `~/.proliferate/supervisor/logs/supervisor.log`. Before this, both processes logged to console only — their logs vanished on exit, and the local one-tail-per-session story had two holes.
- **Cloud JSON mode**: one format decision per process applied to every fmt sink — explicit `PROLIFERATE_LOG_FORMAT` (json|text) wins; otherwise non-local `PROLIFERATE_RUNTIME_ENV` (e.g. `e2b`) ⇒ JSON, local ⇒ human text. Applied to anyharness's console + file layers too.
- `tracing-subscriber` workspace dep gains the `json` feature (adds `tracing-serde` to the lock).
- The format/file-sink modules are deliberate mirrored copies in worker + supervisor (master: `anyharness/src/file_logging.rs`), following the repo's per-crate scrub-module precedent.

**Pins**: `json_mode_emits_one_parseable_json_line_per_event` (fields addressable by name — the CloudWatch/Grafana contract), pure `decide()` table, file-sink create-on-write + error paths. Worker 51 green, supervisor 46 green, anyharness builds clean.

**Observability delta:** cloud runtime stdout becomes CloudWatch-parseable JSON carrying whatever correlation fields the event has; the local tail gains its two missing homes.

Note: ~19 files of pre-existing rustfmt drift under the local toolchain were deliberately left untouched (same as #2255–#2258 observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)