### PR TITLE
ci(staging): auto-deploy green main to staging — doctrine tests pin the new law

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,9 +1,15 @@
-# Manual-only staging. Merging to main deploys nothing: the one automated
-# transition is `release.yml` (main to production). Staging is an optional
-# proving ground an operator dispatches on purpose.
+# Staging deploys automatically from green main: a `CI` run that completes
+# successfully on main fires this workflow at that run's exact head commit
+# (the plan job still waits for Server CI on that SHA, so both rollups gate).
+# Operators keep workflow_dispatch for reruns, forced surfaces, and dry runs.
+# Production is untouched by this path: release.yml stays its only entrypoint.
 name: Deploy Staging
 
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:
@@ -39,6 +45,9 @@ env:
 
 jobs:
   plan:
+    # Auto runs deploy only what CI proved: a workflow_run event that is not a
+    # success plans nothing (every downstream job needs plan's success).
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.detect.outputs.base_sha }}
@@ -60,7 +69,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || github.sha }}
+          # Dispatch: the operator's ref (or the dispatch SHA). Auto: the exact
+          # commit the triggering CI run proved green.
+          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_sha || github.sha }}
 
       - name: Resolve deploy metadata
         id: meta
@@ -145,14 +156,18 @@ jobs:
           --force "$FORCE_SURFACES"
           --only "$ONLY_SURFACES"
         env:
