### PR TITLE
ci(staging): converge deploys on the newest fully green main commit — event-driven dual-rollup gating

### DIFF
--- a/.github/workflows/_deploy-litellm.yml
+++ b/.github/workflows/_deploy-litellm.yml
@@ -121,6 +121,7 @@ jobs:
 
       - name: Build and push LiteLLM image
         if: ${{ steps.switch.outputs.deploy == 'true' }}
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -129,6 +130,18 @@ jobs:
           tags: |
             ${{ steps.image.outputs.image_uri }}
             ${{ steps.ecr.outputs.registry }}/${{ env.ECR_LITELLM_REPOSITORY }}:${{ inputs.environment }}-latest
+
+      - name: Pin the image to its immutable digest
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        id: pinned
+        # The task definition must reference repo@sha256:… like the server
+        # lane does: a tag is mutable, so a later push to the same short-SHA
+        # tag would silently change what a scale-up or task restart runs.
+        run: |
+          set -euo pipefail
+          digest="${{ steps.build.outputs.digest }}"
+          test -n "$digest"
+          echo "image_ref=${{ steps.ecr.outputs.registry }}/${ECR_LITELLM_REPOSITORY}@${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Render ECS task definition
         if: ${{ steps.switch.outputs.deploy == 'true' }}
@@ -179,7 +192,7 @@ jobs:
 
           jq \
             --arg container "$ECS_LITELLM_CONTAINER_NAME" \
-            --arg image "${{ steps.image.outputs.image_uri }}" \
+            --arg image "${{ steps.pinned.outputs.image_ref }}" \
             --slurpfile updates env-updates.json \
             --slurpfile secret_updates secret-updates.json \
             '
@@ -247,7 +260,7 @@ jobs:
             echo "- Environment: $DEPLOY_ENVIRONMENT"
             echo "- Deploy switch: \`$LITELLM_DEPLOY_ENABLED\`"
             if [[ "${{ steps.switch.outputs.deploy }}" == "true" ]]; then
-              echo "- Image: \`${{ steps.image.outputs.image_uri }}\`"
+              echo "- Image: \`${{ steps.pinned.outputs.image_ref }}\` (tagged \`${{ steps.image.outputs.image_uri }}\`)"
               echo "- Task definition: \`${{ steps.task.outputs.task_definition_arn }}\`"
               echo "- Service: \`$ECS_CLUSTER/$ECS_LITELLM_SERVICE\`"
             fi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,10 +4,18 @@
 # Operators keep workflow_dispatch for reruns, forced surfaces, and dry runs.
 # Production is untouched by this path: release.yml stays its only entrypoint.
 name: Deploy Staging
+# The UI otherwise shows the default-branch head for every workflow_run event,
+# which reads as "deploying X" while actually deploying Y.
+run-name: "Deploy Staging · ${{ github.event.workflow_run.head_sha || github.event.inputs.ref || github.sha }} · ${{ github.event_name }}"
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    # Either rollup's completion can be the one that finds both green; the plan
+    # deploys only when CI AND Server CI are both success for the deploy head,
+    # and the earlier event exits neutrally. Re-running a red rollup to green
+    # re-fires this trigger (the old in-job poll caught neither re-runs nor
+    # anything beyond its 45-minute window).
+    workflows: ["CI", "Server CI"]
     types: [completed]
     branches: [main]
   workflow_dispatch:
@@ -57,6 +65,7 @@ jobs:
     outputs:
       base_sha: ${{ steps.detect.outputs.base_sha }}
       head_sha: ${{ steps.detect.outputs.head_sha }}
+      proceed: ${{ steps.head.outputs.proceed }}
       dry_run: ${{ steps.meta.outputs.dry_run }}
       server: ${{ steps.detect.outputs.server }}
       workers: ${{ steps.detect.outputs.workers }}
@@ -83,96 +92,133 @@ jobs:
         run: |
           set -euo pipefail
           head_sha="$(git rev-parse HEAD)"
-          fallback="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-list --max-parents=0 "$head_sha" | tail -n1)"
           dry_run="${DRY_RUN:-false}"
           {
             echo "head_sha=$head_sha"
-            echo "fallback_sha=$fallback"
             echo "dry_run=$dry_run"
           } >> "$GITHUB_OUTPUT"
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
 
-      - name: Wait for Server CI if present
+      - name: Resolve the deploy head and base
+        id: head
+        # One step owns "what do we deploy, from what base, and may we":
+        #   1. Auto runs advance to the NEWEST first-parent main commit
+        #      at-or-after the event head whose CI and Server CI rollups are
+        #      both success — deploys converge on the newest proven commit no
+        #      matter which rollup finished last or in what order the events
+        #      arrive (post-merge refuter findings on #2269: completion-order
+        #      latest-wins could cancel a newer commit's deploy in favor of an
+        #      older one's). If nothing at-or-after the head is fully green
+        #      yet, exit neutrally: a later completion event will deploy.
+        #   2. Dispatch runs deploy the operator's exact ref, single-shot
+        #      checked: an existing red or pending rollup refuses out loud; a
+        #      missing rollup warns and continues (operator judgment).
+        #   3. The regression guard: never deploy a head that the last
+        #      successfully deployed commit does not precede — an out-of-order
+        #      event cannot roll staging backwards.
         run: |
           set -euo pipefail
