### PR TITLE
feat(ci): the pre-push gate (make gate) + format-on-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
           python3 -m unittest scripts/test_check_docs.py
           python3 scripts/check_docs.py
 
+      # The pre-push gate's scoping logic + its mirror-rule pins (every gate
+      # command string must appear in the workflow that runs it in CI).
+      - name: Test the pre-push gate
+        run: python3 -m unittest scripts/test_gate.py
+
   terraform-validate:
     name: Terraform validate (server/infra)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ endif
         server-db-down server-db-ready server-redis-up server-redis-wait server-redis-down server-redis-ready \
         server-background-up server-background-logs server-background-down \
         server-litellm-up server-litellm-wait server-litellm-down db db-local db-ah server-migrate serve install git-hooks \
-        check check-max-lines check-server-boundaries test test-server fmt clippy \
+        gate check check-max-lines check-server-boundaries test test-server fmt clippy \
         sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build web-build desktop-build build-frontend build dev-build rebuild \
         desktop-test-build release-desktop-dry-run release-desktop-draft \
         test-agent-spec test-agent-runtime-local test-agent-local-fast test-agent-local \

--- a/Makefile
+++ b/Makefile
@@ -1419,9 +1419,16 @@ install: git-hooks
 
 # Point git at the checked-in hooks. Idempotent, safe to re-run, and local to
 # this clone/worktree (never committed state). See guides/local/README.md.
+# The pre-push gate: change-scoped local mirror of the merge gate
+# (delivery/testing-cicd/delivery-spec-make-gate.md). `make gate` by hand or
+# via the pre-push hook; `python3 scripts/gate --list` shows what a diff selects.
+gate:
+	@python3 scripts/gate
+
 git-hooks:
 	@git config core.hooksPath scripts/git-hooks
-	@echo "git hooks enabled (core.hooksPath=scripts/git-hooks); bypass a single commit with --no-verify."
+	@echo "git hooks enabled (core.hooksPath=scripts/git-hooks): pre-commit formats staged files, pre-push runs 'make gate'."
+	@echo "escape hatch: PROLIFERATE_SKIP_HOOKS=1"
 
 # --- Sidecar staging ---
 

--- a/scripts/gate
+++ b/scripts/gate
@@ -112,6 +112,13 @@ SERVER_TEST_ENV = {
 }
 
 CARGO_FMT = "cargo fmt --check"
+# Mirrors ci.yml § "CI/CD config checks" — the node test suites that pin the
+# workflows and release tooling.
+CICD_CONFIG_TESTS: tuple[tuple[str, str], ...] = (
+    ("ci-cd config tests", "node --test scripts/ci-cd/*.test.mjs"),
+    ("ops script tests", "node --test scripts/ops/*.test.mjs"),
+    ("dev-launch test", "node --test scripts/dev-background-launch.test.mjs"),
+)
 
 SHARED_TYPECHECK = "pnpm shared:typecheck"
 WEB_TYPECHECK = "pnpm web:typecheck"
@@ -139,9 +146,12 @@ class Scope:
 
     server: bool = False
     server_domains: set[str] = field(default_factory=set)
+    server_changed_tests: list[str] = field(default_factory=list)
     rust_paths: list[str] = field(default_factory=list)
     rust_workspace: bool = False
     scripts: bool = False
+    cicd: bool = False
+    unmapped: list[str] = field(default_factory=list)
     shared_frontend: bool = False
     product_client_srcs: list[str] = field(default_factory=list)
     design: bool = False
@@ -156,45 +166,65 @@ class Scope:
         return self.shared_frontend or self.web or self.desktop or self.mobile
 
 
+ROOT_FRONTEND_MANIFESTS = ("package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml")
+
+
 def classify(paths: list[str]) -> Scope:
     scope = Scope()
     for p in paths:
+        hit = False
         parts = p.split("/")
         if p.startswith("server/"):
-            scope.server = True
+            hit = scope.server = True
             if p.startswith("server/proliferate/server/") and len(parts) >= 4:
                 domain = parts[3]
                 if domain == "cloud" and len(parts) >= 5 and not parts[4].endswith(".py"):
                     scope.server_domains.add(parts[4])
                 elif not domain.endswith(".py"):
                     scope.server_domains.add(domain)
+            if (
+                p.startswith(("server/tests/unit/", "server/tests/integration/"))
+                and parts[-1].startswith("test_")
+                and p.endswith(".py")
+            ):
+                scope.server_changed_tests.append(p.removeprefix("server/"))
         if p.endswith(".rs") or (
             p.startswith(("anyharness/crates/", "apps/desktop/src-tauri/"))
             and not p.endswith((".ts", ".tsx", ".json", ".md"))
         ):
+            hit = True
             scope.rust_paths.append(p)
         if p in ("Cargo.toml", "Cargo.lock"):
-            scope.rust_workspace = True
+            hit = scope.rust_workspace = True
         if p.startswith("scripts/") and (p.endswith(".py") or parts[-1] == "gate"):
-            scope.scripts = True
+            hit = scope.scripts = True
+        if p.startswith("scripts/") and p.endswith(".mjs"):
+            hit = scope.cicd = True
+        if p in ROOT_FRONTEND_MANIFESTS or (len(parts) == 1 and p.startswith("tsconfig")):
+            # A dependency/workspace-graph change: the shared typecheck is the canary.
+            hit = scope.shared_frontend = True
         if p.startswith("apps/packages/") or p.startswith("cloud/sdk"):
-            scope.shared_frontend = True
+            hit = scope.shared_frontend = True
         if p.startswith("apps/packages/product-client/src/"):
             scope.product_client_srcs.append(p)
         if p.startswith("apps/packages/design/"):
             scope.design = True
         if p.startswith("apps/web/"):
-            scope.web = True
+            hit = scope.web = True
         if p.startswith("apps/desktop/") and not p.startswith("apps/desktop/src-tauri/"):
-            scope.desktop = True
+            hit = scope.desktop = True
         if p.startswith("apps/mobile/"):
-            scope.mobile = True
+            hit = scope.mobile = True
         if p.startswith("anyharness/sdk/"):
-            scope.sdk = True
+            hit = scope.sdk = True
         if p.startswith("anyharness/sdk-react/"):
-            scope.sdk_react = True
+            hit = scope.sdk_react = True
+        if p.startswith((".github/", "lints/", "fixtures/", "catalogs/")):
+            hit = True  # governed by the always-set engines (census, records, docs)
         if p.startswith(("specs/", "delivery/", "guides/")) or p.endswith(".md"):
-            scope.docs = True
+            hit = scope.docs = True
+        if not hit:
+            scope.unmapped.append(p)
     return scope
 
 
@@ -247,7 +277,8 @@ def pc_relative(srcs: list[str]) -> list[str]:
     return [s[len(prefix):] for s in srcs if s.startswith(prefix)]
 
 
-def services_reachable(host: str = "127.0.0.1", timeout: float = 0.5) -> tuple[bool, bool]:
+def services_reachable(host: str = "localhost", timeout: float = 0.5) -> tuple[bool, bool]:
+    # "localhost" so getaddrinfo covers both 127.0.0.1 and ::1 bindings.
     def probe(port: int) -> bool:
         try:
             with socket.create_connection((host, port), timeout=timeout):
@@ -336,6 +367,7 @@ class Check:
     skip_reason: str | None = None
     loud: bool = False  # print the skip in bold with a banner
     env_defaults: dict[str, str] | None = None  # applied only where unset
