### PR TITLE
fix(ci): staging auto-deploy trusts only pushes to this repo's main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,8 +36,10 @@ permissions:
   id-token: write
 
 concurrency:
-  # One staging deploy at a time, and never cancel one mid-roll.
-  group: deploy-staging-${{ github.repository }}
+  # One staging deploy at a time, and never cancel one mid-roll. Events that
+  # cannot deploy (a red CI, or a non-push trigger) get their own group so they
+  # never contend for — or cancel — a pending real deploy.
+  group: deploy-staging-${{ github.repository }}-${{ (github.event_name == 'workflow_run' && (github.event.workflow_run.conclusion != 'success' || github.event.workflow_run.event != 'push')) && github.run_id || 'main' }}
   cancel-in-progress: false
 
 env:
@@ -45,9 +47,12 @@ env:
 
 jobs:
   plan:
-    # Auto runs deploy only what CI proved: a workflow_run event that is not a
-    # success plans nothing (every downstream job needs plan's success).
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Auto runs deploy only what CI proved ON MAIN IN THIS REPOSITORY: the
+    # workflow_run `branches:` filter matches the triggering run's head branch,
+    # which a fork PR can name `main`, so a success from any event other than a
+    # push to this repo's main plans nothing (every downstream job needs plan's
+    # success). This is the trust boundary; never relax it.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.head_repository.full_name == github.repository) }}
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.detect.outputs.base_sha }}

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -50,11 +50,20 @@ test("staging deploys from green main and from an operator", () => {
   assert.doesNotMatch(triggers, /\bpush:/);
   assert.doesNotMatch(triggers, /\bschedule:/);
 
-  // Auto runs deploy only what CI proved: the plan job refuses non-success
-  // conclusions, and the checkout pins the triggering run's exact head SHA.
+  // Auto runs deploy only what CI proved ON THIS REPO'S MAIN: the plan job
+  // refuses non-success conclusions AND anything that is not a push to main
+  // from this repository (the workflow_run branch filter matches a fork PR's
+  // head branch named `main`, which would otherwise auto-deploy fork code with
+  // inherited secrets). The checkout pins the triggering run's exact head SHA.
   assert.match(
     workflow,
-    /github\.event_name != 'workflow_run' \|\| github\.event\.workflow_run\.conclusion == 'success'/,
+    /github\.event_name != 'workflow_run' \|\| \(github\.event\.workflow_run\.conclusion == 'success' && github\.event\.workflow_run\.event == 'push' && github\.event\.workflow_run\.head_branch == 'main' && github\.event\.workflow_run\.head_repository\.full_name == github\.repository\)/,
+  );
+  // Non-deployable events (red CI, non-push triggers) never share the deploy
+  // concurrency group, so they cannot cancel a pending real deploy.
+  assert.match(
+    workflow,
+    /group: deploy-staging-\$\{\{ github\.repository \}\}-\$\{\{ \(github\.event_name == 'workflow_run' && \(github\.event\.workflow_run\.conclusion != 'success' \|\| github\.event\.workflow_run\.event != 'push'\)\) && github\.run_id \|\| 'main' \}\}/,
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
Hot-patch for two post-merge refuter findings on #2269 (frozen spec: `delivery/testing-cicd/delivery-spec-staging-pipeline.md`, #2267). Implements the spec's falsifier *"a staging deploy fires from unfinished main"* as a mechanical guard.

**BLOCKER — trust boundary.** `workflow_run`'s `branches: [main]` filter matches the *triggering run's head branch*. A fork PR whose branch is named `main` produces a green `CI` run with `head_branch: main`, and on this public repo (70 forks, first-time-contributor approval only, no `staging` environment protection) that would auto-deploy unmerged fork code into staging ECS with inherited secrets and OIDC. The plan job's guard now requires `conclusion == 'success' && event == 'push' && head_branch == 'main' && head_repository.full_name == github.repository`.

**MAJOR — concurrency contention.** Non-deployable `workflow_run` events (red CI, non-push triggers) entered the single deploy concurrency group and cancelled *pending green* deploys — reproduced live in the first auto-fire batch at 06:59Z. Such events now get a per-run group, so they never contend.

## Testing
- workflow YAML parses (ruby)
- `node --test scripts/ci-cd/*.test.mjs`: 202/202 — the doctrine test now pins both the four-clause guard and the isolated concurrency group.

## Not in this PR (handed to staging-pipeline follow-up r2)
Refuter findings 2 (latest-wins by CI-completion order → regression guard + newest-proven-SHA), 4 (Server CI as second trigger), 5 (porous doctrine scan), 6 (pin the Server CI wait), 7 (run-name), 8 (release.yml header doctrine), 9 (LiteLLM task-def digest pin).

## Review
Coordinator hot-patch of a live exposure; the refuter that found it is the independent review (full report in the fleet ledger, Vault/Testing Linting CICD/51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)