-          FORCE_SURFACES: ${{ github.event.inputs.force_surfaces || '' }}
+          # A staleness fallback (no resolvable prior deploy) must deploy the
+          # full surface set, not head^-diff to a near-no-op — unless the
+          # operator explicitly chose surfaces.
+          FORCE_SURFACES: ${{ github.event.inputs.force_surfaces || (steps.base.outputs.base_mode == 'fallback' && 'all') || '' }}
           ONLY_SURFACES: ${{ github.event.inputs.only_surfaces || '' }}
 
       - name: Summarize plan
         run: |
           {
             echo "### Staging deploy plan"
-            echo "- Base: \`${{ steps.detect.outputs.base_sha }}\`"
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- Base: \`${{ steps.detect.outputs.base_sha }}\` (\`${{ steps.base.outputs.base_mode }}\`)"
             echo "- Head: \`${{ steps.detect.outputs.head_sha }}\`"
             echo "- Changed files: \`${{ steps.detect.outputs.changed_files_count }}\`"
             echo "- Dry run: \`${{ steps.meta.outputs.dry_run }}\`"

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -37,17 +37,42 @@ const MAIN_BRANCH_FILTER = /branches:\s*(?:\[[^\]]*\bmain\b[^\]]*\]|(?:\r?\n\s*-
 // deploy-environment casing test below.
 const PRODUCTION_ENVIRONMENT = /environment:\s*["']?[Pp]roduction["']?/;
 
-test("staging runs only when an operator dispatches it", () => {
+test("staging deploys from green main and from an operator", () => {
   const triggers = triggerBlock(workflow, "deploy-staging.yml");
 
-  assert.match(triggers, /^on:\n  workflow_dispatch:$/m);
-  assert.doesNotMatch(triggers, /workflow_run:/);
+  // The one automated transition: a completed `CI` run on main.
+  assert.match(
+    triggers,
+    /workflow_run:\n    workflows: \["CI"\]\n    types: \[completed\]\n    branches: \[main\]/,
+  );
+  // Operators keep dispatch for reruns, forced surfaces, and dry runs.
+  assert.match(triggers, /workflow_dispatch:/);
   assert.doesNotMatch(triggers, /\bpush:/);
   assert.doesNotMatch(triggers, /\bschedule:/);
+
+  // Auto runs deploy only what CI proved: the plan job refuses non-success
+  // conclusions, and the checkout pins the triggering run's exact head SHA.
+  assert.match(
+    workflow,
+    /github\.event_name != 'workflow_run' \|\| github\.event\.workflow_run\.conclusion == 'success'/,
+  );
+  assert.match(
+    workflow,
+    /ref: \$\{\{ github\.event\.inputs\.ref \|\| github\.event\.workflow_run\.head_sha \|\| github\.sha \}\}/,
+  );
+
+  // Latest-wins staggering: one running plus one pending, never cancel a
+  // deploy mid-roll.
   assert.match(workflow, /^  cancel-in-progress: false$/m);
+
+  // A staleness fallback deploys everything unless the operator chose surfaces.
+  assert.match(
+    workflow,
+    /FORCE_SURFACES: \$\{\{ github\.event\.inputs\.force_surfaces \|\| \(steps\.base\.outputs\.base_mode == 'fallback' && 'all'\) \|\| '' \}\}/,
+  );
 });
 
-test("merging to main deploys nothing", () => {
+test("deploy-staging is the only workflow that auto-deploys from main", () => {
   const automatic = [];
   for (const name of workflowNames()) {
     const source = read(name);
@@ -60,7 +85,9 @@ test("merging to main deploys nothing", () => {
     }
   }
 
-  assert.deepEqual(automatic, []);
+  // Staging is the sanctioned automatic transition; production reaches a
+  // deploy lane only through release.yml's cron/dispatch (pinned below).
+  assert.deepEqual(automatic, ["deploy-staging.yml"]);
 });
 
 test("release.yml is the only entrypoint into a production deploy lane", () => {

--- a/scripts/ci-cd/resolve-deploy-base.mjs
+++ b/scripts/ci-cd/resolve-deploy-base.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 import {
   listSuccessfulWorkflowRuns,
@@ -71,12 +72,24 @@ function fallbackSha(parsed) {
   return parsed.fallback || parsed.head;
 }
 
-function writeGithubOutput(baseSha) {
+// The resolution contract: a real prior deploy yields `resolved`; every other
+// path (no token, no candidate run, no live artifact) is a `fallback` and the
+// caller must treat the base as unreliable — deploy-staging.yml forces the full
+// surface set on fallback so a long-idle environment cannot head^-diff to a
+// near-no-op.
+export function resolutionOutputs(deployHeadSha, parsed) {
+  if (deployHeadSha) {
+    return { baseSha: deployHeadSha, baseMode: "resolved" };
+  }
+  return { baseSha: fallbackSha(parsed), baseMode: "fallback" };
+}
+
+function writeGithubOutput(baseSha, baseMode) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) {
     return;
   }
-  fs.appendFileSync(outputPath, `base_sha=${baseSha}\n`);
+  fs.appendFileSync(outputPath, `base_sha=${baseSha}\nbase_mode=${baseMode}\n`);
 }
 
 async function resolveCandidateDeployHeadSha(candidate, artifactName, token) {
@@ -111,8 +124,9 @@ async function main() {
 
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
-    const baseSha = fallbackSha(parsed);
-    writeGithubOutput(baseSha);
+    const { baseSha, baseMode } = resolutionOutputs("", parsed);
+    writeGithubOutput(baseSha, baseMode);
+    console.error(`base_mode=${baseMode} (no token)`);
     console.log(baseSha);
     return;
   }
@@ -160,9 +174,12 @@ async function main() {
     );
   }
 
-  const baseSha = run?.deployHeadSha || fallbackSha(parsed);
-  writeGithubOutput(baseSha);
+  const { baseSha, baseMode } = resolutionOutputs(run?.deployHeadSha || "", parsed);
+  writeGithubOutput(baseSha, baseMode);
+  console.error(`base_mode=${baseMode}`);
   console.log(baseSha);
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/ci-cd/resolve-deploy-base.test.mjs
+++ b/scripts/ci-cd/resolve-deploy-base.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { resolutionOutputs } from "./resolve-deploy-base.mjs";
+
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "resolve-deploy-base.mjs",
+);
+
+// The output contract deploy-staging.yml's plan job builds on: `base_mode` is
+// `resolved` only when a real prior deploy's head SHA was recovered; every
+// other path is `fallback`, and the workflow then forces the full surface set
+// so a long-idle environment cannot head^-diff its deploy down to a no-op.
+
+test("a recovered prior deploy resolves", () => {
+  const { baseSha, baseMode } = resolutionOutputs("abc123", {
+    fallback: "fff000",
+    head: "head99",
+  });
+  assert.equal(baseSha, "abc123");
+  assert.equal(baseMode, "resolved");
+});
+
+test("no recovered deploy falls back to --fallback, then --head", () => {
+  assert.deepEqual(resolutionOutputs("", { fallback: "fff000", head: "head99" }), {
+    baseSha: "fff000",
+    baseMode: "fallback",
+  });
+  assert.deepEqual(resolutionOutputs("", { fallback: "", head: "head99" }), {
+    baseSha: "head99",
+    baseMode: "fallback",
+  });
+});
+
+test("the CLI writes base_sha and base_mode to GITHUB_OUTPUT on the token-less path", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "resolve-deploy-base-"));
+  const outputPath = path.join(dir, "output");
+  try {
+    const env = { ...process.env, GITHUB_OUTPUT: outputPath };
+    delete env.GITHUB_TOKEN;
+    delete env.GH_TOKEN;
+    execFileSync(
+      process.execPath,
+      [scriptPath, "--workflow", "deploy-staging.yml", "--head", "head99", "--fallback", "fff000"],
+      { env, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    assert.equal(readFileSync(outputPath, "utf8"), "base_sha=fff000\nbase_mode=fallback\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Implements the frozen delivery spec `delivery/testing-cicd/delivery-spec-staging-pipeline.md` (#2267) — the first implementation slice of the 2026-08-26 testing/linting/ci-cd alignment. Supersedes #2140's manual-only-staging doctrine, deliberately: the same tests that enforced the old law now pin the new one.

## Scope summary

- **`deploy-staging.yml`**: `workflow_run` on `CI` `completed` @ `main` added beside the kept `workflow_dispatch`; the plan job refuses non-success conclusions; auto runs check out and deploy `workflow_run.head_sha` — the exact commit CI proved. The existing Server CI wait stays, so **both rollups green-gate the deploy**. Concurrency unchanged (`cancel-in-progress: false`): GitHub's one-running-one-pending semantics give latest-wins without ever cancelling mid-roll. Header doctrine comment rewritten.
- **`resolve-deploy-base.mjs`**: emits `base_mode=resolved|fallback` alongside `base_sha` (base selection behavior unchanged); pure helper exported; CLI main guarded for importability.
- **Staleness fix**: when `base_mode == 'fallback'` and the operator forced nothing, surface detection runs with `--force all` — a long-idle staging deploys the **full surface set** instead of head^-diffing to a near-no-op (audit gap 5).
- **`deploy-staging-trigger.test.mjs`**: the two doctrine tests rewritten — (1) staging deploys from green main and from an operator (trigger shape, success guard, head-SHA pin, latest-wins, fallback-forces-all all pinned); (2) the workflow-scan now asserts the automatic-deploy set equals exactly `[deploy-staging.yml]`. `release.yml is the only entrypoint into a production deploy lane` and `staging never targets the production environment` stay verbatim — **prod paths byte-untouched**.
- **New `resolve-deploy-base.test.mjs`**: the `base_mode` output contract (resolved / fallback precedence / token-less CLI path via GITHUB_OUTPUT).

## Acceptance gate (verbatim from the frozen spec — performed by Pablo)

> Merge any PR to main; once `CI` and `Server CI` complete green on that commit, **within ~25 minutes `https://staging-app.proliferate.com/api/health` reports the new version — with nobody dispatching anything**. Falsifier: the version is unchanged after green CI · a staging deploy fires from a red or unfinished main · any production surface is touched by the staging path. Secondary: after a long-idle period the next auto-deploy still deploys the full surface set.

## Live proof so far

The operational unfreeze (manual dispatch path, run 33046464376) completed tonight: staging serves `{"status":"ok","version":"0.4.28"}` — current main — after six days frozen at 0.4.23. The first `workflow_run`-triggered deploy will be recorded here after this merges and the next green main lands.

## Verification

- `node --test scripts/ci-cd/*.test.mjs` — **202/202 pass** (199 prior + 3 new)
- `ruby YAML.load_file` on the workflow — parses
- `node --check` on both touched scripts — clean
- No docs touched; no prod workflow touched

## Findings triage (inline adversarial pass — a fresh-context refuter could not be spawned from this fork; flagging per the review law that this is a fallback, not a pass)

| # | Concern hunted | Outcome |
|---|---|---|
| 1 | `github.event.inputs.*` on `workflow_run` events | Empty → expressions fall through to `head_sha` / `'false'` defaults correctly; pinned by test |
| 2 | Skipped-plan auto runs (CI red) polluting base resolution | A skipped run uploads **no** `deploy-summary-staging` artifact, and `--required-artifact` already excludes artifact-less candidates — cannot become a false base |
| 3 | Server CI red on the same commit | The kept wait step fails the plan → nothing deploys; the red is visible on the deploy run |
| 4 | Concurrency pile-up under rapid merges | One running + newest pending; older pending superseded (latest-wins); in-flight never cancelled |
| 5 | `base_mode` expression precedence | Operator `force_surfaces` > fallback-forces-all > empty; literal string pinned by test |
| 6 | Import guard breaking the CLI under `node --check`/`--test` | Guard on `import.meta.url === pathToFileURL(argv[1])`; CLI path verified by the subprocess test |

Residual noted: the 45-min Server CI wait can expire on a badly backed-up queue → visible red deploy run; re-dispatch recovers. Desktop lane stays `dry_run: true` (non-goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)