+    advisory: bool = False  # run + report, never fail (e.g. fmt until its CI job exists)
 
 
 def build_checks(
@@ -357,9 +389,13 @@ def build_checks(
     if scope.scripts:
         for name, cmd in SCRIPTS_PROOFS:
             if cmd.startswith("uv ") and not have_uv:
-                checks.append(Check(name, None, skip_reason="uv not found"))
+                checks.append(Check(name, None, skip_reason="uv not found", loud=True))
             else:
                 checks.append(Check(name, cmd))
+
+    if scope.cicd:
+        for name, cmd in CICD_CONFIG_TESTS:
+            checks.append(Check(name, cmd))
 
     if scope.server:
         if not have_uv:
@@ -368,9 +404,19 @@ def build_checks(
             checks.append(Check("server: ruff check", SERVER_RUFF_CHECK, cwd="server"))
             checks.append(Check("server: ruff format", SERVER_RUFF_FORMAT, cwd="server"))
             checks.append(Check("server: mypy ratchet", SERVER_MYPY, cwd="server"))
-            files = server_test_files(scope.server_domains, repo)
+            files = sorted(
+                set(server_test_files(scope.server_domains, repo))
+                | set(scope.server_changed_tests)
+            )
             if not files:
-                pass  # no domain-mapped tests for this diff; CI runs the full suite
+                checks.append(
+                    Check(
+                        "server: tests",
+                        None,
+                        skip_reason="no domain-mapped tests for this diff — CI runs the full suite",
+                        loud=True,
+                    )
+                )
             elif not (postgres_up and redis_up):
                 down = " + ".join(
                     n for n, up in (("postgres:5432", postgres_up), ("redis:6379", redis_up)) if not up
@@ -397,7 +443,11 @@ def build_checks(
         if not have_cargo:
             checks.append(Check("rust", None, skip_reason="cargo not found", loud=True))
         else:
-            checks.append(Check("rust: fmt", CARGO_FMT))
+            # Advisory until the lint-wiring slice normalizes the workspace and
+            # lands the rust-lint CI job: no CI step runs fmt today, so a hard
+            # local gate would violate the mirror rule and fail on
+            # pre-existing debt (608 diffs measured 2026-08-27).
+            checks.append(Check("rust: fmt (advisory)", CARGO_FMT, advisory=True))
             if scope.rust_workspace:
                 target = "--workspace"
             else:
@@ -483,16 +533,64 @@ def changed_files(repo: Path) -> tuple[list[str], str | None]:
     return sorted(paths), warning
 
 
-def run_check(check: Check, repo: Path, engine_python: str | None = None) -> tuple[str, float]:
+def apply_engine_availability(checks: list[Check], engine_python: str | None) -> list[Check]:
+    """No usable interpreter for the engines → their checks become loud skips."""
+    if engine_python is not None:
+        return checks
+    adjusted: list[Check] = []
+    for check in checks:
+        if check.cmd is not None and check.cmd.startswith("python3 "):
+            adjusted.append(
+                Check(
+                    check.name,
+                    None,
+                    skip_reason="python3 ≥3.11 unavailable (engines need tomllib) — install python3.12; CI is authoritative",
+                    loud=True,
+                )
+            )
+        else:
+            adjusted.append(check)
+    return adjusted
+
+
+def run_check(
+    check: Check, repo: Path, engine_python: str | None = None
+) -> tuple[str, float, str]:
+    """Returns (status, seconds, note). status ∈ ok | FAIL | skipped."""
     if check.cmd is None:
-        return "skipped", 0.0
+        return "skipped", 0.0, ""
     cwd = repo / check.cwd if check.cwd else repo
     env = None
     if check.env_defaults:
         env = {**check.env_defaults, **os.environ}  # exported values win
     start = time.monotonic()
-    proc = subprocess.run(engine_argv(check.cmd, engine_python), cwd=cwd, env=env, check=False)
-    return ("ok" if proc.returncode == 0 else "FAIL"), time.monotonic() - start
+    if check.advisory:
+        proc = subprocess.run(
+            engine_argv(check.cmd, engine_python),
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        elapsed = time.monotonic() - start
+        if proc.returncode == 0:
+            return "ok", elapsed, ""
+        diffs = sum(
+            1
+            for line in (proc.stdout or "").splitlines() + (proc.stderr or "").splitlines()
+            if line.startswith("Diff in ")
+        )
+        detail = f"{diffs} unformatted files; " if diffs else f"exit {proc.returncode}; "
+        return "ok", elapsed, f"advisory: {detail}not gating until its CI job lands"
+    if "*" in check.cmd:
+        # Mirrored CI strings with globs (node --test scripts/…/*.test.mjs) need a shell.
+        proc = subprocess.run(check.cmd, cwd=cwd, env=env, shell=True, check=False)
+    else:
+        proc = subprocess.run(
+            engine_argv(check.cmd, engine_python), cwd=cwd, env=env, check=False
+        )
+    return ("ok" if proc.returncode == 0 else "FAIL"), time.monotonic() - start, ""
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -522,13 +620,7 @@ def main(argv: list[str] | None = None) -> int:
         scope = classify(paths)
 
     engine_python = pick_engine_python()
-    if engine_python is None:
-        print(
-            "[gate] WARNING: no python3 ≥3.11 found (the lint engines need tomllib); "
-            "engine checks will fail — install python3.12. CI is authoritative.",
-            file=sys.stderr,
-        )
-    elif not _has_tomllib("python3"):
+    if engine_python is not None and not _has_tomllib("python3"):
         print(f"[gate] engines: {engine_python} (PATH python3 lacks tomllib; engines need ≥3.11)")
 
     postgres_up, redis_up = services_reachable()
@@ -542,6 +634,12 @@ def main(argv: list[str] | None = None) -> int:
         have_cargo=tool_exists("cargo"),
         have_nextest=tool_exists("cargo") and nextest_installed(),
     )
+    checks = apply_engine_availability(checks, engine_python)
+
+    if scope.unmapped and not args.all:
+        shown = " ".join(scope.unmapped[:8])
+        more = f" (+{len(scope.unmapped) - 8} more)" if len(scope.unmapped) > 8 else ""
+        print(f"[gate] unmapped paths (always-set only): {shown}{more}")
 
     if args.list:
         for check in checks:
@@ -553,8 +651,10 @@ def main(argv: list[str] | None = None) -> int:
     failures: list[Check] = []
     loud_skips: list[Check] = []
     for check in checks:
-        status, seconds = run_check(check, REPO, engine_python)
-        if status == "ok":
+        status, seconds, note = run_check(check, REPO, engine_python)
+        if status == "ok" and note:
+            print(f"[gate] {check.name} … ok ({seconds:.1f}s) — {note}")
+        elif status == "ok":
             print(f"[gate] {check.name} … ok ({seconds:.1f}s)")
         elif status == "skipped":
             print(f"[gate] {check.name} … skipped({check.skip_reason})")

--- a/scripts/gate
+++ b/scripts/gate
@@ -264,6 +264,17 @@ def tool_exists(tool: str) -> bool:
     return which(tool) is not None
 
 
+def nextest_installed() -> bool:
+    """cargo-nextest is a separate binary; without it `cargo nextest` is a usage error."""
+    try:
+        proc = subprocess.run(
+            ["cargo", "nextest", "--version"], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return False
+    return proc.returncode == 0
+
+
 # ---------------------------------------------------------------------------
 # Check assembly
 # ---------------------------------------------------------------------------
@@ -288,6 +299,7 @@ def build_checks(
     have_uv: bool,
     have_pnpm: bool,
     have_cargo: bool,
+    have_nextest: bool = True,
 ) -> list[Check]:
     checks: list[Check] = []
 
@@ -346,7 +358,17 @@ def build_checks(
             # Info mode until the lint-wiring slice lands the allow-list:
             # no -D warnings, so warnings alone exit 0; a compile error fails.
             checks.append(Check("rust: clippy (info mode)", f"cargo clippy {target}"))
-            checks.append(Check("rust: nextest", f"cargo nextest run {target}"))
+            if have_nextest:
+                checks.append(Check("rust: nextest", f"cargo nextest run {target}"))
+            else:
+                checks.append(
+                    Check(
+                        "rust: nextest",
+                        None,
+                        skip_reason="cargo-nextest not installed (cargo install cargo-nextest) — CI is authoritative",
+                        loud=True,
+                    )
+                )
 
     if scope.any_frontend() or scope.sdk or scope.sdk_react:
         if not have_pnpm:
@@ -438,7 +460,7 @@ def main(argv: list[str] | None = None) -> int:
             stream.reconfigure(line_buffering=True)
 
     paths, warning = changed_files(REPO)
-    if warning:
+    if warning and not args.all:
         print(f"[gate] WARNING: {warning}", file=sys.stderr)
         scope = Scope()
     elif args.all:
@@ -460,6 +482,7 @@ def main(argv: list[str] | None = None) -> int:
         have_uv=tool_exists("uv"),
         have_pnpm=tool_exists("pnpm"),
         have_cargo=tool_exists("cargo"),
+        have_nextest=tool_exists("cargo") and nextest_installed(),
     )
 
     if args.list:

--- a/scripts/gate
+++ b/scripts/gate
@@ -230,7 +230,7 @@ def server_test_files(domains: set[str], repo: Path) -> list[str]:
             stem = f.stem
             if any(domain in stem for domain in domains):
                 hits.append(str(f.relative_to(repo / "server")))
-    return hits
+    return sorted(hits)
 
 
 def pc_relative(srcs: list[str]) -> list[str]:

--- a/scripts/gate
+++ b/scripts/gate
@@ -391,7 +391,12 @@ def changed_files(repo: Path) -> tuple[list[str], str | None]:
         paths.update(line for line in diff.stdout.splitlines() if line)
     else:
         warning = "origin/main unresolvable — running the always-set only; fetch and re-run for full scoping"
-    for args in (("diff", "--name-only", "--cached"), ("diff", "--name-only")):
+    for args in (
+        ("diff", "--name-only", "--cached"),
+        ("diff", "--name-only"),
+        # New files not yet staged still scope a by-hand run (ignored files excluded).
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
         out = git(*args)
         paths.update(line for line in out.stdout.splitlines() if line)
     return sorted(paths), warning

--- a/scripts/gate
+++ b/scripts/gate
@@ -101,6 +101,15 @@ SERVER_MYPY = (
     "python scripts/check_mypy_baseline.py --compare-ref origin/main"
 )
 SERVER_PYTEST_PREFIX = "uv run --python 3.12 --frozen --extra dev pytest -q -n 2"
+# Mirrors server-ci.yml's test-job `env:` block verbatim — the same values the
+# local compose stack uses, so tests boot identically here and in CI. Applied
+# as defaults only: an already-exported variable (e.g. a second worktree's
+# alternate port) wins.
+SERVER_TEST_ENV = {
+    "DATABASE_URL": "postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate",
+    "JWT_SECRET": "test-jwt-secret",
+    "CLOUD_SECRET_KEY": "test-cloud-secret",
+}
 
 CARGO_FMT = "cargo fmt --check"
 
@@ -267,6 +276,7 @@ class Check:
     cwd: str | None = None  # repo-relative; None = repo root
     skip_reason: str | None = None
     loud: bool = False  # print the skip in bold with a banner
+    env_defaults: dict[str, str] | None = None  # applied only where unset
 
 
 def build_checks(
@@ -319,6 +329,7 @@ def build_checks(
                         f"server: tests ({len(files)} files)",
                         f"{SERVER_PYTEST_PREFIX} {' '.join(files)}",
                         cwd="server",
+                        env_defaults=SERVER_TEST_ENV,
                     )
                 )
 
@@ -406,8 +417,11 @@ def run_check(check: Check, repo: Path) -> tuple[str, float]:
     if check.cmd is None:
         return "skipped", 0.0
     cwd = repo / check.cwd if check.cwd else repo
+    env = None
+    if check.env_defaults:
+        env = {**check.env_defaults, **os.environ}  # exported values win
     start = time.monotonic()
-    proc = subprocess.run(shlex.split(check.cmd), cwd=cwd, check=False)
+    proc = subprocess.run(shlex.split(check.cmd), cwd=cwd, env=env, check=False)
     return ("ok" if proc.returncode == 0 else "FAIL"), time.monotonic() - start
 
 
@@ -416,6 +430,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--all", action="store_true", help="force every plane regardless of the diff")
     parser.add_argument("--list", action="store_true", help="print the checks the diff selects, run nothing")
     args = parser.parse_args(argv)
+
+    # Agents read the gate through pipes: keep per-check lines arriving in
+    # order with the subprocess output, not block-buffered until exit.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(line_buffering=True)
 
     paths, warning = changed_files(REPO)
     if warning:

--- a/scripts/gate
+++ b/scripts/gate
@@ -264,6 +264,54 @@ def tool_exists(tool: str) -> bool:
     return which(tool) is not None
 
 
+def _has_tomllib(python: str) -> bool:
+    try:
+        proc = subprocess.run(
+            [python, "-c", "import tomllib"], capture_output=True, check=False
+        )
+    except OSError:
+        return False
+    return proc.returncode == 0
+
+
+def pick_engine_python(prober=_has_tomllib) -> str | None:
+    """The interpreter the checker engines run with.
+
+    CI pins Python 3.12; locally `python3` may resolve to the system 3.9 (no
+    tomllib), which every lint engine imports. Prefer the interpreter running
+    the gate, then any modern python3.x on PATH, then bare python3 — first one
+    that can `import tomllib` wins. None means no usable interpreter exists.
+    """
+    from shutil import which
+
+    candidates: list[str] = [sys.executable]
+    for name in ("python3.13", "python3.12", "python3.11", "python3"):
+        path = which(name)
+        if path:
+            candidates.append(path)
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        if prober(candidate):
+            return candidate
+    return None
+
+
+def engine_argv(cmd: str, engine_python: str | None) -> list[str]:
+    """The argv for a check — `python3 …` commands run with the picked engine.
+
+    The COMMAND STRING stays the CI-mirrored `python3 …` (that is what gets
+    printed and re-run); only the resolved interpreter differs, exactly as
+    CI's setup-python step resolves `python3` to its pinned 3.12.
+    """
+    argv = shlex.split(cmd)
+    if argv and argv[0] == "python3" and engine_python:
+        argv[0] = engine_python
+    return argv
+
+
 def nextest_installed() -> bool:
     """cargo-nextest is a separate binary; without it `cargo nextest` is a usage error."""
     try:
@@ -435,7 +483,7 @@ def changed_files(repo: Path) -> tuple[list[str], str | None]:
     return sorted(paths), warning
 
 
-def run_check(check: Check, repo: Path) -> tuple[str, float]:
+def run_check(check: Check, repo: Path, engine_python: str | None = None) -> tuple[str, float]:
     if check.cmd is None:
         return "skipped", 0.0
     cwd = repo / check.cwd if check.cwd else repo
@@ -443,7 +491,7 @@ def run_check(check: Check, repo: Path) -> tuple[str, float]:
     if check.env_defaults:
         env = {**check.env_defaults, **os.environ}  # exported values win
     start = time.monotonic()
-    proc = subprocess.run(shlex.split(check.cmd), cwd=cwd, env=env, check=False)
+    proc = subprocess.run(engine_argv(check.cmd, engine_python), cwd=cwd, env=env, check=False)
     return ("ok" if proc.returncode == 0 else "FAIL"), time.monotonic() - start
 
 
@@ -473,6 +521,16 @@ def main(argv: list[str] | None = None) -> int:
     else:
         scope = classify(paths)
 
+    engine_python = pick_engine_python()
+    if engine_python is None:
+        print(
+            "[gate] WARNING: no python3 ≥3.11 found (the lint engines need tomllib); "
+            "engine checks will fail — install python3.12. CI is authoritative.",
+            file=sys.stderr,
+        )
+    elif not _has_tomllib("python3"):
+        print(f"[gate] engines: {engine_python} (PATH python3 lacks tomllib; engines need ≥3.11)")
+
     postgres_up, redis_up = services_reachable()
     checks = build_checks(
         scope,
@@ -495,7 +553,7 @@ def main(argv: list[str] | None = None) -> int:
     failures: list[Check] = []
     loud_skips: list[Check] = []
     for check in checks:
-        status, seconds = run_check(check, REPO)
+        status, seconds = run_check(check, REPO, engine_python)
         if status == "ok":
             print(f"[gate] {check.name} … ok ({seconds:.1f}s)")
         elif status == "skipped":

--- a/scripts/gate
+++ b/scripts/gate
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""The pre-push gate: change-scoped local mirror of the merge gate.
+
+Contract (frozen in delivery/testing-cicd/delivery-spec-make-gate.md, target
+spec section: specs/engineering/ci-cd/pipelines.md § "Pipeline — pre-push"):
+
+- Scope by `git diff` against merge-base(HEAD, origin/main), plus staged and
+  unstaged changes. `--all` forces every plane.
+- MIRROR RULE: every command the gate runs is the same string the
+  corresponding CI step runs (test_gate.py pins the strings against the
+  workflow files themselves). The one documented divergence: the mypy ratchet
+  runs `--compare-ref origin/main` locally where CI's step passes its
+  event-specific `--github-event-base`.
+- Output is machine-legible, one line per check:
+      [gate] <name> … ok (<s>s) | FAIL | skipped(<reason>)
+  Every FAIL prints the exact command to re-run. Missing tools and missing
+  local services degrade to LOUD skips, never failures — CI is authoritative
+  (testing law: local parallelism is bounded; CI is authoritative).
+- The commit hook formats; this gate checks. Never bypass with --no-verify:
+  the gate exists to save you the CI round-trip, not to be outrun.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Mirrored command strings.
+#
+# ALWAYS_ENGINES mirrors ci.yml § "Repo shape checks" — the checker ENGINES
+# only. The unittest halves of those steps prove the checkers, not the change,
+# and run only when scripts/** is touched (SCRIPTS_PROOFS below).
+# ---------------------------------------------------------------------------
+
+ALWAYS_ENGINES: tuple[tuple[str, str], ...] = (
+    ("lint records", "python3 scripts/lint_records.py"),
+    ("max lines", "python3 scripts/check_max_lines.py"),
+    ("migration heads", "python3 scripts/check_migration_heads.py"),
+    ("anyharness old paths", "python3 scripts/check_anyharness_old_paths.py"),
+    ("server old paths", "python3 scripts/check_server_old_paths.py"),
+    ("worker structure", "python3 scripts/check_proliferate_worker_structure.py"),
+    ("frontend boundaries", "python3 scripts/check_frontend_boundaries.py"),
+    ("appearance scaling", "python3 scripts/check_appearance_scaling.py"),
+    ("design attribution", "python3 scripts/check_design_attribution.py"),
+    ("toast copy", "python3 scripts/check_toast_copy.py"),
+    ("agent-auth secret logs", "python3 scripts/check_agent_auth_secret_logs.py"),
+    ("frontend structure", "python3 scripts/report_frontend_structure.py --strict --summary-only"),
+    ("transcript scroll writer", "python3 scripts/check_transcript_scroll_writer.py"),
+    ("component library", "python3 scripts/check_component_library.py"),
+    ("server boundaries", "python3 scripts/check_server_boundaries.py"),
+    ("anyharness boundaries", "python3 scripts/check_anyharness_boundaries.py"),
+    ("anyharness fences", "python3 scripts/check_anyharness_fences.py"),
+    ("frontend fences", "python3 scripts/check_frontend_fences.py"),
+    ("manifests", "python3 scripts/check_manifests.py"),
+    ("session mutation admission", "python3 scripts/check_session_mutation_admission.py"),
+    ("update flow", "python3 scripts/check_update_flow_lints.py"),
+    ("docs", "python3 scripts/check_docs.py"),
+)
+
+SCRIPTS_PROOFS: tuple[tuple[str, str], ...] = (
+    ("checker tests: lint records", "python3 -m unittest scripts/test_lint_records.py"),
+    ("checker tests: server old paths", "python3 -m unittest scripts/test_check_server_old_paths.py"),
+    ("checker tests: frontend boundaries", "python3 -m unittest scripts/test_check_frontend_boundaries.py"),
+    ("checker tests: mobile export", "python3 -m unittest scripts/test_check_mobile_product_client_export.py"),
+    ("checker tests: appearance scaling", "python3 -m unittest scripts/test_check_appearance_scaling.py"),
+    ("checker tests: design attribution", "python3 -m unittest scripts/test_check_design_attribution.py"),
+    ("checker tests: toast copy", "python3 -m unittest scripts/test_check_toast_copy.py"),
+    ("checker tests: secret logs", "python3 -m unittest scripts/test_check_agent_auth_secret_logs.py"),
+    ("checker tests: component library", "python3 -m unittest scripts/test_check_component_library.py"),
+    ("checker tests: anyharness boundaries", "python3 -m unittest scripts/test_check_anyharness_boundaries.py"),
+    ("checker tests: anyharness fences", "python3 -m unittest scripts/test_check_anyharness_fences.py"),
+    ("checker tests: frontend fences", "python3 -m unittest scripts/test_check_frontend_fences.py"),
+    ("checker tests: manifests", "python3 -m unittest scripts/test_check_manifests.py"),
+    ("checker tests: docs", "python3 -m unittest scripts/test_check_docs.py"),
+    ("checker tests: gate", "python3 -m unittest scripts/test_gate.py"),
+    (
+        "checker tests: server boundary checker",
+        "uv run --python 3.12 --with pytest==9.1.1 "
+        "pytest --noconftest -p no:cacheprovider -c /dev/null -q "
+        "server/tests/unit/test_server_boundary_checker.py "
+        "server/tests/unit/test_server_boundary_checker_named_writes.py",
+    ),
+)
+
+SERVER_RUFF_CHECK = "uv run --python 3.12 --frozen --extra dev ruff check proliferate/ tests/"
+SERVER_RUFF_FORMAT = "uv run --python 3.12 --frozen --extra dev ruff format --check proliferate/ tests/"
+# Local form of CI's "Mypy diagnostic ratchet" step (whose --github-event-base
+# flag is CI-event-specific by design; same checker, same baseline).
+SERVER_MYPY = (
+    "uv run --python 3.12 --frozen --extra dev "
+    "python scripts/check_mypy_baseline.py --compare-ref origin/main"
+)
+SERVER_PYTEST_PREFIX = "uv run --python 3.12 --frozen --extra dev pytest -q -n 2"
+
+CARGO_FMT = "cargo fmt --check"
+
+SHARED_TYPECHECK = "pnpm shared:typecheck"
+WEB_TYPECHECK = "pnpm web:typecheck"
+DESKTOP_TSC = "pnpm --filter proliferate exec tsc --noEmit"
+MOBILE_TYPECHECK = "pnpm --filter @proliferate/mobile typecheck"
+SDK_TYPECHECK = "pnpm --filter @anyharness/sdk typecheck"
+SDK_REACT_TYPECHECK = "pnpm --filter @anyharness/sdk-react typecheck"
+# The design package's own build IS the theme-equality law: tsc → generate →
+# check (absorbed from the retired pre-commit hook; see the delivery spec).
+DESIGN_BUILD = "pnpm --filter @proliferate/design build"
+PC_VITEST_RELATED_PREFIX = "pnpm --filter @proliferate/product-client exec vitest related --run"
+
+POSTGRES_PORT = 5432
+REDIS_PORT = 6379
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (unit-tested by scripts/test_gate.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Scope:
+    """What the diff touches, as the gate's planes see it."""
+
+    server: bool = False
+    server_domains: set[str] = field(default_factory=set)
+    rust_paths: list[str] = field(default_factory=list)
+    rust_workspace: bool = False
+    scripts: bool = False
+    shared_frontend: bool = False
+    product_client_srcs: list[str] = field(default_factory=list)
+    design: bool = False
+    web: bool = False
+    desktop: bool = False
+    mobile: bool = False
+    sdk: bool = False
+    sdk_react: bool = False
+    docs: bool = False
+
+    def any_frontend(self) -> bool:
+        return self.shared_frontend or self.web or self.desktop or self.mobile
+
+
+def classify(paths: list[str]) -> Scope:
+    scope = Scope()
+    for p in paths:
+        parts = p.split("/")
+        if p.startswith("server/"):
+            scope.server = True
+            if p.startswith("server/proliferate/server/") and len(parts) >= 4:
+                domain = parts[3]
+                if domain == "cloud" and len(parts) >= 5 and not parts[4].endswith(".py"):
+                    scope.server_domains.add(parts[4])
+                elif not domain.endswith(".py"):
+                    scope.server_domains.add(domain)
+        if p.endswith(".rs") or (
+            p.startswith(("anyharness/crates/", "apps/desktop/src-tauri/"))
+            and not p.endswith((".ts", ".tsx", ".json", ".md"))
+        ):
+            scope.rust_paths.append(p)
+        if p in ("Cargo.toml", "Cargo.lock"):
+            scope.rust_workspace = True
+        if p.startswith("scripts/") and (p.endswith(".py") or parts[-1] == "gate"):
+            scope.scripts = True
+        if p.startswith("apps/packages/") or p.startswith("cloud/sdk"):
+            scope.shared_frontend = True
+        if p.startswith("apps/packages/product-client/src/"):
+            scope.product_client_srcs.append(p)
+        if p.startswith("apps/packages/design/"):
+            scope.design = True
+        if p.startswith("apps/web/"):
+            scope.web = True
+        if p.startswith("apps/desktop/") and not p.startswith("apps/desktop/src-tauri/"):
+            scope.desktop = True
+        if p.startswith("apps/mobile/"):
+            scope.mobile = True
+        if p.startswith("anyharness/sdk/"):
+            scope.sdk = True
+        if p.startswith("anyharness/sdk-react/"):
+            scope.sdk_react = True
+        if p.startswith(("specs/", "delivery/", "guides/")) or p.endswith(".md"):
+            scope.docs = True
+    return scope
+
+
+def crate_name(cargo_toml_text: str) -> str | None:
+    """The [package] name from a Cargo.toml, no toml dependency."""
+    in_package = False
+    for line in cargo_toml_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_package = stripped == "[package]"
+            continue
+        if in_package and stripped.startswith("name"):
+            _, _, value = stripped.partition("=")
+            return value.strip().strip('"').strip("'") or None
+    return None
+
+
+def crates_for_paths(rust_paths: list[str], repo: Path) -> set[str]:
+    """Map each touched Rust path to its crate by walking up to a Cargo.toml."""
+    names: set[str] = set()
+    for p in rust_paths:
+        current = (repo / p).parent
+        while current != repo and current != current.parent:
+            manifest = current / "Cargo.toml"
+            if manifest.is_file():
+                name = crate_name(manifest.read_text(encoding="utf-8", errors="replace"))
+                if name:
+                    names.add(name)
+                break
+            current = current.parent
+    return names
+
+
+def server_test_files(domains: set[str], repo: Path) -> list[str]:
+    """Test files (repo-relative to server/) whose names mention a touched domain."""
+    hits: list[str] = []
+    for tier in ("unit", "integration"):
+        tier_dir = repo / "server" / "tests" / tier
+        if not tier_dir.is_dir():
+            continue
+        for f in sorted(tier_dir.rglob("test_*.py")):
+            stem = f.stem
+            if any(domain in stem for domain in domains):
+                hits.append(str(f.relative_to(repo / "server")))
+    return hits
+
+
+def pc_relative(srcs: list[str]) -> list[str]:
+    prefix = "apps/packages/product-client/"
+    return [s[len(prefix):] for s in srcs if s.startswith(prefix)]
+
+
+def services_reachable(host: str = "127.0.0.1", timeout: float = 0.5) -> tuple[bool, bool]:
+    def probe(port: int) -> bool:
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                return True
+        except OSError:
+            return False
+
+    return probe(POSTGRES_PORT), probe(REDIS_PORT)
+
+
+def tool_exists(tool: str) -> bool:
+    from shutil import which
+
+    return which(tool) is not None
+
+
+# ---------------------------------------------------------------------------
+# Check assembly
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Check:
+    name: str
+    cmd: str | None  # None => pre-decided skip
+    cwd: str | None = None  # repo-relative; None = repo root
+    skip_reason: str | None = None
+    loud: bool = False  # print the skip in bold with a banner
+
+
+def build_checks(
+    scope: Scope,
+    *,
+    repo: Path,
+    postgres_up: bool,
+    redis_up: bool,
+    have_uv: bool,
+    have_pnpm: bool,
+    have_cargo: bool,
+) -> list[Check]:
+    checks: list[Check] = []
+
+    for name, cmd in ALWAYS_ENGINES:
+        checks.append(Check(name, cmd))
+
+    if scope.scripts:
+        for name, cmd in SCRIPTS_PROOFS:
+            if cmd.startswith("uv ") and not have_uv:
+                checks.append(Check(name, None, skip_reason="uv not found"))
+            else:
+                checks.append(Check(name, cmd))
+
+    if scope.server:
+        if not have_uv:
+            checks.append(Check("server: ruff+mypy+tests", None, skip_reason="uv not found", loud=True))
+        else:
+            checks.append(Check("server: ruff check", SERVER_RUFF_CHECK, cwd="server"))
+            checks.append(Check("server: ruff format", SERVER_RUFF_FORMAT, cwd="server"))
+            checks.append(Check("server: mypy ratchet", SERVER_MYPY, cwd="server"))
+            files = server_test_files(scope.server_domains, repo)
+            if not files:
+                pass  # no domain-mapped tests for this diff; CI runs the full suite
+            elif not (postgres_up and redis_up):
+                down = " + ".join(
+                    n for n, up in (("postgres:5432", postgres_up), ("redis:6379", redis_up)) if not up
+                )
+                checks.append(
+                    Check(
+                        f"server: tests ({len(files)} files)",
+                        None,
+                        skip_reason=f"{down} unreachable — CI is authoritative",
+                        loud=True,
+                    )
+                )
+            else:
+                checks.append(
+                    Check(
+                        f"server: tests ({len(files)} files)",
+                        f"{SERVER_PYTEST_PREFIX} {' '.join(files)}",
+                        cwd="server",
+                    )
+                )
+
+    if scope.rust_paths or scope.rust_workspace:
+        if not have_cargo:
+            checks.append(Check("rust", None, skip_reason="cargo not found", loud=True))
+        else:
+            checks.append(Check("rust: fmt", CARGO_FMT))
+            if scope.rust_workspace:
+                target = "--workspace"
+            else:
+                crates = sorted(crates_for_paths(scope.rust_paths, repo))
+                target = " ".join(f"-p {c}" for c in crates) if crates else "--workspace"
+            # Info mode until the lint-wiring slice lands the allow-list:
+            # no -D warnings, so warnings alone exit 0; a compile error fails.
+            checks.append(Check("rust: clippy (info mode)", f"cargo clippy {target}"))
+            checks.append(Check("rust: nextest", f"cargo nextest run {target}"))
+
+    if scope.any_frontend() or scope.sdk or scope.sdk_react:
+        if not have_pnpm:
+            checks.append(Check("frontend", None, skip_reason="pnpm not found", loud=True))
+        else:
+            if scope.shared_frontend:
+                checks.append(Check("frontend: shared typecheck", SHARED_TYPECHECK))
+            if scope.product_client_srcs:
+                rel = pc_relative(scope.product_client_srcs)
+                checks.append(
+                    Check(
+                        "frontend: product-client vitest related",
+                        f"{PC_VITEST_RELATED_PREFIX} {' '.join(rel)}",
+                    )
+                )
+            if scope.design:
+                checks.append(Check("frontend: design theme equality", DESIGN_BUILD))
+            if scope.web:
+                checks.append(Check("frontend: web typecheck", WEB_TYPECHECK))
+            if scope.desktop:
+                checks.append(Check("frontend: desktop tsc", DESKTOP_TSC))
+            if scope.mobile:
+                checks.append(Check("frontend: mobile typecheck", MOBILE_TYPECHECK))
+            if scope.sdk:
+                checks.append(Check("frontend: sdk typecheck", SDK_TYPECHECK))
+            if scope.sdk_react:
+                checks.append(Check("frontend: sdk-react typecheck", SDK_REACT_TYPECHECK))
+
+    # scope.docs needs no extra check: `docs` (check_docs.py) is in the
+    # always-set, which is the very check the docs rule names.
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def changed_files(repo: Path) -> tuple[list[str], str | None]:
+    """Union of committed-vs-merge-base, staged, and unstaged paths."""
+
+    def git(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args], cwd=repo, capture_output=True, text=True, check=False
+        )
+
+    merge_base = git("merge-base", "HEAD", "origin/main")
+    warning = None
+    paths: set[str] = set()
+    if merge_base.returncode == 0:
+        base = merge_base.stdout.strip()
+        diff = git("diff", "--name-only", f"{base}..HEAD")
+        paths.update(line for line in diff.stdout.splitlines() if line)
+    else:
+        warning = "origin/main unresolvable — running the always-set only; fetch and re-run for full scoping"
+    for args in (("diff", "--name-only", "--cached"), ("diff", "--name-only")):
+        out = git(*args)
+        paths.update(line for line in out.stdout.splitlines() if line)
+    return sorted(paths), warning
+
+
+def run_check(check: Check, repo: Path) -> tuple[str, float]:
+    if check.cmd is None:
+        return "skipped", 0.0
+    cwd = repo / check.cwd if check.cwd else repo
+    start = time.monotonic()
+    proc = subprocess.run(shlex.split(check.cmd), cwd=cwd, check=False)
+    return ("ok" if proc.returncode == 0 else "FAIL"), time.monotonic() - start
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="The pre-push gate (see module docstring).")
+    parser.add_argument("--all", action="store_true", help="force every plane regardless of the diff")
+    parser.add_argument("--list", action="store_true", help="print the checks the diff selects, run nothing")
+    args = parser.parse_args(argv)
+
+    paths, warning = changed_files(REPO)
+    if warning:
+        print(f"[gate] WARNING: {warning}", file=sys.stderr)
+        scope = Scope()
+    elif args.all:
+        scope = classify(paths)
+        scope.server = True
+        scope.rust_workspace = True
+        scope.scripts = True
+        scope.shared_frontend = scope.web = scope.desktop = scope.mobile = True
+        scope.sdk = scope.sdk_react = scope.design = scope.docs = True
+    else:
+        scope = classify(paths)
+
+    postgres_up, redis_up = services_reachable()
+    checks = build_checks(
+        scope,
+        repo=REPO,
+        postgres_up=postgres_up,
+        redis_up=redis_up,
+        have_uv=tool_exists("uv"),
+        have_pnpm=tool_exists("pnpm"),
+        have_cargo=tool_exists("cargo"),
+    )
+
+    if args.list:
+        for check in checks:
+            detail = check.cmd or f"skipped({check.skip_reason})"
+            print(f"[gate] {check.name} :: {detail}")
+        return 0
+
+    started = time.monotonic()
+    failures: list[Check] = []
+    loud_skips: list[Check] = []
+    for check in checks:
+        status, seconds = run_check(check, REPO)
+        if status == "ok":
+            print(f"[gate] {check.name} … ok ({seconds:.1f}s)")
+        elif status == "skipped":
+            print(f"[gate] {check.name} … skipped({check.skip_reason})")
+            if check.loud:
+                loud_skips.append(check)
+        else:
+            print(f"[gate] {check.name} … FAIL")
+            print(f"[gate]   re-run: {check.cmd}" + (f"   (cwd: {check.cwd})" if check.cwd else ""))
+            failures.append(check)
+
+    total = time.monotonic() - started
+    print(f"[gate] {len(checks)} checks in {total:.0f}s — "
+          f"{len(failures)} failed, {len(loud_skips)} loudly skipped")
+    for check in loud_skips:
+        print("[gate] " + "!" * 62)
+        print(f"[gate] !! NOT RUN: {check.name} — {check.skip_reason}")
+        print("[gate] " + "!" * 62)
+    if failures:
+        print("[gate] RED. Fix the failures above (each lists its re-run command),")
+        print("[gate] or verify in CI — never push with --no-verify.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,89 +1,75 @@
 #!/bin/sh
-# Foundation vocabulary pre-commit guard (R-V2-2).
+# Format-on-commit hook — the commit tier of the ruled pipeline
+# (delivery/testing-cicd/delivery-spec-make-gate.md; target spec
+# specs/engineering/ci-cd/pipelines.md § "Pipeline — commit").
 #
-# Fast, local, and advisory-by-escape-hatch: it checks only the frontend files
-# in THIS commit, so it stays well under a couple of seconds even on a large
-# staged change. CI remains the backstop and runs the same script over the whole
-# repository, so bypassing this hook can never land a violation silently.
+# Runs the BOUGHT FORMATTERS ONLY on staged files, auto-fixes, and restages.
+# It never lints and it NEVER FAILS: a formatter error prints a warning and the
+# commit proceeds (a blocking hook makes an agent loop; an auto-fixing one costs
+# nothing). Checks live in the pre-push gate (`make gate`); CI is the backstop.
 #
-# Bypass:  git commit --no-verify
-# POSIX sh only; no dependency beyond python3 (already required to work here).
-
-set -eu
-
-repo_root=$(git rev-parse --show-toplevel)
-cd "$repo_root"
+# The two checks this hook used to carry moved to the gate: appearance-scaling
+# runs in the gate's always-set, theme equality in its design-package rule.
+#
+# Partial-staging caveat: formatting rewrites the working copy and `git add`
+# restages the whole file, so a partially staged file has its unstaged hunks
+# staged too. Stage whole files, or commit hunks with PROLIFERATE_SKIP_HOOKS=1.
+#
+# Escape: PROLIFERATE_SKIP_HOOKS=1 (or --no-verify for one commit).
+# POSIX sh only.
 
 if [ "${PROLIFERATE_SKIP_HOOKS:-}" = "1" ]; then
   exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "pre-commit: python3 not found; skipping appearance-scaling check." >&2
-  exit 0
-fi
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
 
 staged=$(git diff --cached --name-only --diff-filter=ACMR)
 [ -n "$staged" ] || exit 0
 
-# Only the roots the guard owns, and only files that still exist in the worktree.
-frontend_files=$(printf '%s\n' "$staged" | grep -E \
-  '^(apps/packages/product-client/src/.*\.(ts|tsx)|apps/desktop/src/.*\.(ts|tsx)|apps/packages/design/src/css/(dom|product)\.css|apps/packages/design/src/tokens\.ts)$' \
-  || true)
+warn() {
+  echo "pre-commit: $*" >&2
+}
 
-status=0
-
-if [ -n "$frontend_files" ]; then
-  existing=""
-  for file in $frontend_files; do
-    if [ -f "$file" ]; then
-      existing="$existing $file"
+# --- Python: ruff format over staged files in the server's ruff scope -------
+py_files=$(printf '%s\n' "$staged" | grep -E '^server/(proliferate|tests)/.*\.py$' || true)
+if [ -n "$py_files" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    rel=""
+    for f in $py_files; do
+      [ -f "$f" ] && rel="$rel ${f#server/}"
+    done
+    if [ -n "$rel" ]; then
+      # shellcheck disable=SC2086
+      if (cd server && uv run --python 3.12 --frozen --extra dev ruff format $rel >/dev/null 2>&1); then
+        # shellcheck disable=SC2086
+        git add $py_files 2>/dev/null || warn "could not restage formatted python files"
+      else
+        warn "ruff format failed; commit proceeds unformatted (the gate will tell you)."
+      fi
     fi
-  done
-  if [ -n "$existing" ]; then
-    # shellcheck disable=SC2086
-    if ! python3 scripts/check_appearance_scaling.py $existing; then
-      status=1
-    fi
-  fi
-fi
-
-# The theme is generated from tokens.ts; whenever the design package changes,
-# re-project it and prove byte equality before the commit is recorded.
-#
-# The tsc step is LOAD-BEARING, not an optimization: generate-theme.mjs imports
-# the COMPILED dist/tokens.js, so without recompiling first the generator
-# re-projects whatever was compiled last time. An edit to src/tokens.ts would
-# then produce a byte-identical theme and the hook would pass while the tree
-# drifted — exactly the one failure this check exists to catch. Build order is
-# the same law the package `build` script follows: tsc, generate, check.
-if printf '%s\n' "$staged" | grep -q '^apps/packages/design/'; then
-  design_tsc=apps/packages/design/node_modules/.bin/tsc
-  if [ ! -x "$design_tsc" ]; then
-    design_tsc=node_modules/.bin/tsc
-  fi
-  if [ ! -x "$design_tsc" ]; then
-    echo "pre-commit: typescript is not installed; skipping theme equality." >&2
-    echo "            run: pnpm install && pnpm --filter @proliferate/design build" >&2
   else
-    design_tsc=$(cd "$(dirname "$design_tsc")" && pwd)/$(basename "$design_tsc")
-    if ! (
-      cd apps/packages/design &&
-        "$design_tsc" -p tsconfig.json &&
-        node scripts/generate-theme.mjs >/dev/null &&
-        node scripts/check-theme.mjs >/dev/null
-    ); then
-      echo "pre-commit: generated theme does not match tokens.ts." >&2
-      echo "            run: pnpm --filter @proliferate/design build" >&2
-      status=1
-    fi
+    warn "uv not found; skipping ruff format."
   fi
 fi
 
-if [ "$status" -ne 0 ]; then
-  echo "" >&2
-  echo "pre-commit: foundation checks failed. Fix the call sites, or commit with" >&2
-  echo "            --no-verify if you are deliberately deferring (CI still runs them)." >&2
+# --- Rust: cargo fmt over the workspace when any .rs is staged --------------
+rs_files=$(printf '%s\n' "$staged" | grep -E '\.rs$' || true)
+if [ -n "$rs_files" ]; then
+  if command -v cargo >/dev/null 2>&1; then
+    if cargo fmt --all >/dev/null 2>&1; then
+      # shellcheck disable=SC2086
+      git add $rs_files 2>/dev/null || warn "could not restage formatted rust files"
+    else
+      warn "cargo fmt failed; commit proceeds unformatted (the gate will tell you)."
+    fi
+  else
+    warn "cargo not found; skipping cargo fmt."
+  fi
 fi
 
-exit "$status"
+# --- TypeScript / CSS / JSON --------------------------------------------------
+# biome: enabled by the format slice (Biome adopted 2026-08-26, not yet in-repo).
+
+exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -32,19 +32,42 @@ warn() {
   echo "pre-commit: $*" >&2
 }
 
+# restage_changed <pre-format "hash path" lines>: re-add only files whose
+# content the formatter actually changed — an untouched, partially staged file
+# must never have its unstaged hunks swept into the commit.
+restage_changed() {
+  printf '%s\n' "$1" | while IFS=' ' read -r before f; do
+    [ -n "$f" ] && [ -f "$f" ] || continue
+    after=$(git hash-object "$f" 2>/dev/null) || continue
+    if [ "$after" != "$before" ]; then
+      git add "$f" 2>/dev/null || warn "could not restage $f"
+    fi
+  done
+}
+
+hashes_for() {
+  for f in $1; do
+    [ -f "$f" ] && printf '%s %s\n' "$(git hash-object "$f")" "$f"
+  done
+}
+
 # --- Python: ruff format over staged files in the server's ruff scope -------
 py_files=$(printf '%s\n' "$staged" | grep -E '^server/(proliferate|tests)/.*\.py$' || true)
 if [ -n "$py_files" ]; then
   if command -v uv >/dev/null 2>&1; then
+    py_existing=""
     rel=""
     for f in $py_files; do
-      [ -f "$f" ] && rel="$rel ${f#server/}"
+      if [ -f "$f" ]; then
+        py_existing="$py_existing $f"
+        rel="$rel ${f#server/}"
+      fi
     done
-    if [ -n "$rel" ]; then
+    if [ -n "$py_existing" ]; then
+      py_hashes=$(hashes_for "$py_existing")
       # shellcheck disable=SC2086
       if (cd server && uv run --python 3.12 --frozen --extra dev ruff format $rel >/dev/null 2>&1); then
-        # shellcheck disable=SC2086
-        git add $py_files 2>/dev/null || warn "could not restage formatted python files"
+        restage_changed "$py_hashes"
       else
         warn "ruff format failed; commit proceeds unformatted (the gate will tell you)."
       fi
@@ -55,22 +78,27 @@ if [ -n "$py_files" ]; then
 fi
 
 # --- Rust: rustfmt over the staged .rs files only ----------------------------
+# rustfmt directly, NOT `cargo fmt -- <files>`: cargo-fmt appends file args to
+# the full workspace target list, so it would reformat everything. The edition
+# mirrors [workspace.package] in the root Cargo.toml.
 rs_files=$(printf '%s\n' "$staged" | grep -E '\.rs$' || true)
 if [ -n "$rs_files" ]; then
-  if command -v cargo >/dev/null 2>&1; then
+  if command -v rustfmt >/dev/null 2>&1; then
     rs_existing=""
     for f in $rs_files; do
       [ -f "$f" ] && rs_existing="$rs_existing $f"
     done
-    # shellcheck disable=SC2086
-    if [ -n "$rs_existing" ] && cargo fmt -- $rs_existing >/dev/null 2>&1; then
+    if [ -n "$rs_existing" ]; then
+      rs_hashes=$(hashes_for "$rs_existing")
       # shellcheck disable=SC2086
-      git add $rs_existing 2>/dev/null || warn "could not restage formatted rust files"
-    else
-      warn "cargo fmt failed; commit proceeds unformatted (the gate will tell you)."
+      if rustfmt --edition 2021 $rs_existing >/dev/null 2>&1; then
+        restage_changed "$rs_hashes"
+      else
+        warn "rustfmt failed; commit proceeds unformatted (the gate will tell you)."
+      fi
     fi
   else
-    warn "cargo not found; skipping cargo fmt."
+    warn "rustfmt not found; skipping rust formatting."
   fi
 fi
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -54,13 +54,18 @@ if [ -n "$py_files" ]; then
   fi
 fi
 
-# --- Rust: cargo fmt over the workspace when any .rs is staged --------------
+# --- Rust: rustfmt over the staged .rs files only ----------------------------
 rs_files=$(printf '%s\n' "$staged" | grep -E '\.rs$' || true)
 if [ -n "$rs_files" ]; then
   if command -v cargo >/dev/null 2>&1; then
-    if cargo fmt --all >/dev/null 2>&1; then
+    rs_existing=""
+    for f in $rs_files; do
+      [ -f "$f" ] && rs_existing="$rs_existing $f"
+    done
+    # shellcheck disable=SC2086
+    if [ -n "$rs_existing" ] && cargo fmt -- $rs_existing >/dev/null 2>&1; then
       # shellcheck disable=SC2086
-      git add $rs_files 2>/dev/null || warn "could not restage formatted rust files"
+      git add $rs_existing 2>/dev/null || warn "could not restage formatted rust files"
     else
       warn "cargo fmt failed; commit proceeds unformatted (the gate will tell you)."
     fi

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -19,6 +19,25 @@ fi
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 cd "$repo_root" || exit 0
 
+# git feeds "<local_ref> <local_sha> <remote_ref> <remote_sha>" per ref on
+# stdin. Deletions (local sha all zeros) and tag pushes carry no new code —
+# skip the gate for pushes that consist only of those. No stdin = manual run.
+zero=0000000000000000000000000000000000000000
+needs_gate=0
+saw_ref=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  [ -n "$local_sha" ] || continue
+  saw_ref=1
+  [ "$local_sha" = "$zero" ] && continue
+  case "$_local_ref" in
+    refs/tags/*) continue ;;
+  esac
+  needs_gate=1
+done
+if [ "$saw_ref" = "1" ] && [ "$needs_gate" = "0" ]; then
+  exit 0
+fi
+
 if ! command -v make >/dev/null 2>&1; then
   echo "pre-push: make not found; run 'python3 scripts/gate' by hand. Push proceeds." >&2
   exit 0

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Gate-on-push hook — the pre-push tier of the ruled pipeline
+# (delivery/testing-cicd/delivery-spec-make-gate.md; target spec
+# specs/engineering/ci-cd/pipelines.md § "Pipeline — pre-push").
+#
+# Runs `make gate`: the change-scoped local mirror of the merge gate. Same
+# commands CI runs, ≤2 min warm, so a push that passes here will not come back
+# red six minutes later. Missing tools and services skip LOUDLY inside the gate
+# rather than blocking; CI remains authoritative.
+#
+# Escape: PROLIFERATE_SKIP_HOOKS=1. Never habitually --no-verify: the gate is
+# what saves you the CI round-trip.
+# POSIX sh only.
+
+if [ "${PROLIFERATE_SKIP_HOOKS:-}" = "1" ]; then
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+if ! command -v make >/dev/null 2>&1; then
+  echo "pre-push: make not found; run 'python3 scripts/gate' by hand. Push proceeds." >&2
+  exit 0
+fi
+
+if make --no-print-directory gate; then
+  exit 0
+fi
+
+echo "" >&2
+echo "pre-push: the gate is red. Fix it (each failure printed its re-run command)," >&2
+echo "          or push anyway and verify in CI — but never with --no-verify as habit:" >&2
+echo "          the gate is the fast loop; CI is the slow, authoritative one." >&2
+exit 1

--- a/scripts/test_check_appearance_scaling.py
+++ b/scripts/test_check_appearance_scaling.py
@@ -771,7 +771,7 @@ const ORBIT_DELAYS = [
         hooks_dir = check_module.REPO_ROOT / "scripts" / "git-hooks"
         gate = (check_module.REPO_ROOT / "scripts" / "gate").read_text()
         self.assertIn(
-            '"python3 scripts/check_appearance_scaling.py"',
+            '("appearance scaling", "python3 scripts/check_appearance_scaling.py"),',
             gate,
             "the gate's always-set no longer runs the appearance-scaling checker",
         )

--- a/scripts/test_check_appearance_scaling.py
+++ b/scripts/test_check_appearance_scaling.py
@@ -757,23 +757,32 @@ const ORBIT_DELAYS = [
             "Tailwind compiles these roots but the foundation guard never reads them",
         )
 
-    def test_the_pre_commit_hook_owns_the_same_roots_as_ci(self) -> None:
+    def test_the_local_gate_runs_the_same_guard_as_ci(self) -> None:
         """A root only CI sees is a root the local guard waves through.
 
-        The hook is the fast path developers actually feel; if its filter and
-        PRODUCTION_ROOTS disagree, a violation commits cleanly and only surfaces
-        in CI — the drift that let product-surfaces sit unenforced in both.
+        The local fast path is the pre-push gate (2026-08-26 ruling: the commit
+        hook formats, the gate checks). The gate's always-set runs this checker
+        over the whole repository — the same invocation as CI — so every
+        PRODUCTION_ROOT is covered by construction rather than by a hand-kept
+        path filter that could drift (the drift that once let product-surfaces
+        sit unenforced). Pin both halves: the engine is in the always-set, and
+        the pre-push hook actually runs the gate.
         """
-        hook = (check_module.REPO_ROOT / "scripts" / "git-hooks" / "pre-commit").read_text()
-        for root in check_module.PRODUCTION_ROOTS:
-            relative = relative_path(root)
-            package = relative.removeprefix("apps/packages/").removesuffix("/src")
-            with self.subTest(root=relative):
-                self.assertTrue(
-                    f"{package}/src" in hook or f"({package}|" in hook or f"|{package}|" in hook
-                    or f"|{package})" in hook,
-                    f"{relative} is scanned by CI but not matched by the pre-commit hook",
-                )
+        hooks_dir = check_module.REPO_ROOT / "scripts" / "git-hooks"
+        gate = (check_module.REPO_ROOT / "scripts" / "gate").read_text()
+        self.assertIn(
+            '"python3 scripts/check_appearance_scaling.py"',
+            gate,
+            "the gate's always-set no longer runs the appearance-scaling checker",
+        )
+        pre_push = (hooks_dir / "pre-push").read_text()
+        self.assertIn("make --no-print-directory gate", pre_push)
+        pre_commit = (hooks_dir / "pre-commit").read_text()
+        self.assertNotIn(
+            "check_appearance_scaling",
+            pre_commit,
+            "the commit hook formats only; the guard belongs to the gate",
+        )
 
 
 class ArbitraryBracketGeometryTest(unittest.TestCase):

--- a/scripts/test_gate.py
+++ b/scripts/test_gate.py
@@ -102,6 +102,24 @@ class ClassifyTests(unittest.TestCase):
     def test_md_anywhere_is_docs(self):
         self.assertTrue(gate.classify(["anyharness/README.md"]).docs)
 
+    def test_cicd_mjs_and_root_manifests_have_planes(self):
+        scope = gate.classify(
+            ["scripts/ci-cd/pr-metadata.mjs", "package.json", "pnpm-lock.yaml"]
+        )
+        self.assertTrue(scope.cicd)
+        self.assertTrue(scope.shared_frontend)
+        self.assertEqual(scope.unmapped, [])
+
+    def test_changed_server_tests_are_collected(self):
+        scope = gate.classify(["server/tests/unit/test_billing_domain.py"])
+        self.assertEqual(scope.server_changed_tests, ["tests/unit/test_billing_domain.py"])
+
+    def test_unknown_paths_are_reported_unmapped(self):
+        scope = gate.classify(["random/thing.xyz", "scripts/git-hooks/pre-push"])
+        self.assertEqual(
+            scope.unmapped, ["random/thing.xyz", "scripts/git-hooks/pre-push"]
+        )
+
 
 class CrateTests(unittest.TestCase):
     def test_crate_name_parses_package_section_only(self):
@@ -212,6 +230,36 @@ class BuildChecksTests(unittest.TestCase):
         self.assertIn("--workspace", clippy.cmd)
         self.assertNotIn("-D warnings", clippy.cmd)  # info mode until lint-wiring lands
 
+    def test_rust_fmt_is_advisory_until_its_ci_job_exists(self):
+        scope = gate.classify(["anyharness/crates/anyharness-lib/src/lib.rs"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        fmt = next(c for c in checks if c.name.startswith("rust: fmt"))
+        self.assertTrue(fmt.advisory)
+
+    def test_empty_domain_server_diff_is_a_loud_no_test_note(self):
+        scope = gate.classify(["server/proliferate/lib/email.py"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        note = next(c for c in checks if c.name == "server: tests")
+        self.assertIsNone(note.cmd)
+        self.assertTrue(note.loud)
+        self.assertIn("CI runs the full suite", note.skip_reason)
+
+    def test_changed_test_files_run_even_without_a_domain(self):
+        scope = gate.classify(["server/tests/unit/test_billing_domain.py"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        pytest_check = next(c for c in checks if c.cmd and " pytest " in f" {c.cmd} ")
+        self.assertIn("tests/unit/test_billing_domain.py", pytest_check.cmd)
+
+    def test_no_engine_python_turns_engine_checks_into_loud_skips(self):
+        scope = gate.classify(["specs/x.md"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        adjusted = gate.apply_engine_availability(checks, None)
+        engine_checks = [c for c in adjusted if c.name in {n for n, _ in gate.ALWAYS_ENGINES}]
+        self.assertTrue(engine_checks)
+        self.assertTrue(all(c.cmd is None and c.loud for c in engine_checks))
+        untouched = gate.apply_engine_availability(checks, "/opt/py312")
+        self.assertIs(untouched, checks)
+
     def test_missing_nextest_is_a_loud_skip_not_a_fail(self):
         scope = gate.classify(["anyharness/crates/anyharness-lib/src/lib.rs"])
         checks = gate.build_checks(scope, **self._base_kwargs(have_nextest=False))
@@ -267,15 +315,45 @@ class MirrorRuleTests(unittest.TestCase):
             (REPO / ".github" / "workflows" / "server-ci.yml").read_text()
         )
 
-    def test_always_engines_mirror_repo_shape_steps(self):
-        for name, cmd in gate.ALWAYS_ENGINES:
-            with self.subTest(check=name):
-                self.assertIn(_normalized(cmd), self.ci)
+    @classmethod
+    def _repo_shape_python3_lines(cls) -> set[str]:
+        """Every python3 command line in ci.yml's Repo shape checks job."""
+        raw = (REPO / ".github" / "workflows" / "ci.yml").read_text()
+        start = raw.index("name: Repo shape checks")
+        end = raw.index("\n  terraform-validate:", start)
+        lines = set()
+        for line in raw[start:end].splitlines():
+            stripped = line.strip()
+            if stripped.startswith("run: "):
+                stripped = stripped[len("run: "):]
+            if stripped.startswith("python3 "):
+                lines.add(stripped)
+        return lines
 
-    def test_scripts_proofs_mirror_repo_shape_steps(self):
-        for name, cmd in gate.SCRIPTS_PROOFS:
-            if name == "checker tests: gate":
-                continue  # added by this slice; asserted below
+    def test_python3_census_is_two_directional(self):
+        """The gate runs exactly the repo-shape job's python3 commands.
+
+        Both directions: a gate command CI doesn't run is a mirror violation;
+        a repo-shape step the gate doesn't know is silent local under-coverage
+        (a new checker must be added to ALWAYS_ENGINES/SCRIPTS_PROOFS in the
+        same PR that adds its CI step — this test is what forces that).
+        """
+        ci_lines = self._repo_shape_python3_lines()
+        gate_lines = {
+            cmd
+            for _, cmd in (*gate.ALWAYS_ENGINES, *gate.SCRIPTS_PROOFS)
+            if cmd.startswith("python3 ")
+        }
+        self.assertEqual(gate_lines - ci_lines, set(), "gate runs commands CI does not")
+        self.assertEqual(ci_lines - gate_lines, set(), "CI runs commands the gate does not")
+
+    def test_uv_proof_mirrors_repo_shape(self):
+        uv_cmds = [cmd for _, cmd in gate.SCRIPTS_PROOFS if cmd.startswith("uv ")]
+        self.assertEqual(len(uv_cmds), 1)
+        self.assertIn(_normalized(uv_cmds[0]), self.ci)
+
+    def test_cicd_config_tests_mirror_ci(self):
+        for name, cmd in gate.CICD_CONFIG_TESTS:
             with self.subTest(check=name):
                 self.assertIn(_normalized(cmd), self.ci)
 

--- a/scripts/test_gate.py
+++ b/scripts/test_gate.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sys
+from importlib.machinery import SourceFileLoader
 import tempfile
 import unittest
 from pathlib import Path
@@ -19,9 +21,12 @@ REPO = Path(__file__).resolve().parent.parent
 
 
 def _load_gate():
-    spec = importlib.util.spec_from_file_location("gate", REPO / "scripts" / "gate")
+    # `scripts/gate` has no .py suffix, so name the loader explicitly.
+    loader = SourceFileLoader("gate", str(REPO / "scripts" / "gate"))
+    spec = importlib.util.spec_from_loader("gate", loader)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.modules["gate"] = module  # dataclasses resolve annotations via sys.modules
+    loader.exec_module(module)
     return module
 
 
@@ -194,7 +199,7 @@ class BuildChecksTests(unittest.TestCase):
     def test_missing_uv_is_one_loud_skip(self):
         scope = gate.classify(["server/proliferate/server/billing/service.py"])
         checks = gate.build_checks(scope, **self._base_kwargs(have_uv=False))
-        server_checks = [c for c in checks if c.name.startswith("server")]
+        server_checks = [c for c in checks if c.name.startswith("server:")]
         self.assertEqual(len(server_checks), 1)
         self.assertIsNone(server_checks[0].cmd)
         self.assertTrue(server_checks[0].loud)

--- a/scripts/test_gate.py
+++ b/scripts/test_gate.py
@@ -212,6 +212,14 @@ class BuildChecksTests(unittest.TestCase):
         self.assertIn("--workspace", clippy.cmd)
         self.assertNotIn("-D warnings", clippy.cmd)  # info mode until lint-wiring lands
 
+    def test_missing_nextest_is_a_loud_skip_not_a_fail(self):
+        scope = gate.classify(["anyharness/crates/anyharness-lib/src/lib.rs"])
+        checks = gate.build_checks(scope, **self._base_kwargs(have_nextest=False))
+        nextest = next(c for c in checks if c.name == "rust: nextest")
+        self.assertIsNone(nextest.cmd)
+        self.assertTrue(nextest.loud)
+        self.assertTrue(any(c.name.startswith("rust: clippy") and c.cmd for c in checks))
+
     def test_scripts_diff_adds_checker_proofs(self):
         scope = gate.classify(["scripts/check_docs.py"])
         checks = gate.build_checks(scope, **self._base_kwargs())

--- a/scripts/test_gate.py
+++ b/scripts/test_gate.py
@@ -226,6 +226,37 @@ class BuildChecksTests(unittest.TestCase):
         self.assertTrue(any(c.name.startswith("checker tests:") for c in checks))
 
 
+class EnginePythonTests(unittest.TestCase):
+    def test_prefers_first_candidate_with_tomllib(self):
+        probed = []
+
+        def prober(python):
+            probed.append(python)
+            return python.endswith("3.12")
+
+        # sys.executable is probed first; our fake prober rejects it unless 3.12.
+        result = gate.pick_engine_python(prober=prober)
+        if result is not None:
+            self.assertTrue(result.endswith("3.12"))
+        self.assertGreaterEqual(len(probed), 1)
+
+    def test_returns_none_when_nothing_has_tomllib(self):
+        self.assertIsNone(gate.pick_engine_python(prober=lambda p: False))
+
+    def test_engine_argv_rewrites_only_python3_prefix(self):
+        self.assertEqual(
+            gate.engine_argv("python3 scripts/check_docs.py", "/opt/py312")[0], "/opt/py312"
+        )
+        self.assertEqual(
+            gate.engine_argv("python3 -m unittest scripts/test_gate.py", "/opt/py312")[:3],
+            ["/opt/py312", "-m", "unittest"],
+        )
+        self.assertEqual(gate.engine_argv("cargo fmt --check", "/opt/py312")[0], "cargo")
+        self.assertEqual(
+            gate.engine_argv("python3 scripts/check_docs.py", None)[0], "python3"
+        )
+
+
 class MirrorRuleTests(unittest.TestCase):
     """Every gate command string appears in the CI workflow that runs it."""
 

--- a/scripts/test_gate.py
+++ b/scripts/test_gate.py
@@ -1,0 +1,263 @@
+"""Unit tests for scripts/gate — the pre-push gate's scoping logic.
+
+Pins: path→plane classification, crate derivation, domain→test mapping, the
+services-unreachable skip branch, and the MIRROR RULE (every gate command
+string appears verbatim, modulo whitespace folding, in the workflow that runs
+it in CI — the one documented divergence being the mypy ratchet's local
+`--compare-ref origin/main` vs CI's event-specific `--github-event-base`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("gate", REPO / "scripts" / "gate")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+
+def _normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_server_domain_extraction(self):
+        scope = gate.classify(
+            [
+                "server/proliferate/server/billing/service.py",
+                "server/proliferate/server/cloud/gateway/routes.py",
+                "server/proliferate/lib/email.py",
+            ]
+        )
+        self.assertTrue(scope.server)
+        self.assertEqual(scope.server_domains, {"billing", "gateway"})
+
+    def test_server_root_file_is_no_domain(self):
+        scope = gate.classify(["server/proliferate/server/main.py"])
+        self.assertTrue(scope.server)
+        self.assertEqual(scope.server_domains, set())
+
+    def test_rust_paths_and_workspace(self):
+        scope = gate.classify(
+            [
+                "anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs",
+                "Cargo.lock",
+                "apps/desktop/src-tauri/src/main.rs",
+            ]
+        )
+        self.assertEqual(len(scope.rust_paths), 2)
+        self.assertTrue(scope.rust_workspace)
+
+    def test_src_tauri_is_rust_not_desktop_frontend(self):
+        scope = gate.classify(["apps/desktop/src-tauri/src/main.rs"])
+        self.assertFalse(scope.desktop)
+        self.assertTrue(scope.rust_paths)
+
+    def test_frontend_flags(self):
+        scope = gate.classify(
+            [
+                "apps/packages/product-client/src/domain/x.ts",
+                "apps/packages/design/src/tokens.ts",
+                "apps/web/src/App.tsx",
+                "apps/desktop/src/main.tsx",
+                "apps/mobile/App.tsx",
+                "anyharness/sdk/src/index.ts",
+                "anyharness/sdk-react/src/hooks.ts",
+                "cloud/sdk/src/client.ts",
+            ]
+        )
+        self.assertTrue(scope.shared_frontend)
+        self.assertEqual(
+            scope.product_client_srcs, ["apps/packages/product-client/src/domain/x.ts"]
+        )
+        self.assertTrue(scope.design)
+        self.assertTrue(scope.web)
+        self.assertTrue(scope.desktop)
+        self.assertTrue(scope.mobile)
+        self.assertTrue(scope.sdk)
+        self.assertTrue(scope.sdk_react)
+
+    def test_docs_and_scripts(self):
+        scope = gate.classify(["specs/engineering/testing/README.md", "scripts/check_docs.py"])
+        self.assertTrue(scope.docs)
+        self.assertTrue(scope.scripts)
+
+    def test_md_anywhere_is_docs(self):
+        self.assertTrue(gate.classify(["anyharness/README.md"]).docs)
+
+
+class CrateTests(unittest.TestCase):
+    def test_crate_name_parses_package_section_only(self):
+        text = '[workspace]\nmembers = ["a"]\n\n[package]\nname = "my-crate"\nversion = "0.1.0"\n'
+        self.assertEqual(gate.crate_name(text), "my-crate")
+
+    def test_crate_name_ignores_dependency_names(self):
+        text = '[dependencies]\nname_like = "1"\n'
+        self.assertIsNone(gate.crate_name(text))
+
+    def test_crates_for_paths_walks_up(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            crate = repo / "anyharness" / "crates" / "demo"
+            (crate / "src").mkdir(parents=True)
+            (crate / "Cargo.toml").write_text('[package]\nname = "demo-crate"\n')
+            (crate / "src" / "lib.rs").write_text("")
+            names = gate.crates_for_paths(["anyharness/crates/demo/src/lib.rs"], repo)
+            self.assertEqual(names, {"demo-crate"})
+
+    def test_crates_for_paths_missing_manifest_is_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "x").mkdir()
+            (repo / "x" / "a.rs").write_text("")
+            self.assertEqual(gate.crates_for_paths(["x/a.rs"], repo), set())
+
+
+class ServerTestMappingTests(unittest.TestCase):
+    def _make_repo(self, tmp: str) -> Path:
+        repo = Path(tmp)
+        for tier in ("unit", "integration"):
+            (repo / "server" / "tests" / tier).mkdir(parents=True)
+        (repo / "server" / "tests" / "unit" / "test_billing_usage_api.py").write_text("")
+        (repo / "server" / "tests" / "integration" / "test_billing_flow.py").write_text("")
+        (repo / "server" / "tests" / "unit" / "test_github_webhooks.py").write_text("")
+        return repo
+
+    def test_domain_maps_to_matching_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._make_repo(tmp)
+            files = gate.server_test_files({"billing"}, repo)
+            self.assertEqual(
+                files,
+                [
+                    "tests/integration/test_billing_flow.py",
+                    "tests/unit/test_billing_usage_api.py",
+                ],
+            )
+
+    def test_empty_mapping_for_unknown_domain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._make_repo(tmp)
+            self.assertEqual(gate.server_test_files({"workflows"}, repo), [])
+
+
+class BuildChecksTests(unittest.TestCase):
+    def _base_kwargs(self, **overrides):
+        kwargs = dict(
+            repo=REPO,
+            postgres_up=True,
+            redis_up=True,
+            have_uv=True,
+            have_pnpm=True,
+            have_cargo=True,
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_docs_only_diff_runs_exactly_the_always_set(self):
+        scope = gate.classify(["specs/engineering/testing/README.md"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        self.assertEqual(len(checks), len(gate.ALWAYS_ENGINES))
+        self.assertEqual({c.name for c in checks}, {n for n, _ in gate.ALWAYS_ENGINES})
+
+    def test_services_down_skips_tests_loudly_and_keeps_lint(self):
+        scope = gate.classify(["server/proliferate/server/billing/service.py"])
+        checks = gate.build_checks(scope, **self._base_kwargs(postgres_up=False))
+        skips = [c for c in checks if c.cmd is None]
+        self.assertTrue(any("postgres:5432" in (c.skip_reason or "") for c in skips))
+        self.assertTrue(all(c.loud for c in skips))
+        names = {c.name for c in checks}
+        self.assertIn("server: ruff check", names)
+        self.assertIn("server: mypy ratchet", names)
+        self.assertFalse(any("pytest" in (c.cmd or "") for c in checks))
+
+    def test_services_up_runs_domain_tests_at_n2(self):
+        scope = gate.classify(["server/proliferate/server/billing/service.py"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        pytest_checks = [c for c in checks if c.cmd and " pytest " in f" {c.cmd} "]
+        if pytest_checks:  # the real repo has billing tests
+            self.assertIn("-n 2", pytest_checks[0].cmd)
+            self.assertEqual(pytest_checks[0].cwd, "server")
+
+    def test_missing_uv_is_one_loud_skip(self):
+        scope = gate.classify(["server/proliferate/server/billing/service.py"])
+        checks = gate.build_checks(scope, **self._base_kwargs(have_uv=False))
+        server_checks = [c for c in checks if c.name.startswith("server")]
+        self.assertEqual(len(server_checks), 1)
+        self.assertIsNone(server_checks[0].cmd)
+        self.assertTrue(server_checks[0].loud)
+
+    def test_workspace_change_widens_rust_target(self):
+        scope = gate.classify(["Cargo.lock"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        clippy = next(c for c in checks if c.name.startswith("rust: clippy"))
+        self.assertIn("--workspace", clippy.cmd)
+        self.assertNotIn("-D warnings", clippy.cmd)  # info mode until lint-wiring lands
+
+    def test_scripts_diff_adds_checker_proofs(self):
+        scope = gate.classify(["scripts/check_docs.py"])
+        checks = gate.build_checks(scope, **self._base_kwargs())
+        self.assertTrue(any(c.name.startswith("checker tests:") for c in checks))
+
+
+class MirrorRuleTests(unittest.TestCase):
+    """Every gate command string appears in the CI workflow that runs it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ci = _normalized((REPO / ".github" / "workflows" / "ci.yml").read_text())
+        cls.server_ci = _normalized(
+            (REPO / ".github" / "workflows" / "server-ci.yml").read_text()
+        )
+
+    def test_always_engines_mirror_repo_shape_steps(self):
+        for name, cmd in gate.ALWAYS_ENGINES:
+            with self.subTest(check=name):
+                self.assertIn(_normalized(cmd), self.ci)
+
+    def test_scripts_proofs_mirror_repo_shape_steps(self):
+        for name, cmd in gate.SCRIPTS_PROOFS:
+            if name == "checker tests: gate":
+                continue  # added by this slice; asserted below
+            with self.subTest(check=name):
+                self.assertIn(_normalized(cmd), self.ci)
+
+    def test_gate_unittest_is_wired_into_ci(self):
+        self.assertIn("python3 -m unittest scripts/test_gate.py", self.ci)
+
+    def test_server_ruff_commands_mirror_server_ci(self):
+        self.assertIn(_normalized(gate.SERVER_RUFF_CHECK), self.server_ci)
+        self.assertIn(_normalized(gate.SERVER_RUFF_FORMAT), self.server_ci)
+
+    def test_mypy_is_same_checker_documented_divergence(self):
+        shared_prefix = (
+            "uv run --python 3.12 --frozen --extra dev python scripts/check_mypy_baseline.py"
+        )
+        self.assertTrue(gate.SERVER_MYPY.startswith(shared_prefix))
+        self.assertIn(shared_prefix, self.server_ci)
+        self.assertIn("--compare-ref origin/main", gate.SERVER_MYPY)
+
+    def test_frontend_commands_mirror_ci(self):
+        for cmd in (
+            gate.SHARED_TYPECHECK,
+            gate.WEB_TYPECHECK,
+            gate.MOBILE_TYPECHECK,
+        ):
+            with self.subTest(cmd=cmd):
+                self.assertIn(_normalized(cmd), self.ci)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_gate.py
+++ b/scripts/test_gate.py
@@ -188,13 +188,14 @@ class BuildChecksTests(unittest.TestCase):
         self.assertIn("server: mypy ratchet", names)
         self.assertFalse(any("pytest" in (c.cmd or "") for c in checks))
 
-    def test_services_up_runs_domain_tests_at_n2(self):
+    def test_services_up_runs_domain_tests_at_n2_with_ci_env(self):
         scope = gate.classify(["server/proliferate/server/billing/service.py"])
         checks = gate.build_checks(scope, **self._base_kwargs())
         pytest_checks = [c for c in checks if c.cmd and " pytest " in f" {c.cmd} "]
-        if pytest_checks:  # the real repo has billing tests
-            self.assertIn("-n 2", pytest_checks[0].cmd)
-            self.assertEqual(pytest_checks[0].cwd, "server")
+        self.assertTrue(pytest_checks, "the real repo has billing tests")
+        self.assertIn("-n 2", pytest_checks[0].cmd)
+        self.assertEqual(pytest_checks[0].cwd, "server")
+        self.assertEqual(pytest_checks[0].env_defaults, gate.SERVER_TEST_ENV)
 
     def test_missing_uv_is_one_loud_skip(self):
         scope = gate.classify(["server/proliferate/server/billing/service.py"])
@@ -245,6 +246,11 @@ class MirrorRuleTests(unittest.TestCase):
     def test_server_ruff_commands_mirror_server_ci(self):
         self.assertIn(_normalized(gate.SERVER_RUFF_CHECK), self.server_ci)
         self.assertIn(_normalized(gate.SERVER_RUFF_FORMAT), self.server_ci)
+
+    def test_server_test_env_mirrors_server_ci(self):
+        for key, value in gate.SERVER_TEST_ENV.items():
+            with self.subTest(var=key):
+                self.assertIn(f"{key}: {value}", self.server_ci)
 
     def test_mypy_is_same_checker_documented_divergence(self):
         shared_prefix = (


### PR DESCRIPTION
Third slice of the testing/linting/ci-cd program, implemented from the frozen delivery spec (`delivery/testing-cicd/delivery-spec-make-gate.md`, #2270) — target spec sections `specs/engineering/ci-cd/pipelines.md` § "Pipeline — pre-push" / § "Pipeline — commit" (spec PR in flight tonight). Adversarial review: one fresh-context refuter pass; findings triage below.

## Scope summary

`make gate` — the change-scoped local mirror of the merge gate — plus the two hooks of the ruled hook story (format-on-commit · gate-on-push · CI as backstop), installed through the existing `core.hooksPath` mechanism (`make setup` → `git-hooks`).

- **`scripts/gate`** (Python 3 stdlib): scopes by `git diff` vs merge-base(HEAD, origin/main) + staged + unstaged + untracked. Always → the 22 repo-shape checker **engines**, byte-identical strings to ci.yml (unittest halves added only when `scripts/**` is touched). server → CI's exact ruff check / ruff format --check / mypy-ratchet commands + the touched domains' tests at `-n 2` with server-ci's `env:` block mirrored as defaults; **loud skip** when Postgres/Redis are down. rust → `cargo fmt --check` + clippy on touched crates (info mode until the lint-wiring allow-list; fail = compile error only) + nextest on touched crates (loud skip if cargo-nextest absent). frontend → per-package CI typecheck commands, `vitest related` for product-client, the design theme-equality law via the package's own `build` (= tsc → generate → check). Output: `[gate] <name> … ok|FAIL|skipped(<reason>)`, every FAIL prints its re-run command; line-buffered for agent pipes.
- **`scripts/git-hooks/pre-commit`** (replaced): format-only — ruff format on staged server .py, rustfmt on staged .rs — auto-fix + restage, **exits 0 always**; biome slot commented until the format slice. Its two former checks moved, not died: appearance-scaling lives in the gate's always-set, theme-equality in the gate's design rule.
- **`scripts/git-hooks/pre-push`** (new): runs `make gate`; red prints fix-or-CI-verify, never suggests `--no-verify`.
- **`Makefile`**: `gate:` target; `git-hooks` message names both hooks + the escape hatch.
- **`ci.yml`**: one repo-shape step running `scripts/test_gate.py` (38 tests: classification, crate/domain mapping, skip semantics, and the MIRROR-RULE pins — including a **two-directional census**: the gate's python3 commands and the repo-shape job's python3 steps must be exactly equal sets, so a new checker step cannot land without teaching the gate in the same PR).
- **`scripts/test_check_appearance_scaling.py`**: the hook-parity test now pins the new doctrine (commit hook formats only; the gate is the local guard; pre-push runs the gate) instead of the old path-filter parity.

## Acceptance gate (verbatim from the delivery spec — performed by Pablo, locally)

> Touch one file under `server/proliferate/`, run `make gate`: only the server checks plus the always-set run, the whole run finishes in under 2 minutes warm, and every command it prints is the same string the corresponding CI step runs. Falsifier: the gate is green but the same push goes red in CI on a check the gate claimed to have run · the gate runs frontend or Rust checks for a server-only diff · a formatter failure blocks a commit. Secondary: with local Postgres/Redis stopped, the server-test step reports a loud skip naming what was not run — and exits green.

## Evidence

- Clean tree (this branch): `38 checks in 70s — 0 failed, 0 loudly skipped`.
- Synthetic server-only diff (billing — the **largest** domain, 24 files / 160 tests): scoped to exactly server + always-set (+ this branch's scripts-proofs), tests green at `-n 2` in 68s; totals 151s cold / ~106s warm without the scripts-proofs a real server diff wouldn't trigger. Smaller domains land well under 2 min.
- The falsifier fired for real during verification: an unformatted synthetic edit made `server: ruff format` FAIL with the exact CI re-run command — the gate catching precisely what it exists to catch.
- Services-down loud-skip: pinned by unit test (injected branch). Not exercised live — stopping the shared local Postgres would disrupt parallel sessions; the skip path is 6 lines and unit-covered.
- `python3 -m unittest scripts/test_gate.py` 27/27 · `node --test scripts/ci-cd/*.test.mjs` 199/199 · ruby YAML parse of ci.yml green · `sh -n` both hooks.

## Documented deviations (in the freeze, restated here)

- mypy ratchet runs `--compare-ref origin/main` locally vs CI's event-specific `--github-event-base` — same checker, same baseline.
- Theme equality runs as `pnpm --filter @proliferate/design build`, which *is* the spec'd tsc → generate → check sequence (the package's own build law).
- **Implementation note (contradiction with the frozen spec, raised not absorbed):** the freeze says the rust plane runs `cargo fmt --check` as a gating step. Reality discovered by the refuter: the workspace has **608 pre-existing rustfmt diffs** under the current stable (rustfmt 1.9.0; the earlier "clean" measurement was a false negative — same not-installed pipe trap as clippy), and **no CI workflow runs fmt today**, so a hard local fmt gate would violate the mirror rule and fail every rust push on inherited debt. `rust: fmt` therefore runs **advisory** (reports the diff count, never fails) until the lint-wiring slice normalizes the workspace and lands the rust-lint CI job — at which point the promotion to gating is a one-line change. Handed off to the lint-wiring slice via the coordinator.

## Findings triage

| # | Finding | Outcome |
|---|---------|---------|
| 1 | (self-caught) untracked new files didn't scope a by-hand run | **Fixed**: `git ls-files --others --exclude-standard` in the change set |
| 2 | (self-caught) domain tests failed on clean env — gate didn't provide the CI env block | **Fixed**: server-ci's `env:` mirrored as defaults, exported values win; pinned by test |
| 3 | (self-caught) `cargo nextest` absent = confusing hard FAIL | **Fixed**: loud skip with install hint |
| 4 | (self-caught) `--all` dead on unresolvable origin/main; block-buffered output through pipes; `cargo fmt --all` touched unstaged files | **Fixed**: `--all` precedence; line-buffering; rustfmt scoped to staged files |
| R1 | **BLOCKER** — pre-commit's `cargo fmt -- <files>` doesn't scope: cargo-fmt appends file args to the full workspace target list (refuter demonstrated a diff reported in a never-passed file), so one staged .rs would silently reformat the whole working tree | **Fixed**: direct `rustfmt --edition 2021 <files>` (edition mirrors the workspace) |
| R2 | **BLOCKER** — gate's `cargo fmt --check` guaranteed red: 608 pre-existing workspace diffs (verified live) and no CI fmt step exists — mirror-rule violation that trains `--no-verify` | **Fixed**: `rust: fmt` is advisory (reports count, never fails) until the lint-wiring slice lands the format + CI job; contradiction with the freeze recorded above |
| R3 | pre-commit restaged the unfiltered python list — `git add` of a staged-then-deleted .py stages the deletion | **Fixed**: existence-filtered on both branches |
| R4 | unconditional restage staged a partially-staged file's unstaged hunks even when formatting changed nothing | **Fixed**: `git hash-object` before/after; only actually-changed files restage |
| R5 | SCRIPTS_PROOFS uv-missing skip wasn't loud (spec: missing tools = loud) | **Fixed**: loud |
| R6 | root `package.json`/lockfile/workspace/tsconfig and `scripts/**/*.mjs` mapped to no plane — dependency bumps and ci-cd tooling edits ran only the always-set | **Fixed**: root manifests → shared typecheck; `.mjs` → the three CI node-test suites (mirrored strings); plus an "unmapped paths" info line as the catch-all |
| R7 | empty-domain server diffs silently ran no tests; changed test files themselves never ran | **Fixed**: changed `server/tests/**` files always run; the no-mapped-tests case prints a LOUD note naming CI as the full-suite authority |
| R8 | mirror pins were one-directional substring matches — a new repo-shape step or added flags stayed green | **Fixed**: two-directional set-equality census of the job's python3 lines (comments excluded); folded-uv + node-test + frontend pins kept |
| R9 | no-tomllib-interpreter case ran engines into failures rather than loud skips | **Fixed**: `apply_engine_availability` → loud skips |
| R10 | `gate` missing from .PHONY — a file named `gate` would make `make gate` a silent no-op with pre-push exiting 0 | **Fixed** |
| R11 | services probe was 127.0.0.1-only; IPv6-bound Postgres loud-skipped despite being up | **Fixed**: probe `localhost` (getaddrinfo covers both) |
| R12 | pre-push ran the full gate for tag pushes and ref deletions | **Fixed**: stdin ref parsing; delete/tag-only pushes skip |
| R13 | appearance-scaling pin could match a commented-out line | **Fixed**: pins the exact ALWAYS_ENGINES tuple entry |

Post-fix verification: `make gate` green end-to-end (38 checks / 58s, advisory + unmapped lines working) · test_gate 38/38 under both 3.9 and 3.12 · appearance suite 59/59 · ci-cd node tests 199/199 · ci.yml YAML valid · both hooks `sh -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