-          head_sha="${{ steps.meta.outputs.head_sha }}"
+          event_head="${{ steps.meta.outputs.head_sha }}"
 
-          for _ in $(seq 1 90); do
-            mapfile -t runs < <(
-              gh run list \
-                --workflow server-ci.yml \
-                --commit "$head_sha" \
-                --limit 20 \
-                --json databaseId,status,conclusion,url \
-                --jq '.[] | select(.conclusion != "skipped") | [.databaseId, .status, (.conclusion // ""), .url] | @tsv'
-            )
+          rollup_status() {
+            local sha="$1" wf="$2"
+            gh run list \
+              --workflow "$wf" \
+              --commit "$sha" \
+              --limit 10 \
+              --json createdAt,status,conclusion \
+              --jq '[.[] | select(.conclusion != "skipped")] | sort_by(.createdAt) | last
+                    | if . == null then "missing"
+                      elif .status != "completed" then "pending"
+                      else .conclusion end'
+          }
 
-            if [[ "${#runs[@]}" -eq 0 ]]; then
-              echo "No Server CI run found for $head_sha; continuing."
+          deploy_head=""
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            git fetch --quiet origin main
+            while read -r candidate; do
+              git merge-base --is-ancestor "$event_head" "$candidate" || continue
+              green=true
+              for wf in ci.yml server-ci.yml; do
+                status="$(rollup_status "$candidate" "$wf")"
+                echo "$wf @ ${candidate:0:9}: $status"
+                [[ "$status" == "success" ]] || { green=false; break; }
+              done
+              if [[ "$green" == "true" ]]; then
+                deploy_head="$candidate"
+                break
+              fi
+            done < <(git rev-list --first-parent --max-count=30 origin/main)
+
+            if [[ -z "$deploy_head" ]]; then
+              echo "No fully green main commit at-or-after $event_head yet; the other rollup's completion event will deploy."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-
-            pending=0
-            for run in "${runs[@]}"; do
-              IFS=$'\t' read -r run_id status conclusion url <<< "$run"
-              if [[ "$status" != "completed" ]]; then
-                echo "Server CI $run_id is $status; waiting. $url"
-                pending=1
-                continue
-              fi
-              if [[ "$conclusion" != "success" ]]; then
-                echo "Server CI $run_id finished with $conclusion. $url" >&2
-                exit 1
-              fi
+          else
+            deploy_head="$event_head"
+            for wf in ci.yml server-ci.yml; do
+              status="$(rollup_status "$deploy_head" "$wf")"
+              case "$status" in
+                success) echo "$wf green for $deploy_head." ;;
+                missing) echo "::warning::No $wf run found for $deploy_head; continuing on operator judgment." ;;
+                *)
+                  echo "::error::$wf for $deploy_head is $status; deploy refused. Re-dispatch once it is green." >&2
+                  exit 1
+                  ;;
+              esac
             done
+          fi
 
-            if [[ "$pending" == "0" ]]; then
-              echo "Server CI succeeded for $head_sha."
-              exit 0
-            fi
+          fallback="$(git rev-parse "${deploy_head}^" 2>/dev/null || git rev-list --max-parents=0 "$deploy_head" | tail -n1)"
+          base_sha="$(
+            node scripts/ci-cd/resolve-deploy-base.mjs \
+              --workflow deploy-staging.yml \
+              --branch main \
+              --head "$deploy_head" \
+              --fallback "$fallback" \
+              --required-artifact deploy-summary-staging
+          )"
+          base_mode="$(grep '^base_mode=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2)"
 
-            sleep 30
-          done
+          if [[ "$base_mode" == "resolved" ]] && ! git merge-base --is-ancestor "$base_sha" "$deploy_head"; then
+            echo "Regression guard: last deployed $base_sha is not an ancestor of $deploy_head; refusing to move staging backwards."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          echo "Timed out waiting for Server CI for $head_sha." >&2
-          exit 1
+          {
+            echo "deploy_head=$deploy_head"
+            echo "base_sha=$base_sha"
+            echo "proceed=true"
+          } >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Resolve previous successful staging deploy
-        id: base
-        run: >
-          node scripts/ci-cd/resolve-deploy-base.mjs
-          --workflow deploy-staging.yml
-          --branch main
-          --head "${{ steps.meta.outputs.head_sha }}"
-          --fallback "${{ steps.meta.outputs.fallback_sha }}"
-          --required-artifact deploy-summary-staging
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
       - name: Detect deploy surfaces
+        if: ${{ steps.head.outputs.proceed == 'true' }}
         id: detect
         run: >
           node scripts/ci-cd/detect-deploy-surfaces.mjs
-          --base "${{ steps.base.outputs.base_sha }}"
-          --head "${{ steps.meta.outputs.head_sha }}"
+          --base "${{ steps.head.outputs.base_sha }}"
+          --head "${{ steps.head.outputs.deploy_head }}"
           --force "$FORCE_SURFACES"
           --only "$ONLY_SURFACES"
         env:
           # A staleness fallback (no resolvable prior deploy) must deploy the
           # full surface set, not head^-diff to a near-no-op — unless the
           # operator explicitly chose surfaces.
-          FORCE_SURFACES: ${{ github.event.inputs.force_surfaces || (steps.base.outputs.base_mode == 'fallback' && 'all') || '' }}
+          FORCE_SURFACES: ${{ github.event.inputs.force_surfaces || (steps.head.outputs.base_mode == 'fallback' && 'all') || '' }}
           ONLY_SURFACES: ${{ github.event.inputs.only_surfaces || '' }}
 
       - name: Summarize plan
+        if: ${{ steps.head.outputs.proceed == 'true' }}
         run: |
           {
             echo "### Staging deploy plan"
             echo "- Trigger: \`${{ github.event_name }}\`"
-            echo "- Base: \`${{ steps.detect.outputs.base_sha }}\` (\`${{ steps.base.outputs.base_mode }}\`)"
+            echo "- Base: \`${{ steps.detect.outputs.base_sha }}\` (\`${{ steps.head.outputs.base_mode }}\`)"
             echo "- Head: \`${{ steps.detect.outputs.head_sha }}\`"
             echo "- Changed files: \`${{ steps.detect.outputs.changed_files_count }}\`"
             echo "- Dry run: \`${{ steps.meta.outputs.dry_run }}\`"
@@ -195,7 +241,7 @@ jobs:
 
   deploy-server:
     needs: [plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.proceed == 'true' && needs.plan.outputs.dry_run != 'true' }}
     uses: ./.github/workflows/_deploy-server.yml
     with:
       environment: staging
@@ -205,7 +251,7 @@ jobs:
 
   deploy-litellm:
     needs: [plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.proceed == 'true' && needs.plan.outputs.dry_run != 'true' }}
     uses: ./.github/workflows/_deploy-litellm.yml
     with:
       environment: staging
@@ -215,7 +261,7 @@ jobs:
 
   deploy-web:
     needs: [plan, deploy-server]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.proceed == 'true' && needs.plan.outputs.dry_run != 'true' }}
     uses: ./.github/workflows/_deploy-web.yml
     with:
       environment: staging
@@ -225,7 +271,7 @@ jobs:
 
   deploy-desktop:
     needs: [plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.proceed == 'true' && needs.plan.outputs.dry_run != 'true' }}
     permissions:
       contents: write
       id-token: write
@@ -245,7 +291,9 @@ jobs:
       - deploy-litellm
       - deploy-web
       - deploy-desktop
-    if: ${{ always() && needs.plan.result == 'success' }}
+    # A guarded run (proceed=false) writes no summary artifact: the artifact is
+    # the base-resolution anchor, and an undeployed head must never become one.
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Write deploy summary artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,6 +37,11 @@ on:
         default: false
         required: false
         type: boolean
+      allow_regression:
+        description: Deploy even if the ref is behind the last deployed commit (deliberate rollback).
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   actions: read
@@ -123,15 +128,19 @@ jobs:
 
           rollup_status() {
             local sha="$1" wf="$2"
+            # Any completed success for the SHA counts (same commit = same
+            # code): a later cancelled duplicate run must not mask an earlier
+            # green one.
             gh run list \
               --workflow "$wf" \
               --commit "$sha" \
               --limit 10 \
               --json createdAt,status,conclusion \
-              --jq '[.[] | select(.conclusion != "skipped")] | sort_by(.createdAt) | last
-                    | if . == null then "missing"
-                      elif .status != "completed" then "pending"
-                      else .conclusion end'
+              --jq '[.[] | select(.conclusion != "skipped")] as $runs
+                    | if ($runs | length) == 0 then "missing"
+                      elif ($runs | any(.status == "completed" and .conclusion == "success")) then "success"
+                      elif ($runs | any(.status != "completed")) then "pending"
+                      else ($runs | sort_by(.createdAt) | last | .conclusion) end'
           }
 
           deploy_head=""
@@ -143,7 +152,18 @@ jobs:
               for wf in ci.yml server-ci.yml; do
                 status="$(rollup_status "$candidate" "$wf")"
                 echo "$wf @ ${candidate:0:9}: $status"
-                [[ "$status" == "success" ]] || { green=false; break; }
+                # Server CI's push trigger is PATH-FILTERED (server/**,
+                # catalogs/**, locks…), so most main commits have no Server CI
+                # run at all — `missing` is green for it. CI's push trigger is
+                # unfiltered: a missing CI run is genuinely not-proven.
+                case "$wf:$status" in
+                  ci.yml:success) ;;
+                  server-ci.yml:success | server-ci.yml:missing) ;;
+                  *)
+                    green=false
+                    break
+                    ;;
+                esac
               done
               if [[ "$green" == "true" ]]; then
                 deploy_head="$candidate"
@@ -181,11 +201,42 @@ jobs:
               --required-artifact deploy-summary-staging
           )"
           base_mode="$(grep '^base_mode=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2)"
+          already_deployed="$(grep '^already_deployed=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2)"
 
-          if [[ "$base_mode" == "resolved" ]] && ! git merge-base --is-ancestor "$base_sha" "$deploy_head"; then
-            echo "Regression guard: last deployed $base_sha is not an ancestor of $deploy_head; refusing to move staging backwards."
+          # Both rollups fire one event each per commit; when the earlier
+          # event's run executes after both are already green, it would resolve
+          # the SAME deploy head — and the base scan's self-exclusion would
+          # anchor it on the OLDER base, re-deploying an identical delta twice.
+          # Operator dispatch stays allowed to re-deploy on purpose.
+          if [[ "${{ github.event_name }}" == "workflow_run" && "$already_deployed" == "true" ]]; then
+            echo "$deploy_head is already the newest deployed head (duplicate rollup event); nothing to do."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # A force-push can remove the last-deployed commit from history; an
+          # unresolvable base is staleness (deploy everything), never a wedge.
+          if [[ "$base_mode" == "resolved" ]] && ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "::warning::Last deployed commit $base_sha is absent from this history (force-push?); treating the base as stale and deploying the full surface set."
+            base_sha="$fallback"
+            base_mode="fallback"
+            {
+              echo "base_sha=$base_sha"
+              echo "base_mode=fallback"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$base_mode" == "resolved" ]] && ! git merge-base --is-ancestor "$base_sha" "$deploy_head"; then
+            if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+              echo "Regression guard: last deployed $base_sha is not an ancestor of $deploy_head; refusing to move staging backwards."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            elif [[ "${{ github.event.inputs.allow_regression }}" == "true" ]]; then
+              echo "::warning::Deploying $deploy_head although it is behind the last deployed $base_sha (allow_regression)."
+            else
+              echo "::error::$deploy_head is behind the last deployed $base_sha. Re-dispatch with allow_regression: true to roll staging back deliberately." >&2
+              exit 1
+            fi
           fi
 
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 # The one pipeline that moves Main to Production.
 #
-# States: Main (passed CI), Staging (deployed, not e2e-proven), Production.
-# Merging to main deploys nothing; continuous staging is retired and
-# `deploy-staging.yml` is manual-only. This workflow is the single transition
-# from a main commit to production, run unattended by the daily cron or
-# dispatched by hand.
+# States: Main (passed CI), Staging (auto-deployed from green main, the
+# standing e2e world), Production. `deploy-staging.yml` owns main -> staging;
+# this workflow is the single transition from a main commit to production —
+# run unattended by the daily cron (transitional: it retires once the nightly
+# e2e battery stands and promotion becomes deliberate) or dispatched by hand.
 #
 # Hotfix and promote are inputs here, not separate files:
 #   hotfix  = ref (exact commit on main) + surfaces (exact set)

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -19,16 +19,43 @@ function workflowNames() {
 function triggerBlock(source, name) {
   const start = source.indexOf("\non:");
   assert.notEqual(start, -1, `${name}: could not locate the on: trigger block`);
-  const end = source.indexOf("\npermissions:", start);
-  const block = source.slice(start, end === -1 ? undefined : end);
+  // End at the NEXT top-level key, whatever it is — slicing to a hard-coded
+  // `permissions:` let a workflow without one leak job keys into the block.
+  const rest = source.slice(start + 1);
+  const next = rest.slice("on:".length).search(/\n[A-Za-z_-]+:/);
+  const block = next === -1 ? rest : rest.slice(0, next + "on:".length);
   assert.notEqual(block.trim(), "", `${name}: trigger block is empty`);
   return block;
 }
 
-// A workflow starts from main when it chains off another workflow's run or
-// filters on the main branch. `branches:` accepts a flow sequence
-// (`[main]`) and a block sequence (`\n  - main`); both forms must be caught.
-const MAIN_BRANCH_FILTER = /branches:\s*(?:\[[^\]]*\bmain\b[^\]]*\]|(?:\r?\n\s*-\s*["']?main["']?))/;
+// Every event name a workflow is triggered by, across all three YAML
+// spellings: `on: push` (scalar), `on: [push, workflow_dispatch]` (flow
+// sequence), and the block map. Filters (branches/tags/paths) are irrelevant
+// here on purpose: a bare `push:`, `push: tags:`, or `branches: ['**']` is
+// exactly the porous spelling the previous filter-matching scan waved through.
+function triggerEvents(source, name) {
+  const scalar = source.match(/^on:\s*([a-z_]+)\s*$/m);
+  if (scalar) return [scalar[1]];
+  const flow = source.match(/^on:\s*\[([^\]]*)\]/m);
+  if (flow) {
+    return flow[1]
+      .split(",")
+      .map((entry) => entry.trim().replace(/["']/g, ""))
+      .filter(Boolean);
+  }
+  const block = triggerBlock(source, name);
+  return [...block.matchAll(/^\s{2}([a-z_]+):/gm)].map((match) => match[1]);
+}
+
+// Events that fire without a human pressing anything on this repository.
+const AUTOMATIC_EVENTS = new Set([
+  "push",
+  "pull_request",
+  "pull_request_target",
+  "workflow_run",
+  "merge_group",
+  "repository_dispatch",
+]);
 // `Production` and `production` are the same GitHub Environment reference as
 // far as a reviewer scanning for prod reach is concerned, and the two deleted
 // coordinators both used the lowercase spelling. The spellings are NOT
@@ -40,10 +67,19 @@ const PRODUCTION_ENVIRONMENT = /environment:\s*["']?[Pp]roduction["']?/;
 test("staging deploys from green main and from an operator", () => {
   const triggers = triggerBlock(workflow, "deploy-staging.yml");
 
-  // The one automated transition: a completed `CI` run on main.
+  // The one automated transition: either rollup's completion on main (the
+  // plan deploys only when both are green for the head; the earlier event
+  // exits neutrally, and a re-run-to-green re-fires the trigger).
   assert.match(
     triggers,
-    /workflow_run:\n    workflows: \["CI"\]\n    types: \[completed\]\n    branches: \[main\]/,
+    /workflow_run:\n(?:\s*#[^\n]*\n)*    workflows: \["CI", "Server CI"\]\n    types: \[completed\]\n    branches: \[main\]/,
+  );
+
+  // The run title names what is being deployed — every workflow_run row
+  // otherwise displays the default-branch head while deploying another SHA.
+  assert.match(
+    workflow,
+    /run-name: "Deploy Staging · \$\{\{ github\.event\.workflow_run\.head_sha \|\| github\.event\.inputs\.ref \|\| github\.sha \}\} · \$\{\{ github\.event_name \}\}"/,
   );
   // Operators keep dispatch for reruns, forced surfaces, and dry runs.
   assert.match(triggers, /workflow_dispatch:/);
@@ -77,26 +113,76 @@ test("staging deploys from green main and from an operator", () => {
   // A staleness fallback deploys everything unless the operator chose surfaces.
   assert.match(
     workflow,
-    /FORCE_SURFACES: \$\{\{ github\.event\.inputs\.force_surfaces \|\| \(steps\.base\.outputs\.base_mode == 'fallback' && 'all'\) \|\| '' \}\}/,
+    /FORCE_SURFACES: \$\{\{ github\.event\.inputs\.force_surfaces \|\| \(steps\.head\.outputs\.base_mode == 'fallback' && 'all'\) \|\| '' \}\}/,
   );
 });
 
-test("deploy-staging is the only workflow that auto-deploys from main", () => {
+test("deploy-staging is the only workflow that auto-deploys, and only release.yml deploys on a schedule", () => {
+  // A workflow deploys if it reaches a `_deploy-` lane directly OR through any
+  // chain of local reusable workflows — a non-`_deploy-` wrapper with
+  // `workflow_call` must not launder its callers past this scan.
+  const sources = new Map(workflowNames().map((name) => [name, read(name)]));
+  const memo = new Map();
+  const deploysTransitively = (name) => {
+    if (memo.has(name)) return memo.get(name);
+    memo.set(name, false); // cycle guard
+    const source = sources.get(name);
+    if (!source) return false;
+    const uses = [...source.matchAll(/uses: \.\/\.github\/workflows\/([\w.-]+\.ya?ml)/g)].map(
+      (match) => match[1],
+    );
+    const result =
+      uses.some((used) => used.startsWith("_deploy-")) ||
+      uses.some((used) => deploysTransitively(used));
+    memo.set(name, result);
+    return result;
+  };
+
   const automatic = [];
+  const scheduled = [];
   for (const name of workflowNames()) {
-    const source = read(name);
-    const triggers = triggerBlock(source, name);
-    const startsOnMain =
-      /workflow_run:/.test(triggers) || MAIN_BRANCH_FILTER.test(triggers);
-    const deploys = /uses: \.\/\.github\/workflows\/_deploy-/.test(source);
-    if (startsOnMain && deploys) {
-      automatic.push(name);
-    }
+    if (!deploysTransitively(name)) continue;
+    const events = triggerEvents(sources.get(name), name);
+    if (events.some((event) => AUTOMATIC_EVENTS.has(event))) automatic.push(name);
+    if (events.includes("schedule")) scheduled.push(name);
   }
 
-  // Staging is the sanctioned automatic transition; production reaches a
-  // deploy lane only through release.yml's cron/dispatch (pinned below).
+  // Staging is the sanctioned automatic transition. Production reaches a
+  // deploy lane only through release.yml — its daily cron is the transitional
+  // delivery path, pinned here until the retirement PR that makes promotion
+  // deliberate (ruled 2026-08-26).
   assert.deepEqual(automatic, ["deploy-staging.yml"]);
+  assert.deepEqual(scheduled, ["release.yml"]);
+});
+
+test("the plan resolves the deploy head against both rollups and guards regressions", () => {
+  // Refuter findings on #2269: completion-order latest-wins could deploy
+  // commits out of order (or cancel a newer commit's deploy in favor of an
+  // older one's), and the 45-minute Server CI poll neither survived a
+  // re-run-to-green nor a backed-up queue. The plan now advances to the
+  // newest fully green first-parent main commit and refuses to move staging
+  // backwards; the poll is gone in favor of completion events from both
+  // rollups.
+  assert.match(workflow, /workflows: \["CI", "Server CI"\]/);
+  assert.doesNotMatch(workflow, /Wait for Server CI if present/);
+  assert.doesNotMatch(workflow, /sleep 30/);
+  assert.match(workflow, /rollup_status\(\)/);
+  assert.match(workflow, /--workflow "\$wf"/);
+  assert.match(workflow, /for wf in ci\.yml server-ci\.yml; do/);
+  assert.match(workflow, /git rev-list --first-parent --max-count=\d+ origin\/main/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$event_head" "\$candidate"/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$base_sha" "\$deploy_head"/);
+  assert.match(workflow, /proceed=false/);
+
+  // The guard actually gates: detect and every deploy lane require proceed,
+  // and a guarded run must never upload the deploy-summary artifact that
+  // anchors base resolution.
+  assert.match(workflow, /if: \$\{\{ steps\.head\.outputs\.proceed == 'true' \}\}/);
+  const gatedJobs = workflow.match(/needs\.plan\.outputs\.proceed == 'true'/g) || [];
+  assert.ok(
+    gatedJobs.length >= 5,
+    `every deploy lane and the summary job must require plan.proceed (found ${gatedJobs.length})`,
+  );
 });
 
 test("release.yml is the only entrypoint into a production deploy lane", () => {

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -13,7 +13,11 @@ function read(name) {
 }
 
 function workflowNames() {
-  return readdirSync(workflowDir).filter((name) => name.endsWith(".yml"));
+  // GitHub honors both extensions; scanning only .yml would let an
+  // `evil.yaml` deployer past every doctrine test below.
+  return readdirSync(workflowDir).filter(
+    (name) => name.endsWith(".yml") || name.endsWith(".yaml"),
+  );
 }
 
 function triggerBlock(source, name) {
@@ -47,15 +51,12 @@ function triggerEvents(source, name) {
   return [...block.matchAll(/^\s{2}([a-z_]+):/gm)].map((match) => match[1]);
 }
 
-// Events that fire without a human pressing anything on this repository.
-const AUTOMATIC_EVENTS = new Set([
-  "push",
-  "pull_request",
-  "pull_request_target",
-  "workflow_run",
-  "merge_group",
-  "repository_dispatch",
-]);
+// Inverted to an allowlist on purpose: only these events require a human (or
+// an explicit caller) — EVERYTHING else (push, pull_request, workflow_run,
+// release, issue_comment, check_suite, status, deployment, create, …) counts
+// as automatic, so a novel trigger cannot slip past by not being on a
+// blocklist. `schedule` is classified separately and pinned to release.yml.
+const MANUAL_EVENTS = new Set(["workflow_dispatch", "workflow_call"]);
 // `Production` and `production` are the same GitHub Environment reference as
 // far as a reviewer scanning for prod reach is concerned, and the two deleted
 // coordinators both used the lowercase spelling. The spellings are NOT
@@ -117,7 +118,10 @@ test("staging deploys from green main and from an operator", () => {
   );
 });
 
-test("deploy-staging is the only workflow that auto-deploys, and only release.yml deploys on a schedule", () => {
+test("deploy-staging is the only workflow that auto-reaches a reusable deploy lane, and only release.yml does so on a schedule", () => {
+  // Scope, honestly: this scan covers reach through `uses:` of local reusable
+  // workflows. A deploy performed by shelling out (`gh workflow run`, raw
+  // aws-cli, a composite action) is invisible to it — review owns that class.
   // A workflow deploys if it reaches a `_deploy-` lane directly OR through any
   // chain of local reusable workflows — a non-`_deploy-` wrapper with
   // `workflow_call` must not launder its callers past this scan.
@@ -143,7 +147,9 @@ test("deploy-staging is the only workflow that auto-deploys, and only release.ym
   for (const name of workflowNames()) {
     if (!deploysTransitively(name)) continue;
     const events = triggerEvents(sources.get(name), name);
-    if (events.some((event) => AUTOMATIC_EVENTS.has(event))) automatic.push(name);
+    if (events.some((event) => event !== "schedule" && !MANUAL_EVENTS.has(event))) {
+      automatic.push(name);
+    }
     if (events.includes("schedule")) scheduled.push(name);
   }
 
@@ -173,6 +179,26 @@ test("the plan resolves the deploy head against both rollups and guards regressi
   assert.match(workflow, /git merge-base --is-ancestor "\$event_head" "\$candidate"/);
   assert.match(workflow, /git merge-base --is-ancestor "\$base_sha" "\$deploy_head"/);
   assert.match(workflow, /proceed=false/);
+
+  // Server CI's push trigger is path-filtered, so `missing` is green for it
+  // on the auto path (a frontend/docs-only commit has no Server CI run and no
+  // healing event would ever arrive); CI must be a real success.
+  assert.match(workflow, /server-ci\.yml:success \| server-ci\.yml:missing\)/);
+  assert.match(workflow, /ci\.yml:success\)/);
+  // Any completed success for the SHA counts; a later cancelled duplicate
+  // must not mask it.
+  assert.match(workflow, /any\(\.status == "completed" and \.conclusion == "success"\)/);
+
+  // Duplicate rollup events must not re-deploy an identical delta: the auto
+  // path refuses when the newest deployed head already equals the deploy head.
+  assert.match(workflow, /"\$already_deployed" == "true"/);
+
+  // A force-push that removed the last-deployed commit is staleness, not a
+  // permanent wedge; dispatch regressions refuse loudly unless the operator
+  // explicitly allows a rollback.
+  assert.match(workflow, /git cat-file -e "\$\{base_sha\}\^\{commit\}"/);
+  assert.match(workflow, /allow_regression/);
+  assert.match(workflow, /::error::\$deploy_head is behind the last deployed \$base_sha/);
 
   // The guard actually gates: detect and every deploy lane require proceed,
   // and a guarded run must never upload the deploy-summary artifact that

--- a/scripts/ci-cd/resolve-deploy-base.mjs
+++ b/scripts/ci-cd/resolve-deploy-base.mjs
@@ -84,12 +84,15 @@ export function resolutionOutputs(deployHeadSha, parsed) {
   return { baseSha: fallbackSha(parsed), baseMode: "fallback" };
 }
 
-function writeGithubOutput(baseSha, baseMode) {
+function writeGithubOutput(baseSha, baseMode, alreadyDeployed) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) {
     return;
   }
-  fs.appendFileSync(outputPath, `base_sha=${baseSha}\nbase_mode=${baseMode}\n`);
+  fs.appendFileSync(
+    outputPath,
+    `base_sha=${baseSha}\nbase_mode=${baseMode}\nalready_deployed=${alreadyDeployed}\n`
+  );
 }
 
 async function resolveCandidateDeployHeadSha(candidate, artifactName, token) {
@@ -125,7 +128,7 @@ async function main() {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
     const { baseSha, baseMode } = resolutionOutputs("", parsed);
-    writeGithubOutput(baseSha, baseMode);
+    writeGithubOutput(baseSha, baseMode, false);
     console.error(`base_mode=${baseMode} (no token)`);
     console.log(baseSha);
     return;
@@ -135,6 +138,11 @@ async function main() {
   const maxPages = readPositiveIntegerEnv("DEPLOY_RUN_SCAN_MAX_PAGES", 20);
   let run;
   let exhausted = false;
+  // Candidates arrive newest-first, so a head-matching artifact seen before
+  // the base is found means the NEWEST deployed head already equals --head:
+  // the caller's auto path uses this to refuse re-deploying an identical
+  // delta when both rollups' events resolve the same deploy head.
+  let alreadyDeployed = false;
   for (let page = 1; page <= maxPages && !run; page += 1) {
     const data = await listSuccessfulWorkflowRuns({
       workflow: parsed.workflow,
@@ -160,7 +168,11 @@ async function main() {
         parsed.requiredArtifact,
         token
       );
-      if (!deployHeadSha || deployHeadSha === parsed.head) {
+      if (deployHeadSha === parsed.head) {
+        alreadyDeployed = true;
+        continue;
+      }
+      if (!deployHeadSha) {
         continue;
       }
       run = { ...candidate, deployHeadSha };
@@ -175,8 +187,8 @@ async function main() {
   }
 
   const { baseSha, baseMode } = resolutionOutputs(run?.deployHeadSha || "", parsed);
-  writeGithubOutput(baseSha, baseMode);
-  console.error(`base_mode=${baseMode}`);
+  writeGithubOutput(baseSha, baseMode, alreadyDeployed);
+  console.error(`base_mode=${baseMode} already_deployed=${alreadyDeployed}`);
   console.log(baseSha);
 }
 

--- a/scripts/ci-cd/resolve-deploy-base.test.mjs
+++ b/scripts/ci-cd/resolve-deploy-base.test.mjs
@@ -50,7 +50,10 @@ test("the CLI writes base_sha and base_mode to GITHUB_OUTPUT on the token-less p
       [scriptPath, "--workflow", "deploy-staging.yml", "--head", "head99", "--fallback", "fff000"],
       { env, stdio: ["ignore", "pipe", "pipe"] },
     );
-    assert.equal(readFileSync(outputPath, "utf8"), "base_sha=fff000\nbase_mode=fallback\n");
+    assert.equal(
+      readFileSync(outputPath, "utf8"),
+      "base_sha=fff000\nbase_mode=fallback\nalready_deployed=false\n",
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Follow-up to #2269 under the same frozen delivery spec (`delivery/testing-cicd/delivery-spec-staging-pipeline.md`, #2267) — implements the **post-merge refuter findings 2 and 4–9** (the BLOCKER, finding 1, was hot-patched separately in #2279; its `if:`/concurrency lines are untouched here).

## Live reproduction (why finding 2 is real)

Tonight's 06:59Z batch behaved exactly as the refuter predicted: completion-order latest-wins coalesced **four pending deploys into cancellations**, staging held at 0.4.28 while newer commits were green, and the surviving 07:08 run deployed on an event whose arrival order — not commit order — decided what ran. This PR makes arrival order irrelevant.

## Scope summary

- **Finding 2 (MAJOR) — order-independent convergence + regression guard.** The plan's new `Resolve the deploy head and base` step: auto runs **advance to the newest first-parent `origin/main` commit at-or-after the event head whose CI AND Server CI are both green** and deploy that; if none exists yet, the run exits neutrally (`proceed=false`) and a later completion event deploys. After base resolution, the **regression guard** refuses any head the last-deployed commit does not precede (`git merge-base --is-ancestor`). Guarded runs skip detect/summarize/deploys **and upload no `deploy-summary-staging` artifact**, so an undeployed head can never become the base-resolution anchor.
- **Finding 4 — event-driven dual-rollup gate.** `workflow_run` now fires on **"CI" and "Server CI"**; whichever completes last finds both green and deploys. A Server CI **re-run-to-green now re-fires the trigger** (the old 45-minute in-job poll caught neither re-runs nor a backed-up queue — it is deleted). Dispatch runs get a single-shot check: red or pending rollup refuses out loud; a missing rollup warns and continues on operator judgment.
- **Finding 5 — doctrine scan hardened.** Trigger parsing now covers scalar (`on: push`), flow (`on: [push]`), and block forms, classifies by **event** (bare `push:`, `push: tags:`, `branches: ['**']` all count as automatic), and resolves `_deploy-` reach **transitively** so a `workflow_call` wrapper cannot launder its callers. New pins: automatic deployers == exactly `[deploy-staging.yml]`; **schedule deployers == exactly `[release.yml]`** (the transitional 9am cron, pinned until its retirement PR).
- **Finding 6 — the gate is pinned.** New test asserts: both-rollup trigger shape, `rollup_status` helper, first-parent advance, both `merge-base --is-ancestor` guards, `proceed=false` paths, the deleted sleep loop stays deleted, and ≥5 `proceed` gates across detect + the four lanes + summary.
- **Finding 7 — `run-name`** shows `workflow_run.head_sha || inputs.ref || sha` + event (today every auto run displays the default-branch head while deploying another SHA).
- **Finding 8 — `release.yml` header** rewritten to the current doctrine. **Comment-only, zero behavioral change, under the coordinator's explicit waiver** (release.yml is otherwise out of scope for this slice).
- **Finding 9 — litellm digest pin.** The task definition now references `repo@sha256:…` (from `build-push-action`'s digest output) instead of the mutable `:<shortsha>` tag, matching the server lane; the human-readable tag stays in the summary.

## Verification

- `node --test scripts/ci-cd/*.test.mjs` — **203/203** (rebased over #2279; its `if:`/concurrency pins verbatim)
- `ruby YAML.load_file` on all three touched workflows — parse
- No prod behavior touched (release.yml comment-only, waived); `_deploy-litellm.yml` change is task-def image reference only

## Findings triage

| # | Finding | Outcome |
|---|---|---|
| 1 | BLOCKER — fork-main trust + concurrency isolation | **Out of scope** — hot-patched in #2279 by the coordinator; lines untouched, pins kept verbatim |
| 2 | MAJOR — completion-order latest-wins misorders/cancels deploys | **Fixed** — advance-to-newest-fully-green + regression guard; guarded runs anchor nothing |
| 3 | MAJOR — reverse base delta can regress staging | **Fixed** — same guard (`is-ancestor base deploy_head` or refuse) |
| 4 | MINOR — re-run-to-green fires nothing; 45-min poll | **Fixed** — dual-rollup `workflow_run` + neutral-exit; poll deleted |
| 5 | MINOR — porous doctrine scan | **Fixed** — event-based + transitive; schedule set pinned |
| 6 | MINOR — gate step unpinned | **Fixed** — dedicated test |
| 7 | NIT — misleading run titles | **Fixed** — `run-name` |
| 8 | NIT — stale release.yml header | **Fixed** under waiver, comment-only |
| 9 | NIT — litellm mutable tag in task def | **Fixed** — digest-pinned |
| — | Accepted residual | A newer commit's plan-only run (other rollup pending) can supersede an older green pending deploy, then go red → staging trails by one commit until the next green push. Self-healing; deliberate consequence of the at-or-after advance formula. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)