### PR TITLE
feat(release): the staging battery — observe mode, nightly cron, durable session write-back, morning digest

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -25,10 +25,11 @@ name: Release E2E (tier 3)
 #     mapped to RELEASE_E2E_E2B_API_KEY) AND a publicly reachable server URL for
 #     E2B to deliver webhooks to — a locally booted server on 127.0.0.1 needs a
 #     tunnel, so sandbox scenarios self-report blocked without one.
-#   - The staging lane (against the real staging deployment + its gateway) is
-#     the README's documented CI target, but the staging gateway test key is not
-#     provisioned yet (RELEASE_E2E_GATEWAY_TEST_KEY on staging). Its job is left
-#     commented at the bottom until that key exists.
+#   - The staging battery (against the real staging deployment + its gateway)
+#     is the nightly primary: gateway key, durable org, and the rotating
+#     session credential are provisioned; the battery preflight hard-gates only
+#     on API_BASE_URL, and a missing session credential surfaces as blocked
+#     cells in the digest rather than a silent skip.
 
 on:
   schedule:
@@ -46,14 +47,6 @@ on:
         type: choice
         options:
           - all
-          - local
-          - staging
-      lane:
-        description: Runtime target lane the runner points at.
-        default: local
-        required: false
-        type: choice
-        options:
           - local
           - staging
       scenarios:
@@ -146,7 +139,18 @@ jobs:
       cancel-in-progress: false
     environment: staging
     steps:
-      - name: Preflight — staging credentials
+      # Checkout + node are unconditional: the digest step below must run even
+      # when the preflight disables the battery (it is plain node, no install).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      # The preflight hard-gates ONLY on the deployment URL. A missing session
+      # credential is NOT a gate: the runner reports those cells blocked and
+      # the digest carries it — a silent green skip is the one thing observe
+      # mode forbids.
+      - name: Preflight — staging deployment
         id: preflight
         env:
           GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
@@ -154,25 +158,20 @@ jobs:
           STAGING_SESSION_REFRESH_TOKEN: ${{ secrets.RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN }}
         run: |
           enabled=true
+          reason=""
           if [ -z "$STAGING_SERVER_URL" ]; then
-            echo "::notice title=Staging tier-3 skipped::staging API_BASE_URL variable is not set."
+            reason="staging API_BASE_URL variable is not set — the battery cannot target a deployment"
+            echo "::notice title=Staging battery skipped::$reason"
             enabled=false
           fi
           if [ -z "$STAGING_SESSION_REFRESH_TOKEN" ]; then
-            echo "::notice title=Staging tier-3 skipped::RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN (staging env secret) is not set — the durable staging user (proliferate-e2e-bot, GitHub-OAuth-only, no password) authenticates via a rotating session refresh token. Bootstrap one per tests/release/src/fixtures/staging-session.ts and add it (plus a rotation-durable mechanism) before this lane runs. Skipping cleanly."
-            enabled=false
+            echo "::notice title=Staging session bootstrap absent::RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN (staging env secret) is unset — the runner falls back to the cached rotating state; with neither, journeys report blocked in the digest. Recover with tests/release/scripts/staging-session-remint.sh."
           fi
           if [ -z "$GATEWAY_TEST_KEY" ]; then
-            echo "::notice title=Staging gateway key absent::RELEASE_E2E_GATEWAY_TEST_KEY not set — gateway-dependent scenarios report blocked. Billing-surface scenarios (T3-BILL-4) still run."
+            echo "::notice title=Staging gateway key absent::RELEASE_E2E_GATEWAY_TEST_KEY not set — gateway-dependent scenarios report blocked."
           fi
           echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: steps.preflight.outputs.enabled == 'true'
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: steps.preflight.outputs.enabled == 'true'
-        with:
-          node-version: "22"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
       - uses: pnpm/action-setup@v6
         if: steps.preflight.outputs.enabled == 'true'
         with:
@@ -238,23 +237,43 @@ jobs:
           if-no-files-found: ignore
 
       # Rotation write-back, half 2: persist the rotated state for the next run
-      # (always — a red battery still rotated the token).
-      - name: Save the rotating staging session state
+      # (always — a red battery still rotated the token). Guarded on the file
+      # actually existing: a run where no staging login happened (blocked
+      # cells, non-battery selector) must not fail on an empty cache save.
+      # Scope note: the Actions cache is branch-scoped — a branch dispatch
+      # seeds its own scope, and the nightly on main seeds main's on its first
+      # run from the bootstrap secret. That is safe because refresh does NOT
+      # revoke prior tokens (sessions.py mints stateless JWTs; the bootstrap
+      # stays valid for its 30-day lifetime) — the cache is an optimization,
+      # the secret is the floor, and staging-session-remint.sh is the recovery.
+      - name: Check for rotated session state
+        id: session-state
         if: always() && steps.preflight.outputs.enabled == 'true'
+        run: |
+          if [ -f "$GITHUB_WORKSPACE/.release-e2e/staging-session.json" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Save the rotating staging session state
+        if: always() && steps.session-state.outputs.present == 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.release-e2e/staging-session.json
           key: staging-session-state-${{ github.run_id }}-${{ github.run_attempt }}
 
-      # The morning digest: one message naming every journey's verdict. Never
-      # fails the job. Slack when the engineering-alerts webhook is provisioned,
-      # else the pinned "Staging battery — morning digest" issue.
+      # The morning digest: one message naming every journey's verdict — even
+      # when the preflight skipped the battery (NO RESULTS + the reason IS the
+      # signal; the acceptance-gate falsifier is "no digest arrives"). Never
+      # fails the job. Delivery chain: the battery webhook (spec name), else
+      # the engineering-alerts webhook, else the pinned digest issue.
       - name: Morning digest
-        if: always() && steps.preflight.outputs.enabled == 'true'
+        if: always()
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENGINEERING_ALERTS_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BATTERY_WEBHOOK_URL || secrets.SLACK_ENGINEERING_ALERTS_WEBHOOK_URL }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          DIGEST_NOTE: ${{ steps.preflight.outputs.reason }}
         run: >-
           node scripts/ci-cd/battery-digest.mjs
           --reports tests/release/.output

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -5,15 +5,14 @@ name: Release E2E (tier 3)
 # provision/pause/resume/connect, chat per cataloged agent, config apply,
 # secrets materialization, billing metering, repo settings.
 #
-# Cadence: on demand only (workflow_dispatch), never on `pull_request`. It
-# burns real money/time (E2B sandboxes, gateway LLM calls); the daily cron was
-# removed in the 2026-08 engineering cull — re-establishing a cadence is a
-# step-3 CI/CD-spec decision (delivery/engineering-cull/delivery-spec-ci-diet.md).
-# Tier 3 never gates ordinary merges. The legacy
-# local/staging jobs remain provisional and `continue-on-error`; the manual
-# protected-Qualification jobs are strict, preserve red exits, and upload V4
-# evidence for their selected exact-head scope. Production promotion does not
-# yet consume a complete Tier-3/Tier-4 aggregate.
+# Cadence (delivery/testing-cicd/delivery-spec-e2e-observable.md, ruled
+# 2026-08-26): the STAGING BATTERY runs nightly (cron below, ~01:00 PT) in
+# observe mode — red blocks nothing, one morning digest names every journey's
+# verdict — and on demand via workflow_dispatch. Every other job here is
+# dispatch-only and never runs on the cron. Tier 3 never gates ordinary
+# merges. The manual protected-Qualification jobs are strict, preserve red
+# exits, and upload V4 evidence for their selected exact-head scope.
+# Production promotion does not yet consume a complete Tier-3/Tier-4 aggregate.
 #
 # Honest scoping (the runner self-reports blocked/expected-fail per scenario
 # for anything it lacks credentials for; the gates below just avoid booting a
@@ -32,6 +31,9 @@ name: Release E2E (tier 3)
 #     commented at the bottom until that key exists.
 
 on:
+  schedule:
+    # The staging battery, nightly (~01:00 PT). Only release-e2e-staging keys on this.
+    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       manual_world:
@@ -110,229 +112,25 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  release-e2e-local:
-    name: tier-3 local lane (provisional)
-    # NOTE: with the daily cron removed (2026-08 cull) this schedule-only job is
-    # currently unreachable. Kept pending the step-3 CI/CD spec's ruling on the
-    # tier-3 cadence; delete or re-trigger it there, not here.
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    concurrency:
-      group: release-e2e-local
-      cancel-in-progress: false
-    # Provisional posture, enforced twice: the job name says so, and the job
-    # never fails the workflow while it is provisional (README CI mapping —
-    # tier 3 is not yet a merge gate).
-    continue-on-error: true
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: proliferate
-          POSTGRES_PASSWORD: localdev
-          POSTGRES_DB: proliferate
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U proliferate -d proliferate"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-    steps:
-      # Preflight gate (billing-suite pattern): a tier-3 local run needs the
-      # gateway test key to drive real agents in CI. Absent -> skip cleanly.
-      - name: Preflight — required credentials
-        id: preflight
-        env:
-          GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
-          DURABLE_USER_EMAIL: ${{ secrets.RELEASE_E2E_DURABLE_USER_EMAIL }}
-          DURABLE_USER_PASSWORD: ${{ secrets.RELEASE_E2E_DURABLE_USER_PASSWORD }}
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        run: |
-          enabled=true
-          if [ -z "$GATEWAY_TEST_KEY" ]; then
-            echo "::notice title=Tier-3 skipped::RELEASE_E2E_GATEWAY_TEST_KEY is not set. The local lane cannot drive real agents in CI without it (there is no native agent CLI login on the runner). Provision a LiteLLM virtual key for an e2e-tests team (cheap-model allowlist, see T3-CHAT-1) and add it as the RELEASE_E2E_GATEWAY_TEST_KEY secret. Skipping cleanly."
-            enabled=false
-          fi
-          if [ -z "$DURABLE_USER_EMAIL" ] || [ -z "$DURABLE_USER_PASSWORD" ]; then
-            echo "::notice title=Tier-3 durable identity self-seeded::RELEASE_E2E_DURABLE_USER_EMAIL / _PASSWORD not set — the runner seeds a per-run durable user through the real /setup claim (the stack is ephemeral), so local-lane server-mediated scenarios still run. Sandbox-lane scenarios that need the real persistent identity report blocked."
-          fi
-          if [ -z "$E2B_API_KEY" ]; then
-            echo "::notice title=Tier-3 sandbox lane absent::E2B_API_KEY not set — sandbox-lane scenarios will report blocked. (Note: even with the key, the sandbox lane needs a publicly reachable server URL / tunnel for E2B webhooks.)"
-          fi
-          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: steps.preflight.outputs.enabled == 'true'
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: steps.preflight.outputs.enabled == 'true'
-        with:
-          node-version: "22"
-      - uses: pnpm/action-setup@v6
-        if: steps.preflight.outputs.enabled == 'true'
-        with:
-          version: 10
-      - uses: astral-sh/setup-uv@v7
-        if: steps.preflight.outputs.enabled == 'true'
-      - uses: actions/setup-python@v7
-        if: steps.preflight.outputs.enabled == 'true'
-        with:
-          python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.preflight.outputs.enabled == 'true'
-      - uses: Swatinem/rust-cache@v2
-        if: steps.preflight.outputs.enabled == 'true'
-        with:
-          workspaces: "."
-
-      - name: Install workspace dependencies
-        if: steps.preflight.outputs.enabled == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Install server (venv, matches local layout)
-        if: steps.preflight.outputs.enabled == 'true'
-        run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
-
-      - name: Install system deps (Tauri crates in the workspace build)
-        if: steps.preflight.outputs.enabled == 'true'
-        # `make build-rust` compiles the whole workspace, including the Tauri
-        # desktop crate — same package set ci.yml installs for it.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: Build the AnyHarness runtime binary
-        if: steps.preflight.outputs.enabled == 'true'
-        # Builds the workspace once and copies the runtime into
-        # DEV_ANYHARNESS_TARGET_DIR, so downstream tooling and a laptop run
-        # resolve the same binary. Cargo state lives in the workspace target dir,
-        # which is what rust-cache above is pointed at.
-        run: make build-rust
-
-      - name: Boot the server + AnyHarness runtime, then run the tier-3 runner
-        if: steps.preflight.outputs.enabled == 'true'
-        env:
-          # Local stack wiring — the runner points at these (env-manifest.ts).
-          SINGLE_ORG_MODE: "true"
-          # CI-only server secrets (same throwaway values server-ci.yml uses;
-          # settings validation requires them when debug=False).
-          JWT_SECRET: release-e2e-ci-jwt-secret
-          CLOUD_SECRET_KEY: release-e2e-ci-cloud-secret
-          SETUP_TOKEN_FILE: /tmp/proliferate-ci-setup-token
-          DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
-          # Same URL the DB-seam probes (billing_probe.py, integration_audit_probe.py)
-          # read the local profile ledger/audit tables from.
-          RELEASE_E2E_LOCAL_DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
-          REDIS_URL: redis://127.0.0.1:6379/0
-          PROLIFERATE_API_PORT: "8086"
-          # The server's own base URL — worker enrollment mints the integration
-          # gateway URL from it (seam/workers/service.py worker_cloud_base_url);
-          # without it, /worker/enroll 500s cloud_worker_misconfigured (T3-INT-1).
-          API_BASE_URL: http://127.0.0.1:8086
-          ANYHARNESS_PORT: "8542"
-          ANYHARNESS_RUNTIME_HOME: ${{ github.workspace }}/.ci-runtime-home
-          RELEASE_E2E_SERVER_URL: http://127.0.0.1:8086
-          RELEASE_E2E_LOCAL_RUNTIME_URL: http://127.0.0.1:8542
-          # Credentials — mapped from repo secrets to the manifest's env names.
-          # Absent secrets expand to empty; the runner reports those scenarios
-          # blocked rather than failing (env-resolution.ts).
-          RELEASE_E2E_GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
-          # Public base URL of the gateway the test key was issued against
-          # (staging's AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL). With both set the
-          # runner pushes gateway agent-auth to the local runtime so harnesses
-          # chat with no native CLI login (env-manifest.ts).
-          RELEASE_E2E_GATEWAY_BASE_URL: ${{ secrets.RELEASE_E2E_GATEWAY_BASE_URL || 'https://staging-gateway.proliferate.com' }}
-          # Durable-user secrets are OPTIONAL for this lane: when absent the
-          # runner self-seeds a per-run durable user through the real /setup
-          # claim (the stack is ephemeral), and sandbox-lane scenarios that
-          # need the real persistent identity report blocked (#1069).
-          RELEASE_E2E_DURABLE_USER_EMAIL: ${{ secrets.RELEASE_E2E_DURABLE_USER_EMAIL }}
-          RELEASE_E2E_DURABLE_USER_PASSWORD: ${{ secrets.RELEASE_E2E_DURABLE_USER_PASSWORD }}
-          RELEASE_E2E_DURABLE_ORG_ID: ${{ secrets.RELEASE_E2E_DURABLE_ORG_ID }}
-          RELEASE_E2E_INTEGRATION_API_KEY: ${{ secrets.RELEASE_E2E_INTEGRATION_API_KEY }}
-          # E2B repo secrets carry the runner's manifest names.
-          RELEASE_E2E_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          RELEASE_E2E_E2B_TEAM_ID: ${{ secrets.RELEASE_E2E_E2B_TEAM_ID }}
-          # Stripe test mode for the billing scenarios' setup seam.
-          STRIPE_TEST_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
-          LANE: ${{ github.event.inputs.lane || 'local' }}
-          SCENARIOS: ${{ github.event.inputs.scenarios || 'all' }}
-          AGENTS: ${{ github.event.inputs.agents || 'all' }}
-        run: |
-          set -euo pipefail
-          # Apply migrations then boot the API server (headless — not `make run`,
-          # which also launches the Tauri desktop app).
-          ( cd server && .venv/bin/alembic upgrade head )
-          ( cd server && .venv/bin/uvicorn proliferate.main:app --host 127.0.0.1 --port 8086 ) &
-          SERVER_PID=$!
-          # Boot the AnyHarness runtime built above. ANTHROPIC_AUTH_TOKEN is
-          # exported to the runtime process because its session-create
-          # readiness gate reads only process env / native login files — it
-          # does not consult the gateway agent-auth state the runner pushes
-          # (PUT /v1/agent-auth/state), so a gateway-only environment would
-          # report claude LoginRequired. At launch the gateway render overrides
-          # ANTHROPIC_AUTH_TOKEN/_BASE_URL with the same key anyway, so this
-          # only satisfies the readiness check, never routes traffic.
-          ANTHROPIC_AUTH_TOKEN="$RELEASE_E2E_GATEWAY_TEST_KEY" \
-            ./target/runtime-local/debug/anyharness serve --host 127.0.0.1 --port 8542 &
-          RUNTIME_PID=$!
-          trap 'kill $SERVER_PID $RUNTIME_PID 2>/dev/null || true' EXIT
-
-          # Wait for both to report healthy.
-          for url in http://127.0.0.1:8086/health http://127.0.0.1:8542/health; do
-            for i in $(seq 1 60); do
-              if curl -fsS "$url" >/dev/null 2>&1; then break; fi
-              if [ "$i" = "60" ]; then echo "timed out waiting for $url"; exit 1; fi
-              sleep 2
-            done
-          done
-
-          make release-e2e LANE="$LANE" DESKTOP=web AGENTS="$AGENTS" SCENARIOS="$SCENARIOS"
-
-      - name: Upload failure reports
-        # always() (not failure()): the runner step is continue-on-error, so a
-        # red runner never flips the job to "failed" and failure() would skip
-        # this. Upload whenever the job ran the runner; the step no-ops when
-        # there are no reports.
-        if: always() && steps.preflight.outputs.enabled == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: release-e2e-reports
-          path: tests/release/.output/
-          retention-days: 7
-          if-no-files-found: ignore
-
   # ---------------------------------------------------------------------------
-  # Staging lane — the README's documented tier-3 CI target (real deployment,
-  # publicly reachable, real gateway with cheap models). Runs against the
-  # `staging` GitHub environment (its vars/secrets: API_BASE_URL,
-  # RELEASE_E2E_GATEWAY_TEST_KEY, RELEASE_E2E_DURABLE_ORG_ID, …). The staging
-  # gateway + durable org id + gateway test key are now provisioned; the one
-  # remaining gate is the browser-free durable-user session:
-  # RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN (a `staging` environment secret).
-  # Refresh tokens rotate on every use, so a durable-in-CI mechanism (a
-  # non-rotating bootstrap, or persisting the rotated state between runs) is
-  # still needed before this authenticates for real — until then the preflight
-  # skips cleanly (::notice::), the same pattern the local lane uses.
-  # The runner constrains this broad selector to Tier-3 sandbox-runtime cells;
-  # it never runs Tier-2, controller-local, self-host, or Tier-4 bodies here.
+  # Staging lane — THE STAGING BATTERY (delivery/testing-cicd/delivery-spec-e2e-observable.md).
+  # Runs against the `staging` GitHub environment (API_BASE_URL, WEB_URL,
+  # RELEASE_E2E_GATEWAY_TEST_KEY, RELEASE_E2E_DURABLE_ORG_ID, …). The durable
+  # user (proliferate-e2e-bot, GitHub-OAuth-only) authenticates through a
+  # rotating session refresh token: bootstrapped once into the
+  # RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN environment secret
+  # (tests/release/scripts/staging-session-remint.sh), then self-rotated by the
+  # runner and PERSISTED BETWEEN RUNS in the Actions cache (the restore/save
+  # steps below) — the write-back the July design never had. The concurrency
+  # group serializes runs so rotation never races.
+  # Observe mode: NO continue-on-error — red is visible and blocks nothing
+  # (this workflow is in no rollup or branch protection). The runner constrains
+  # the broad selector to Tier-3 sandbox-runtime cells (T3-*, incl. T3-BATT-*).
   release-e2e-staging:
-    name: tier-3 staging lane (provisional)
-    # NOTE: the 'schedule' clause below is dead since the 2026-08 cull removed
-    # the cron (this lane stays reachable via dispatch). Kept because the
-    # qualification-runner workflow test asserts this exact expression; clean it
-    # up with the step-3 cadence ruling.
+    name: staging battery (observe mode)
+    # The cron fires this job; a dispatch reaches it via manual_world
+    # (all|staging) unless it is a self-host-only dispatch. The qualification
+    # runner workflow test asserts this exact expression.
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' &&
@@ -340,10 +138,12 @@ jobs:
       (inputs.manual_world == 'all' || inputs.manual_world == 'staging'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
     concurrency:
       group: release-e2e-staging
       cancel-in-progress: false
-    continue-on-error: true
     environment: staging
     steps:
       - name: Preflight — staging credentials
@@ -387,16 +187,40 @@ jobs:
         if: steps.preflight.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Run tier-3 against staging
+      # Rotation write-back, half 1: restore the last run's rotated session
+      # state. Rolling key (one entry per run) + prefix restore = latest wins.
+      - name: Restore the rotating staging session state
+        if: steps.preflight.outputs.enabled == 'true'
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ github.workspace }}/.release-e2e/staging-session.json
+          key: staging-session-state-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            staging-session-state-
+
+      - name: Run the staging battery
         if: steps.preflight.outputs.enabled == 'true'
         env:
           # API_BASE_URL already includes the deployment's /api prefix, which is
           # exactly what RELEASE_E2E_SERVER_URL wants (env-manifest.ts).
           RELEASE_E2E_SERVER_URL: ${{ vars.API_BASE_URL }}
+          RELEASE_E2E_WEB_URL: ${{ vars.WEB_URL }}
           RELEASE_E2E_GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
           RELEASE_E2E_GATEWAY_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL || 'https://staging-gateway.proliferate.com' }}
+          # Bootstrap only: the runner prefers the restored state file above and
+          # falls back to this secret when no rotated state exists.
           RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN: ${{ secrets.RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN }}
+          RELEASE_E2E_STAGING_SESSION_STATE: ${{ github.workspace }}/.release-e2e/staging-session.json
           RELEASE_E2E_DURABLE_ORG_ID: ${{ vars.RELEASE_E2E_DURABLE_ORG_ID }}
+          # The durable staging user is proliferate-e2e-bot / support@proliferate.com
+          # (what the seed script and fixtures implement). The environment's
+          # RELEASE_E2E_DURABLE_USER_EMAIL names a different, non-existent
+          # identity and is deliberately NOT mapped here.
+          RELEASE_E2E_GITHUB_TEST_REPO: ${{ vars.RELEASE_E2E_GITHUB_TEST_REPO }}
+          RELEASE_E2E_GITHUB_TEST_TOKEN: ${{ secrets.RELEASE_E2E_GITHUB_TEST_TOKEN }}
+          RELEASE_E2E_INTEGRATION_API_KEY: ${{ secrets.RELEASE_E2E_INTEGRATION_API_KEY }}
+          AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
+          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
           RELEASE_E2E_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           RELEASE_E2E_E2B_TEAM_ID: ${{ vars.E2B_TEAM_ID }}
           LANE: staging
@@ -412,6 +236,30 @@ jobs:
           path: tests/release/.output/
           retention-days: 7
           if-no-files-found: ignore
+
+      # Rotation write-back, half 2: persist the rotated state for the next run
+      # (always — a red battery still rotated the token).
+      - name: Save the rotating staging session state
+        if: always() && steps.preflight.outputs.enabled == 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ github.workspace }}/.release-e2e/staging-session.json
+          key: staging-session-state-${{ github.run_id }}-${{ github.run_attempt }}
+
+      # The morning digest: one message naming every journey's verdict. Never
+      # fails the job. Slack when the engineering-alerts webhook is provisioned,
+      # else the pinned "Staging battery — morning digest" issue.
+      - name: Morning digest
+        if: always() && steps.preflight.outputs.enabled == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENGINEERING_ALERTS_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: >-
+          node scripts/ci-cd/battery-digest.mjs
+          --reports tests/release/.output
+          --lane staging
+          --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # ---------------------------------------------------------------------------
   # Local functional — "Complete Local Workspace Qualification (Functional)"

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ apps/packages/product-client/src/generated/
 # Local dev symlink into the root workspace node_modules (never committed)
 tests/release/node_modules
 tmp/
+.release-e2e/

--- a/scripts/ci-cd/battery-digest.mjs
+++ b/scripts/ci-cd/battery-digest.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// The staging battery's morning digest (delivery/testing-cicd/delivery-spec-e2e-observable.md;
+// specs/engineering/ci-cd/pipelines.md "Pipeline — nightly").
+//
+// Reads every qualification-evidence.json the runner wrote, groups the cells
+// by verdict, and delivers ONE message: "staging battery N/M green · red: … ·
+// expected-fail: … · blocked: …". Observe mode: this script never fails the
+// job (exit 0 always) and never per-failure alerts — one digest, once.
+//
+// Delivery: SLACK_WEBHOOK_URL when set (Block Kit-free plain text so every
+// workspace renders it), else the pinned digest issue (created once, its body
+// replaced nightly) via the GitHub REST API with GH_TOKEN + GITHUB_REPOSITORY.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const STATUS_ORDER = ["failed", "expected_fail", "blocked", "green", "cancelled", "not_run", "missing"];
+
+/** Recursively finds every qualification-evidence.json under `root` (sorted for determinism). */
+export function findReports(root) {
+  const found = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort()) {
+      const full = path.join(dir, entry);
+      let stats;
+      try {
+        stats = statSync(full);
+      } catch {
+        continue;
+      }
+      if (stats.isDirectory()) {
+        walk(full);
+      } else if (entry === "qualification-evidence.json") {
+        found.push(full);
+      }
+    }
+  };
+  walk(root);
+  return found;
+}
+
+/** One digest row per result cell across all reports, keyed by cell id (last report wins). */
+export function summarizeReports(reports) {
+  const cells = new Map();
+  for (const report of reports) {
+    for (const result of report.results ?? []) {
+      cells.set(result.cell_id, {
+        cellId: result.cell_id,
+        scenarioId: result.scenario_id,
+        status: result.status,
+        reason: result.reason?.message ?? null,
+      });
+    }
+  }
+  const rows = [...cells.values()].sort((a, b) => a.cellId.localeCompare(b.cellId));
+  const byStatus = {};
+  for (const row of rows) {
+    (byStatus[row.status] ??= []).push(row);
+  }
+  return { rows, byStatus, total: rows.length, green: (byStatus.green ?? []).length };
+}
+
+function oneLine(text, max = 160) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+/** The digest text. `lane` and `runUrl` are context; everything else is the summary. */
+export function formatDigest(summary, { lane = "staging", runUrl = null, when = new Date() } = {}) {
+  const day = when.toISOString().slice(0, 10);
+  const header =
+    summary.total === 0
+      ? `${lane} battery ${day}: NO RESULTS — the runner produced no evidence (check the run).`
+      : `${lane} battery ${day}: ${summary.green}/${summary.total} green`;
+  const lines = [header];
+  const label = { failed: "RED", expected_fail: "expected-fail", blocked: "blocked", green: "green" };
+  for (const status of STATUS_ORDER) {
+    const rows = summary.byStatus[status] ?? [];
+    if (rows.length === 0 || status === "green") {
+      continue;
+    }
+    lines.push(`${label[status] ?? status} (${rows.length}):`);
+    for (const row of rows) {
+      lines.push(`  • ${row.cellId}${row.reason ? ` — ${oneLine(row.reason)}` : ""}`);
+    }
+  }
+  const green = summary.byStatus.green ?? [];
+  if (green.length > 0) {
+    lines.push(`green (${green.length}): ${green.map((row) => row.cellId).join(", ")}`);
+  }
+  if (runUrl) {
+    lines.push(`run: ${runUrl}`);
+  }
+  return lines.join("\n");
+}
+
+/** Which channel the digest goes to, from the environment. Pure, for tests. */
+export function chooseDelivery(env) {
+  if (env.SLACK_WEBHOOK_URL?.trim()) {
+    return { kind: "slack" };
+  }
+  if (env.GH_TOKEN?.trim() && env.GITHUB_REPOSITORY?.trim()) {
+    return { kind: "issue", repository: env.GITHUB_REPOSITORY.trim() };
+  }
+  return { kind: "stdout" };
+}
+
+async function deliverSlack(text, env, fetchImpl) {
+  const response = await fetchImpl(env.SLACK_WEBHOOK_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!response.ok) {
+    throw new Error(`slack webhook responded ${response.status}`);
+  }
+}
+
+async function deliverIssue(text, env, fetchImpl) {
+  const repo = env.GITHUB_REPOSITORY.trim();
+  const title = env.DIGEST_ISSUE_TITLE?.trim() || "Staging battery — morning digest";
+  const api = `https://api.github.com/repos/${repo}`;
+  const headers = {
+    authorization: `Bearer ${env.GH_TOKEN}`,
+    accept: "application/vnd.github+json",
+    "content-type": "application/json",
+    "user-agent": "proliferate-battery-digest",
+  };
+  const body = `\`\`\`\n${text}\n\`\`\`\n\n_Replaced nightly by \`scripts/ci-cd/battery-digest.mjs\`. Observe mode: red blocks nothing; this is the triage queue._`;
+  const search = await fetchImpl(`${api}/issues?state=open&per_page=100&labels=`, { headers });
+  if (!search.ok) {
+    throw new Error(`issue list responded ${search.status}`);
+  }
+  const existing = (await search.json()).find((issue) => issue.title === title && !issue.pull_request);
+  const response = existing
+    ? await fetchImpl(`${api}/issues/${existing.number}`, { method: "PATCH", headers, body: JSON.stringify({ body }) })
+    : await fetchImpl(`${api}/issues`, { method: "POST", headers, body: JSON.stringify({ title, body }) });
+  if (!response.ok) {
+    throw new Error(`issue ${existing ? "update" : "create"} responded ${response.status}`);
+  }
+}
+
+/** Never throws: delivery problems are printed, and the digest is always echoed to stdout. */
+export async function deliver(text, env = process.env, fetchImpl = fetch) {
+  console.log(text);
+  const target = chooseDelivery(env);
+  try {
+    if (target.kind === "slack") {
+      await deliverSlack(text, env, fetchImpl);
+    } else if (target.kind === "issue") {
+      await deliverIssue(text, env, fetchImpl);
+    } else {
+      console.log("[battery-digest] no SLACK_WEBHOOK_URL and no GH_TOKEN/GITHUB_REPOSITORY — digest printed only.");
+    }
+    return { delivered: target.kind, error: null };
+  } catch (error) {
+    console.log(`[battery-digest] delivery via ${target.kind} failed: ${error instanceof Error ? error.message : error}`);
+    return { delivered: target.kind, error: String(error) };
+  }
+}
+
+function parseArgs(argv) {
+  const args = { reports: "tests/release/.output", lane: "staging", runUrl: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--reports") args.reports = argv[++i];
+    else if (arg === "--lane") args.lane = argv[++i];
+    else if (arg === "--run-url") args.runUrl = argv[++i];
+  }
+  return args;
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const args = parseArgs(argv);
+  const reports = findReports(args.reports).map((file) => JSON.parse(readFileSync(file, "utf8")));
+  const summary = summarizeReports(reports);
+  const text = formatDigest(summary, { lane: args.lane, runUrl: args.runUrl });
+  await deliver(text, env);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      // Observe mode: even an unexpected crash never reds the job.
+      console.log(`[battery-digest] unexpected error: ${error instanceof Error ? error.stack : error}`);
+      process.exit(0);
+    });
+}

--- a/scripts/ci-cd/battery-digest.mjs
+++ b/scripts/ci-cd/battery-digest.mjs
@@ -5,11 +5,13 @@
 // Reads every qualification-evidence.json the runner wrote, groups the cells
 // by verdict, and delivers ONE message: "staging battery N/M green · red: … ·
 // expected-fail: … · blocked: …". Observe mode: this script never fails the
-// job (exit 0 always) and never per-failure alerts — one digest, once.
+// job (exit 0 always) and never per-failure alerts — one digest, once. A run
+// that produced no evidence (preflight skipped, runner crashed) still digests:
+// NO RESULTS + the preflight note is itself the signal.
 //
-// Delivery: SLACK_WEBHOOK_URL when set (Block Kit-free plain text so every
-// workspace renders it), else the pinned digest issue (created once, its body
-// replaced nightly) via the GitHub REST API with GH_TOKEN + GITHUB_REPOSITORY.
+// Delivery chain (each failure falls through to the next): SLACK_WEBHOOK_URL →
+// the pinned digest issue (GH_TOKEN + GITHUB_REPOSITORY; found via the search
+// API so it never falls off a page and duplicates) → stdout.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
@@ -45,6 +47,24 @@ export function findReports(root) {
   return found;
 }
 
+/**
+ * Parses report files, tolerating corrupt/partial ones (a cancelled job's
+ * tree is not guaranteed): unreadable files become a note in the digest, not
+ * a silent absence of the whole digest.
+ */
+export function readReports(files, readFile = (file) => readFileSync(file, "utf8")) {
+  const reports = [];
+  const unreadable = [];
+  for (const file of files) {
+    try {
+      reports.push(JSON.parse(readFile(file)));
+    } catch (error) {
+      unreadable.push(`${path.basename(path.dirname(file))}/${path.basename(file)}: ${error instanceof Error ? error.message.slice(0, 80) : error}`);
+    }
+  }
+  return { reports, unreadable };
+}
+
 /** One digest row per result cell across all reports, keyed by cell id (last report wins). */
 export function summarizeReports(reports) {
   const cells = new Map();
@@ -71,14 +91,20 @@ function oneLine(text, max = 160) {
   return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
 }
 
-/** The digest text. `lane` and `runUrl` are context; everything else is the summary. */
-export function formatDigest(summary, { lane = "staging", runUrl = null, when = new Date() } = {}) {
+/** The digest text. `note` carries e.g. the preflight-skip reason; `unreadable` lists corrupt reports. */
+export function formatDigest(summary, { lane = "staging", runUrl = null, when = new Date(), note = "", unreadable = [] } = {}) {
   const day = when.toISOString().slice(0, 10);
   const header =
     summary.total === 0
       ? `${lane} battery ${day}: NO RESULTS — the runner produced no evidence (check the run).`
       : `${lane} battery ${day}: ${summary.green}/${summary.total} green`;
   const lines = [header];
+  if (note && note.trim().length > 0) {
+    lines.push(`note: ${oneLine(note)}`);
+  }
+  for (const entry of unreadable) {
+    lines.push(`note: unreadable report — ${oneLine(entry)}`);
+  }
   const label = { failed: "RED", expected_fail: "expected-fail", blocked: "blocked", green: "green" };
   for (const status of STATUS_ORDER) {
     const rows = summary.byStatus[status] ?? [];
@@ -100,15 +126,17 @@ export function formatDigest(summary, { lane = "staging", runUrl = null, when = 
   return lines.join("\n");
 }
 
-/** Which channel the digest goes to, from the environment. Pure, for tests. */
-export function chooseDelivery(env) {
+/** The ordered delivery chain the environment allows. Pure, for tests. */
+export function deliveryChain(env) {
+  const chain = [];
   if (env.SLACK_WEBHOOK_URL?.trim()) {
-    return { kind: "slack" };
+    chain.push("slack");
   }
   if (env.GH_TOKEN?.trim() && env.GITHUB_REPOSITORY?.trim()) {
-    return { kind: "issue", repository: env.GITHUB_REPOSITORY.trim() };
+    chain.push("issue");
   }
-  return { kind: "stdout" };
+  chain.push("stdout");
+  return chain;
 }
 
 async function deliverSlack(text, env, fetchImpl) {
@@ -122,10 +150,42 @@ async function deliverSlack(text, env, fetchImpl) {
   }
 }
 
+/**
+ * Finds the pinned digest issue via the search API (title-scoped — never
+ * falls off a page-1 listing and starts duplicating), falling back to a
+ * paginated list scan when search is unavailable.
+ */
+async function findDigestIssue(api, title, headers, fetchImpl) {
+  const query = encodeURIComponent(`repo:${api.repo} is:issue is:open in:title "${title}"`);
+  const search = await fetchImpl(`https://api.github.com/search/issues?q=${query}&per_page=20`, { headers });
+  if (search.ok) {
+    const found = (await search.json()).items?.find((issue) => issue.title === title && !issue.pull_request);
+    if (found) {
+      return found;
+    }
+    return null;
+  }
+  for (let page = 1; page <= 5; page += 1) {
+    const list = await fetchImpl(`${api.base}/issues?state=open&per_page=100&page=${page}`, { headers });
+    if (!list.ok) {
+      throw new Error(`issue list responded ${list.status}`);
+    }
+    const issues = await list.json();
+    const found = issues.find((issue) => issue.title === title && !issue.pull_request);
+    if (found) {
+      return found;
+    }
+    if (issues.length < 100) {
+      return null;
+    }
+  }
+  return null;
+}
+
 async function deliverIssue(text, env, fetchImpl) {
   const repo = env.GITHUB_REPOSITORY.trim();
   const title = env.DIGEST_ISSUE_TITLE?.trim() || "Staging battery — morning digest";
-  const api = `https://api.github.com/repos/${repo}`;
+  const api = { repo, base: `https://api.github.com/repos/${repo}` };
   const headers = {
     authorization: `Bearer ${env.GH_TOKEN}`,
     accept: "application/vnd.github+json",
@@ -133,54 +193,67 @@ async function deliverIssue(text, env, fetchImpl) {
     "user-agent": "proliferate-battery-digest",
   };
   const body = `\`\`\`\n${text}\n\`\`\`\n\n_Replaced nightly by \`scripts/ci-cd/battery-digest.mjs\`. Observe mode: red blocks nothing; this is the triage queue._`;
-  const search = await fetchImpl(`${api}/issues?state=open&per_page=100&labels=`, { headers });
-  if (!search.ok) {
-    throw new Error(`issue list responded ${search.status}`);
-  }
-  const existing = (await search.json()).find((issue) => issue.title === title && !issue.pull_request);
+  const existing = await findDigestIssue(api, title, headers, fetchImpl);
   const response = existing
-    ? await fetchImpl(`${api}/issues/${existing.number}`, { method: "PATCH", headers, body: JSON.stringify({ body }) })
-    : await fetchImpl(`${api}/issues`, { method: "POST", headers, body: JSON.stringify({ title, body }) });
+    ? await fetchImpl(`${api.base}/issues/${existing.number}`, { method: "PATCH", headers, body: JSON.stringify({ body }) })
+    : await fetchImpl(`${api.base}/issues`, { method: "POST", headers, body: JSON.stringify({ title, body }) });
   if (!response.ok) {
     throw new Error(`issue ${existing ? "update" : "create"} responded ${response.status}`);
   }
 }
 
-/** Never throws: delivery problems are printed, and the digest is always echoed to stdout. */
+/**
+ * Never throws: walks the delivery chain until one channel succeeds; the
+ * digest is always echoed to stdout regardless.
+ */
 export async function deliver(text, env = process.env, fetchImpl = fetch) {
   console.log(text);
-  const target = chooseDelivery(env);
-  try {
-    if (target.kind === "slack") {
-      await deliverSlack(text, env, fetchImpl);
-    } else if (target.kind === "issue") {
-      await deliverIssue(text, env, fetchImpl);
-    } else {
-      console.log("[battery-digest] no SLACK_WEBHOOK_URL and no GH_TOKEN/GITHUB_REPOSITORY — digest printed only.");
+  const errors = [];
+  for (const channel of deliveryChain(env)) {
+    try {
+      if (channel === "slack") {
+        await deliverSlack(text, env, fetchImpl);
+      } else if (channel === "issue") {
+        await deliverIssue(text, env, fetchImpl);
+      } else {
+        if (errors.length > 0) {
+          console.log(`[battery-digest] all channels failed (${errors.join("; ")}) — digest printed only.`);
+        } else if (deliveryChain(env).length === 1) {
+          console.log("[battery-digest] no SLACK_WEBHOOK_URL and no GH_TOKEN/GITHUB_REPOSITORY — digest printed only.");
+        }
+      }
+      return { delivered: channel, errors };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`${channel}: ${message}`);
+      console.log(`[battery-digest] delivery via ${channel} failed (${message}) — trying the next channel.`);
     }
-    return { delivered: target.kind, error: null };
-  } catch (error) {
-    console.log(`[battery-digest] delivery via ${target.kind} failed: ${error instanceof Error ? error.message : error}`);
-    return { delivered: target.kind, error: String(error) };
   }
+  return { delivered: "stdout", errors };
 }
 
 function parseArgs(argv) {
-  const args = { reports: "tests/release/.output", lane: "staging", runUrl: null };
+  const args = { reports: "tests/release/.output", lane: "staging", runUrl: null, note: "" };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--reports") args.reports = argv[++i];
     else if (arg === "--lane") args.lane = argv[++i];
     else if (arg === "--run-url") args.runUrl = argv[++i];
+    else if (arg === "--note") args.note = argv[++i];
   }
   return args;
 }
 
 export async function main(argv = process.argv.slice(2), env = process.env) {
   const args = parseArgs(argv);
-  const reports = findReports(args.reports).map((file) => JSON.parse(readFileSync(file, "utf8")));
+  const { reports, unreadable } = readReports(findReports(args.reports));
   const summary = summarizeReports(reports);
-  const text = formatDigest(summary, { lane: args.lane, runUrl: args.runUrl });
+  const text = formatDigest(summary, {
+    lane: args.lane,
+    runUrl: args.runUrl,
+    note: args.note || env.DIGEST_NOTE || "",
+    unreadable,
+  });
   await deliver(text, env);
   return 0;
 }

--- a/scripts/ci-cd/battery-digest.test.mjs
+++ b/scripts/ci-cd/battery-digest.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { chooseDelivery, deliver, findReports, formatDigest, summarizeReports } from "./battery-digest.mjs";
+import { deliver, deliveryChain, findReports, formatDigest, readReports, summarizeReports } from "./battery-digest.mjs";
 
 const report = (results) => ({ schema_version: 4, results });
 const cell = (id, status, message) => ({
@@ -61,49 +61,112 @@ test("formatDigest says NO RESULTS when the runner produced no evidence", () => 
   assert.match(text, /NO RESULTS/);
 });
 
-test("chooseDelivery prefers Slack, then the issue, then stdout", () => {
-  assert.equal(chooseDelivery({ SLACK_WEBHOOK_URL: "https://hooks.example/x" }).kind, "slack");
-  assert.equal(chooseDelivery({ GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" }).kind, "issue");
-  assert.equal(chooseDelivery({}).kind, "stdout");
+test("deliveryChain orders Slack, then the issue, then stdout", () => {
+  assert.deepEqual(deliveryChain({ SLACK_WEBHOOK_URL: "https://hooks.example/x", GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" }), [
+    "slack",
+    "issue",
+    "stdout",
+  ]);
+  assert.deepEqual(deliveryChain({ GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" }), ["issue", "stdout"]);
+  assert.deepEqual(deliveryChain({}), ["stdout"]);
 });
 
-test("deliver never throws: a failing webhook is reported, not raised", async () => {
+test("deliver falls through the chain: a failing webhook falls back to the pinned issue", async () => {
   const calls = [];
-  const failingFetch = async (url, init) => {
-    calls.push({ url, body: init.body });
-    return { ok: false, status: 500 };
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url, method: init.method ?? "GET", body: init.body });
+    if (url.startsWith("https://hooks.example/")) {
+      return { ok: false, status: 500 };
+    }
+    if (url.startsWith("https://api.github.com/search/issues")) {
+      return { ok: true, status: 200, json: async () => ({ items: [] }) };
+    }
+    return { ok: true, status: 201 };
   };
-  const outcome = await deliver("digest text", { SLACK_WEBHOOK_URL: "https://hooks.example/x" }, failingFetch);
-  assert.equal(outcome.delivered, "slack");
-  assert.match(outcome.error, /500/);
-  assert.equal(calls.length, 1);
+  const outcome = await deliver(
+    "digest text",
+    { SLACK_WEBHOOK_URL: "https://hooks.example/x", GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" },
+    fetchImpl,
+  );
+  assert.equal(outcome.delivered, "issue");
+  assert.equal(outcome.errors.length, 1);
+  assert.match(outcome.errors[0], /slack: .*500/);
   assert.deepEqual(JSON.parse(calls[0].body), { text: "digest text" });
+  assert.ok(calls.some((call) => call.method === "POST" && call.url.endsWith("/issues")));
 });
 
-test("deliver replaces the pinned issue body when it exists, creates it otherwise", async () => {
+test("deliver never throws even when every channel fails", async () => {
+  const failingFetch = async () => ({ ok: false, status: 500 });
+  const outcome = await deliver(
+    "d",
+    { SLACK_WEBHOOK_URL: "https://hooks.example/x", GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" },
+    failingFetch,
+  );
+  assert.equal(outcome.delivered, "stdout");
+  assert.equal(outcome.errors.length, 2);
+});
+
+test("deliver replaces the pinned issue found via SEARCH (never page-1 listing), creates it otherwise", async () => {
   const seen = [];
   const fetchWithIssue = async (url, init = {}) => {
     seen.push({ url, method: init.method ?? "GET" });
-    if (url.endsWith("&labels=")) {
-      return { ok: true, status: 200, json: async () => [{ number: 7, title: "Staging battery — morning digest" }] };
+    if (url.startsWith("https://api.github.com/search/issues")) {
+      return { ok: true, status: 200, json: async () => ({ items: [{ number: 7, title: "Staging battery — morning digest" }] }) };
     }
     return { ok: true, status: 200 };
   };
   const env = { GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" };
   const updated = await deliver("d", env, fetchWithIssue);
-  assert.equal(updated.error, null);
+  assert.deepEqual(updated.errors, []);
   assert.ok(seen.some((call) => call.method === "PATCH" && call.url.endsWith("/issues/7")));
 
   seen.length = 0;
   const fetchWithout = async (url, init = {}) => {
     seen.push({ url, method: init.method ?? "GET" });
-    if (url.endsWith("&labels=")) {
-      return { ok: true, status: 200, json: async () => [] };
+    if (url.startsWith("https://api.github.com/search/issues")) {
+      return { ok: true, status: 200, json: async () => ({ items: [] }) };
     }
     return { ok: true, status: 201 };
   };
   await deliver("d", env, fetchWithout);
   assert.ok(seen.some((call) => call.method === "POST" && call.url.endsWith("/issues")));
+});
+
+test("deliver falls back to a paginated list scan when search is unavailable", async () => {
+  const seen = [];
+  const fetchImpl = async (url, init = {}) => {
+    seen.push({ url, method: init.method ?? "GET" });
+    if (url.startsWith("https://api.github.com/search/issues")) {
+      return { ok: false, status: 403 };
+    }
+    if (url.includes("/issues?state=open&per_page=100&page=1")) {
+      return { ok: true, status: 200, json: async () => [{ number: 9, title: "Staging battery — morning digest" }] };
+    }
+    return { ok: true, status: 200 };
+  };
+  const outcome = await deliver("d", { GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" }, fetchImpl);
+  assert.deepEqual(outcome.errors, []);
+  assert.ok(seen.some((call) => call.method === "PATCH" && call.url.endsWith("/issues/9")));
+});
+
+test("readReports tolerates corrupt files and reports them instead of dying", () => {
+  const { reports, unreadable } = readReports(["good.json", "bad.json"], (file) =>
+    file === "good.json" ? JSON.stringify(report([cell("T3-BATT-AUTH-1", "green")])) : "{truncated",
+  );
+  assert.equal(reports.length, 1);
+  assert.equal(unreadable.length, 1);
+  assert.match(unreadable[0], /bad\.json/);
+});
+
+test("formatDigest carries the preflight note and unreadable-report notes", () => {
+  const text = formatDigest(summarizeReports([]), {
+    when: new Date("2026-08-27T08:00:00Z"),
+    note: "preflight skipped: API_BASE_URL is not set",
+    unreadable: ["run-x/qualification-evidence.json: Unexpected token"],
+  });
+  assert.match(text, /NO RESULTS/);
+  assert.match(text, /note: preflight skipped: API_BASE_URL is not set/);
+  assert.match(text, /note: unreadable report — run-x/);
 });
 
 test("findReports discovers every qualification-evidence.json under the output tree", () => {

--- a/scripts/ci-cd/battery-digest.test.mjs
+++ b/scripts/ci-cd/battery-digest.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { chooseDelivery, deliver, findReports, formatDigest, summarizeReports } from "./battery-digest.mjs";
+
+const report = (results) => ({ schema_version: 4, results });
+const cell = (id, status, message) => ({
+  cell_id: `${id}/sandbox`,
+  scenario_id: id,
+  status,
+  reason: message ? { code: "scenario_failure", message } : null,
+});
+
+test("summarizeReports groups cells by verdict and counts green", () => {
+  const summary = summarizeReports([
+    report([cell("T3-BATT-AUTH-1", "green"), cell("T3-BATT-WORKER-1", "expected_fail", "no worker plane")]),
+    report([cell("T3-BATT-RUN-1", "failed", "proxy 502"), cell("T3-BATT-INT-1", "blocked", "no key")]),
+  ]);
+  assert.equal(summary.total, 4);
+  assert.equal(summary.green, 1);
+  assert.deepEqual(Object.keys(summary.byStatus).sort(), ["blocked", "expected_fail", "failed", "green"]);
+  assert.equal(summary.byStatus.failed[0].reason, "proxy 502");
+});
+
+test("a later report's verdict for the same cell wins (re-runs replace, never double count)", () => {
+  const summary = summarizeReports([
+    report([cell("T3-BATT-GH-1", "failed", "first attempt")]),
+    report([cell("T3-BATT-GH-1", "green")]),
+  ]);
+  assert.equal(summary.total, 1);
+  assert.equal(summary.green, 1);
+});
+
+test("formatDigest names every non-green journey with its cause and labels expected-fail distinctly", () => {
+  const text = formatDigest(
+    summarizeReports([
+      report([
+        cell("T3-BATT-AUTH-1", "green"),
+        cell("T3-BATT-RUN-1", "failed", "the cloud session path is not serving"),
+        cell("T3-BATT-WORKER-1", "expected_fail", "no worker plane on staging"),
+        cell("T3-BATT-INT-1", "blocked", "RELEASE_E2E_INTEGRATION_API_KEY is not provisioned"),
+      ]),
+    ]),
+    { lane: "staging", runUrl: "https://example/run/1", when: new Date("2026-08-27T08:00:00Z") },
+  );
+  assert.match(text, /^staging battery 2026-08-27: 1\/4 green/m);
+  assert.match(text, /RED \(1\):\n {2}• T3-BATT-RUN-1\/sandbox — the cloud session path is not serving/);
+  assert.match(text, /expected-fail \(1\):\n {2}• T3-BATT-WORKER-1\/sandbox — no worker plane on staging/);
+  assert.match(text, /blocked \(1\):/);
+  assert.match(text, /green \(1\): T3-BATT-AUTH-1\/sandbox/);
+  assert.match(text, /run: https:\/\/example\/run\/1$/);
+  // A red journey is never described as green anywhere in the digest.
+  assert.doesNotMatch(text, /green.*T3-BATT-RUN-1/);
+});
+
+test("formatDigest says NO RESULTS when the runner produced no evidence", () => {
+  const text = formatDigest(summarizeReports([]), { when: new Date("2026-08-27T08:00:00Z") });
+  assert.match(text, /NO RESULTS/);
+});
+
+test("chooseDelivery prefers Slack, then the issue, then stdout", () => {
+  assert.equal(chooseDelivery({ SLACK_WEBHOOK_URL: "https://hooks.example/x" }).kind, "slack");
+  assert.equal(chooseDelivery({ GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" }).kind, "issue");
+  assert.equal(chooseDelivery({}).kind, "stdout");
+});
+
+test("deliver never throws: a failing webhook is reported, not raised", async () => {
+  const calls = [];
+  const failingFetch = async (url, init) => {
+    calls.push({ url, body: init.body });
+    return { ok: false, status: 500 };
+  };
+  const outcome = await deliver("digest text", { SLACK_WEBHOOK_URL: "https://hooks.example/x" }, failingFetch);
+  assert.equal(outcome.delivered, "slack");
+  assert.match(outcome.error, /500/);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(JSON.parse(calls[0].body), { text: "digest text" });
+});
+
+test("deliver replaces the pinned issue body when it exists, creates it otherwise", async () => {
+  const seen = [];
+  const fetchWithIssue = async (url, init = {}) => {
+    seen.push({ url, method: init.method ?? "GET" });
+    if (url.endsWith("&labels=")) {
+      return { ok: true, status: 200, json: async () => [{ number: 7, title: "Staging battery — morning digest" }] };
+    }
+    return { ok: true, status: 200 };
+  };
+  const env = { GH_TOKEN: "t", GITHUB_REPOSITORY: "o/r" };
+  const updated = await deliver("d", env, fetchWithIssue);
+  assert.equal(updated.error, null);
+  assert.ok(seen.some((call) => call.method === "PATCH" && call.url.endsWith("/issues/7")));
+
+  seen.length = 0;
+  const fetchWithout = async (url, init = {}) => {
+    seen.push({ url, method: init.method ?? "GET" });
+    if (url.endsWith("&labels=")) {
+      return { ok: true, status: 200, json: async () => [] };
+    }
+    return { ok: true, status: 201 };
+  };
+  await deliver("d", env, fetchWithout);
+  assert.ok(seen.some((call) => call.method === "POST" && call.url.endsWith("/issues")));
+});
+
+test("findReports discovers every qualification-evidence.json under the output tree", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "battery-digest-"));
+  const a = path.join(root, "run-a", "shard-0", "attempt-1");
+  const b = path.join(root, "run-b", "shard-0", "attempt-2");
+  mkdirSync(a, { recursive: true });
+  mkdirSync(b, { recursive: true });
+  writeFileSync(path.join(a, "qualification-evidence.json"), "{}");
+  writeFileSync(path.join(b, "qualification-evidence.json"), "{}");
+  writeFileSync(path.join(b, "other.json"), "{}");
+  assert.equal(findReports(root).length, 2);
+  assert.equal(findReports(path.join(root, "missing")).length, 0);
+});

--- a/tests/release/scripts/staging-session-remint.sh
+++ b/tests/release/scripts/staging-session-remint.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# One-command recovery for the staging battery's durable-user credential
+# (delivery/testing-cicd/delivery-spec-e2e-observable.md, "Rotation write-back").
+#
+# The runner self-rotates the durable staging user's refresh token and CI
+# persists the rotated state in the Actions cache between runs. When that
+# chain breaks — cache evicted after long idleness AND the bootstrap secret
+# already consumed, or the user's token_generation bumped — the staging lane
+# reports `blocked` in the digest, and this script is the fix:
+#
+#   1. mint a fresh session in-VPC (the staging DB is VPC-only) by piping
+#      staging_session_seed.py into a one-off ECS task on the staging server
+#      image (no image rebuild, no product change — the seed's own recipe);
+#   2. rotate it ONCE through the public refresh route to prove the chain;
+#   3. store the ROTATED token as the `staging` environment secret.
+#
+# The token never reaches stdout, a log, or a persistent file: it lives in a
+# mode-600 temp dir removed on exit. Needs: aws (staging account), gh (repo
+# admin for `gh secret set`), python3. Operator-run only. Staging-only.
+#
+# Usage: tests/release/scripts/staging-session-remint.sh [durable-user-login]
+set -euo pipefail
+
+CLUSTER=${STAGING_ECS_CLUSTER:-proliferate-staging}
+SERVICE=${STAGING_ECS_SERVER_SERVICE:-proliferate-staging-server}
+API_BASE_URL=${STAGING_API_BASE_URL:-https://staging-app.proliferate.com/api}
+REPO=${GITHUB_REPOSITORY:-proliferate-ai/proliferate}
+SECRET_NAME=RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN
+DURABLE_USER=${1:-proliferate-e2e-bot}
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/staging-remint.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+umask 077
+
+echo "==> resolving the staging server task definition + network"
+TASK_DEF=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+  --query 'services[0].taskDefinition' --output text)
+NETWORK=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+  --query 'services[0].networkConfiguration.awsvpcConfiguration' --output json)
+CONTAINER=$(aws ecs describe-task-definition --task-definition "$TASK_DEF" \
+  --query 'taskDefinition.containerDefinitions[0].name' --output text)
+LOG_GROUP=$(aws ecs describe-task-definition --task-definition "$TASK_DEF" \
+  --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-group"' --output text)
+LOG_PREFIX=$(aws ecs describe-task-definition --task-definition "$TASK_DEF" \
+  --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-stream-prefix"' --output text)
+
+# The seed script minus its module docstring: ECS overrides are capped at 8 KB.
+python3 - "$HERE/staging_session_seed.py" "$CONTAINER" "$DURABLE_USER" <<'PY' > "$WORK/overrides.json"
+import json, pathlib, re, sys
+src = pathlib.Path(sys.argv[1]).read_text()
+stripped = re.sub(r'^"""[\s\S]*?"""\n', "", src, count=1)
+print(json.dumps({"containerOverrides": [{"name": sys.argv[2],
+    "command": ["python3", "-c", stripped, "mint", sys.argv[3]]}]}))
+PY
+
+python3 - "$NETWORK" <<'PY' > "$WORK/network.txt"
+import json, sys
+net = json.loads(sys.argv[1])
+print("awsvpcConfiguration={subnets=[%s],securityGroups=[%s],assignPublicIp=%s}" % (
+    ",".join(net["subnets"]), ",".join(net["securityGroups"]), net.get("assignPublicIp", "ENABLED")))
+PY
+
+echo "==> minting in-VPC (one-off task on $TASK_DEF)"
+TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEF" --launch-type FARGATE \
+  --network-configuration "$(cat "$WORK/network.txt")" --overrides "file://$WORK/overrides.json" \
+  --query 'tasks[0].taskArn' --output text)
+TASK_ID=${TASK_ARN##*/}
+aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
+EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+  --query 'tasks[0].containers[0].exitCode' --output text)
+echo "    task $TASK_ID exited $EXIT_CODE"
+
+aws logs get-log-events --log-group-name "$LOG_GROUP" --log-stream-name "$LOG_PREFIX/$CONTAINER/$TASK_ID" \
+  --start-from-head --query 'events[].message' --output json > "$WORK/events.json"
+
+python3 - "$WORK" <<'PY'
+import json, pathlib, sys
+work = pathlib.Path(sys.argv[1])
+payload = None
+for message in json.loads((work / "events.json").read_text()):
+    line = message.strip()
+    if line.startswith("{") and "refreshToken" in line:
+        payload = json.loads(line)
+if payload is None or payload.get("error"):
+    raise SystemExit(f"mint failed: {payload.get('error') if payload else 'no mint JSON in task logs'}")
+(work / "t0").write_text(payload["refreshToken"])
+print(f"    minted for {payload.get('githubLogin')} ({payload.get('email')})")
+PY
+
+echo "==> rotating once through $API_BASE_URL/auth/mobile/session/refresh"
+python3 - "$WORK" "$API_BASE_URL" <<'PY'
+import json, pathlib, sys, urllib.request
+work, base = pathlib.Path(sys.argv[1]), sys.argv[2]
+req = urllib.request.Request(f"{base}/auth/mobile/session/refresh",
+    data=json.dumps({"refreshToken": (work / "t0").read_text().strip()}).encode(),
+    headers={"Content-Type": "application/json"}, method="POST")
+with urllib.request.urlopen(req, timeout=30) as resp:
+    body = json.loads(resp.read())
+if not body.get("refreshToken"):
+    raise SystemExit(f"rotate failed: keys={list(body)}")
+(work / "t1").write_text(body["refreshToken"])
+print("    rotation ok")
+PY
+
+echo "==> storing the rotated token as the staging environment secret $SECRET_NAME"
+gh secret set "$SECRET_NAME" --env staging --repo "$REPO" --body "$(cat "$WORK/t1")"
+echo "==> done. Do NOT rotate this token by hand — the next CI run consumes it and the cache carries on."

--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -42,6 +42,15 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
     secret: false,
   },
   {
+    name: "RELEASE_E2E_WEB_URL",
+    description:
+      "Origin of the deployed web app for the target lane (no path), read by the staging battery's thin " +
+      "web smoke (T3-BATT-WEB-1) to assert the shell and login route serve. Staging: the `staging` " +
+      "environment's WEB_URL variable.",
+    whereItLives: "Staging: https://staging.proliferate.com (GitHub `staging` environment variable WEB_URL).",
+    secret: false,
+  },
+  {
     name: "RELEASE_E2E_GATEWAY_TEST_KEY",
     description:
       "Dedicated LiteLLM gateway virtual key, allowlisted to the cheap test-model set " +

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -38,12 +38,14 @@ test("release qualification has stable independent concurrency groups by world",
   assert.doesNotMatch(workflowHeader, /^concurrency:/m, "one global group would serialize unrelated worlds");
   assert.doesNotMatch(selfhostHeader, /^concurrency:/m, "one global group would serialize unrelated worlds");
 
-  assert.match(job(release, "release-e2e-local"), /group: release-e2e-local/);
   assert.match(job(release, "release-e2e-local-functional"), /group: release-e2e-local/);
   assert.match(job(release, "release-e2e-selfhost-install"), /group: release-e2e-self-host/);
   assert.match(job(selfhost, "artifact-chain"), /group: release-e2e-tier4/);
   assert.match(job(selfhost, "provisioning"), /group: release-e2e-self-host/);
-  assert.match(job(release, "release-e2e-local"), /if: github\.event_name == 'schedule'/);
+  // The provisional schedule-only local lane was deleted with the nightly
+  // restoration (delivery-spec-e2e-observable): the cron fires only the
+  // staging battery; the local world is dispatch-only via local-functional.
+  assert.doesNotMatch(release, /^  release-e2e-local:/m);
   assert.match(job(release, "release-e2e-local-functional"), /inputs\.manual_world == 'local'/);
 
   for (const source of [release, selfhost]) {

--- a/tests/release/src/runner/staging-workflow.test.ts
+++ b/tests/release/src/runner/staging-workflow.test.ts
@@ -37,9 +37,18 @@ test("the staging battery runs in observe mode: visible verdicts, nightly cron, 
   assert.match(job, /actions\/cache\/restore@[0-9a-f]{40}/);
   assert.match(job, /actions\/cache\/save@[0-9a-f]{40}/);
   assert.match(job, /RELEASE_E2E_STAGING_SESSION_STATE: \$\{\{ github\.workspace \}\}\/\.release-e2e\/staging-session\.json/);
-  // The digest always runs and never gates.
-  assert.match(job, /name: Morning digest\n\s+if: always\(\)/);
+  // The digest always runs and never gates — including on preflight-skipped
+  // runs ("no digest arrives" is the acceptance-gate falsifier), so its `if:`
+  // must be exactly always(), with no preflight condition attached.
+  assert.match(job, /name: Morning digest\n\s+if: always\(\)\n/);
   assert.match(job, /battery-digest\.mjs/);
+  // The digest's Slack chain honors the frozen spec's channel name first.
+  assert.match(job, /SLACK_WEBHOOK_URL: \$\{\{ secrets\.SLACK_BATTERY_WEBHOOK_URL \|\| secrets\.SLACK_ENGINEERING_ALERTS_WEBHOOK_URL \}\}/);
+  // The preflight hard-gates ONLY on the deployment URL — a missing session
+  // credential must surface as blocked cells in the digest, never a skip.
+  assert.equal((job.match(/enabled=false/g) ?? []).length, 1);
+  // The cache save is guarded on the state file existing (no false-red saves).
+  assert.match(job, /if: always\(\) && steps\.session-state\.outputs\.present == 'true'/);
   // The provisioned-but-previously-unmapped vars now reach the runner.
   for (const name of ["RELEASE_E2E_WEB_URL", "RELEASE_E2E_GITHUB_TEST_REPO", "RELEASE_E2E_INTEGRATION_API_KEY"]) {
     assert.match(job, new RegExp(`${name}: \\$\\{\\{ (?:vars|secrets)\\.`));

--- a/tests/release/src/runner/staging-workflow.test.ts
+++ b/tests/release/src/runner/staging-workflow.test.ts
@@ -24,10 +24,26 @@ function localFunctionalJob(): string {
   return workflow.slice(start, end);
 }
 
-test("staging workflow remains provisional and delegates compatibility to --lane staging", () => {
+test("the staging battery runs in observe mode: visible verdicts, nightly cron, durable session state", () => {
   const job = stagingJob();
-  assert.match(job, /name: tier-3 staging lane \(provisional\)/);
-  assert.match(job, /continue-on-error: true/);
+  assert.match(job, /name: staging battery \(observe mode\)/);
+  // Observe mode (delivery-spec-e2e-observable): red is visible and blocks
+  // nothing by construction — never masked by continue-on-error.
+  assert.doesNotMatch(job, /continue-on-error: true/);
+  // The nightly cron exists at the workflow level and only this job keys on it.
+  assert.match(workflow, /^  schedule:\n(?:    #.*\n)*    - cron: "0 8 \* \* \*"/m);
+  assert.equal((workflow.match(/github\.event_name == 'schedule'/g) ?? []).length, 1);
+  // Rotation write-back: the state file is restored before and saved after the battery.
+  assert.match(job, /actions\/cache\/restore@[0-9a-f]{40}/);
+  assert.match(job, /actions\/cache\/save@[0-9a-f]{40}/);
+  assert.match(job, /RELEASE_E2E_STAGING_SESSION_STATE: \$\{\{ github\.workspace \}\}\/\.release-e2e\/staging-session\.json/);
+  // The digest always runs and never gates.
+  assert.match(job, /name: Morning digest\n\s+if: always\(\)/);
+  assert.match(job, /battery-digest\.mjs/);
+  // The provisioned-but-previously-unmapped vars now reach the runner.
+  for (const name of ["RELEASE_E2E_WEB_URL", "RELEASE_E2E_GITHUB_TEST_REPO", "RELEASE_E2E_INTEGRATION_API_KEY"]) {
+    assert.match(job, new RegExp(`${name}: \\$\\{\\{ (?:vars|secrets)\\.`));
+  }
   assert.match(job, /LANE: staging/);
   assert.match(job, /SCENARIOS: \$\{\{ github\.event\.inputs\.scenarios \|\| 'all' \}\}/);
   assert.match(job, /make release-e2e LANE="\$LANE"/);
@@ -46,6 +62,18 @@ test("the staging workflow's real all-selector contains only Tier-3 sandbox cell
   assert.ok(cells.every((cell) => cell.scenario_id.startsWith("T3-")));
   assert.ok(cells.some((cell) => cell.scenario_id === "T3-PROV-2"));
   assert.ok(cells.every((cell) => !cell.scenario_id.startsWith("T4-")));
+  // The battery family is admitted by the same gate, unchanged.
+  for (const id of [
+    "T3-BATT-AUTH-1",
+    "T3-BATT-WEB-1",
+    "T3-BATT-GH-1",
+    "T3-BATT-BILL-1",
+    "T3-BATT-WORKER-1",
+    "T3-BATT-INT-1",
+    "T3-BATT-RUN-1",
+  ]) {
+    assert.ok(cells.some((cell) => cell.cell_id === `${id}/sandbox`), `${id} must plan on the staging lane`);
+  }
 });
 
 test("local-functional maps every BYOK env var from the provisioned _API_KEY secret", () => {

--- a/tests/release/src/scenarios/battery/common.ts
+++ b/tests/release/src/scenarios/battery/common.ts
@@ -1,14 +1,14 @@
 /**
  * Shared helpers for the staging battery (`T3-BATT-*`), the observe-mode
- * journeys ruled 2026-08-26 (delivery/testing-cicd/delivery-spec-e2e-observable.md;
- * specs/engineering/testing/release.md "What an e2e scenario is").
+ * journeys ruled 2026-08-26 (delivery/testing-cicd/delivery-spec-e2e-observable.md).
  *
  * Every battery journey: staging-only, authenticates as the durable staging
  * user, asserts OUTCOMES (never transcripts), and never blocks anything — the
  * nightly digest reads the verdicts. Three journeys are expected to be red
  * today; they are still attempted for real, and an expected-fail is declared
- * ONLY when the observed failure matches the known gap's signature — any other
- * failure is a genuine red (`ScenarioExpectedFailError` semantics, types.ts).
+ * ONLY when the observed failure matches the known gap's exact signature —
+ * a status class alone is never a signature (refuter finding 4). Anything
+ * else is a genuine red.
  */
 
 import { ApiClient, ApiRequestError } from "../../fixtures/http.js";
@@ -16,8 +16,16 @@ import type { AuthSessionResponse } from "../../fixtures/identity.js";
 import { assertDurableIdentityAvailableForLane, loginDurableUserForLane } from "../../fixtures/lane-identity.js";
 import { ScenarioBlockedError, ScenarioExpectedFailError, type ScenarioRunContext } from "../types.js";
 
-/** The one registry pointer for the whole battery family. */
-export const BATTERY_FLOW_REF = "specs/engineering/testing/release.md#what-an-e2e-scenario-is";
+/**
+ * The one registry pointer for the whole battery family: the frozen delivery
+ * spec (merged #2272). The testing-system spec's release datasheet lands in a
+ * parallel slice; pointing there before it exists would be a dangling ref in
+ * every cell's evidence (refuter finding 11).
+ */
+export const BATTERY_FLOW_REF = "delivery/testing-cicd/delivery-spec-e2e-observable.md";
+
+/** The seeded durable staging identity (staging_session_seed.py); env-overridable for other worlds. */
+export const DURABLE_USER_EMAIL_DEFAULT = "support@proliferate.com";
 
 export interface BatterySession {
   serverUrl: string;
@@ -35,11 +43,28 @@ export function assertStagingLane(scenarioId: string, ctx: ScenarioRunContext): 
   }
 }
 
-/** Durable-user login for the lane (staging rotates the seeded refresh token). */
+/**
+ * Durable-user login for the lane (staging rotates the seeded refresh token).
+ * A 401 from the refresh route means the CREDENTIAL is dead (rotted bootstrap,
+ * token_generation bump), not that seven product journeys regressed — report
+ * blocked with the one-command fix, never seven reds (refuter finding 8).
+ */
 export async function authenticateBattery(scenarioId: string, ctx: ScenarioRunContext): Promise<BatterySession> {
   const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL");
   assertDurableIdentityAvailableForLane(scenarioId, ctx);
-  const session = await loginDurableUserForLane(ctx, serverUrl);
+  let session: AuthSessionResponse;
+  try {
+    session = await loginDurableUserForLane(ctx, serverUrl);
+  } catch (error) {
+    if (error instanceof ApiRequestError && (error.status === 401 || error.status === 403)) {
+      throw new ScenarioBlockedError(
+        `${scenarioId}: the staging durable-user session credential is invalid or expired (HTTP ${error.status} ` +
+          "from /auth/mobile/session/refresh) — an ops credential problem, not a product verdict. Re-mint with " +
+          "`tests/release/scripts/staging-session-remint.sh`.",
+      );
+    }
+    throw error;
+  }
   const client = new ApiClient({ baseUrl: serverUrl }).withBearerToken(session.accessToken);
   return { serverUrl, session, client };
 }
@@ -52,15 +77,8 @@ export function durableOrgId(env: NodeJS.ProcessEnv = process.env): string | und
 /** Bounded, secret-free description of a failure for reasons and logs. */
 export function describeFailure(error: unknown): string {
   if (error instanceof ApiRequestError) {
-    const body = error.body;
-    const code =
-      typeof body === "object" && body !== null
-        ? ((body as { code?: unknown; detail?: { code?: unknown } | string }).code ??
-          (typeof (body as { detail?: unknown }).detail === "object"
-            ? ((body as { detail?: { code?: unknown } }).detail?.code ?? null)
-            : (body as { detail?: unknown }).detail))
-        : null;
-    return `HTTP ${error.status}${code ? ` ${String(code)}` : ""}`;
+    const code = errorCode(error);
+    return `HTTP ${error.status}${code ? ` ${code}` : ""}`;
   }
   if (error instanceof Error) {
     return error.message.slice(0, 200);
@@ -68,13 +86,37 @@ export function describeFailure(error: unknown): string {
   return String(error).slice(0, 200);
 }
 
+/** The product error code carried in an ApiRequestError body (top-level or detail), if any. */
+export function errorCode(error: unknown): string | undefined {
+  if (!(error instanceof ApiRequestError) || typeof error.body !== "object" || error.body === null) {
+    return undefined;
+  }
+  const body = error.body as { code?: unknown; detail?: { code?: unknown } | string };
+  if (typeof body.code === "string") {
+    return body.code;
+  }
+  if (typeof body.detail === "string") {
+    return body.detail;
+  }
+  if (typeof body.detail === "object" && body.detail !== null && typeof body.detail.code === "string") {
+    return body.detail.code;
+  }
+  return undefined;
+}
+
+/** True when the error carries the exact product error code. */
+export function hasErrorCode(error: unknown, code: string): boolean {
+  return errorCode(error) === code;
+}
+
 /**
- * "The surface is not served by this deployment" — the failure class the
- * known gaps (no worker plane on staging; the cloud session path) produce.
- * A 401/403 or a 4xx validation error is NOT this class: those are real reds.
+ * "The route is not served by this deployment" — strictly absent surfaces
+ * only (404/405/501). Generic 5xx is NOT this class: a 500 in a shipping
+ * surface is a real red, and an ALB 502/503 mid-deploy is a real
+ * infrastructure red the digest should show (refuter finding 4).
  */
-export function isSurfaceUnavailable(error: unknown): boolean {
-  return error instanceof ApiRequestError && [404, 405, 500, 501, 502, 503, 504].includes(error.status);
+export function isSurfaceAbsent(error: unknown): boolean {
+  return error instanceof ApiRequestError && [404, 405, 501].includes(error.status);
 }
 
 /**

--- a/tests/release/src/scenarios/battery/common.ts
+++ b/tests/release/src/scenarios/battery/common.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared helpers for the staging battery (`T3-BATT-*`), the observe-mode
+ * journeys ruled 2026-08-26 (delivery/testing-cicd/delivery-spec-e2e-observable.md;
+ * specs/engineering/testing/release.md "What an e2e scenario is").
+ *
+ * Every battery journey: staging-only, authenticates as the durable staging
+ * user, asserts OUTCOMES (never transcripts), and never blocks anything — the
+ * nightly digest reads the verdicts. Three journeys are expected to be red
+ * today; they are still attempted for real, and an expected-fail is declared
+ * ONLY when the observed failure matches the known gap's signature — any other
+ * failure is a genuine red (`ScenarioExpectedFailError` semantics, types.ts).
+ */
+
+import { ApiClient, ApiRequestError } from "../../fixtures/http.js";
+import type { AuthSessionResponse } from "../../fixtures/identity.js";
+import { assertDurableIdentityAvailableForLane, loginDurableUserForLane } from "../../fixtures/lane-identity.js";
+import { ScenarioBlockedError, ScenarioExpectedFailError, type ScenarioRunContext } from "../types.js";
+
+/** The one registry pointer for the whole battery family. */
+export const BATTERY_FLOW_REF = "specs/engineering/testing/release.md#what-an-e2e-scenario-is";
+
+export interface BatterySession {
+  serverUrl: string;
+  session: AuthSessionResponse;
+  /** Bearer-authenticated client for prefix-relative product routes (/v1/…). */
+  client: ApiClient;
+}
+
+/** Battery journeys assert a real deployment; the local lane is covered elsewhere. */
+export function assertStagingLane(scenarioId: string, ctx: ScenarioRunContext): void {
+  if (ctx.targetLane !== "staging") {
+    throw new ScenarioBlockedError(
+      `${scenarioId}: staging battery journey — asserts the real staging deployment. Run with \`--lane staging\`.`,
+    );
+  }
+}
+
+/** Durable-user login for the lane (staging rotates the seeded refresh token). */
+export async function authenticateBattery(scenarioId: string, ctx: ScenarioRunContext): Promise<BatterySession> {
+  const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL");
+  assertDurableIdentityAvailableForLane(scenarioId, ctx);
+  const session = await loginDurableUserForLane(ctx, serverUrl);
+  const client = new ApiClient({ baseUrl: serverUrl }).withBearerToken(session.accessToken);
+  return { serverUrl, session, client };
+}
+
+export function durableOrgId(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const value = env.RELEASE_E2E_DURABLE_ORG_ID?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+/** Bounded, secret-free description of a failure for reasons and logs. */
+export function describeFailure(error: unknown): string {
+  if (error instanceof ApiRequestError) {
+    const body = error.body;
+    const code =
+      typeof body === "object" && body !== null
+        ? ((body as { code?: unknown; detail?: { code?: unknown } | string }).code ??
+          (typeof (body as { detail?: unknown }).detail === "object"
+            ? ((body as { detail?: { code?: unknown } }).detail?.code ?? null)
+            : (body as { detail?: unknown }).detail))
+        : null;
+    return `HTTP ${error.status}${code ? ` ${String(code)}` : ""}`;
+  }
+  if (error instanceof Error) {
+    return error.message.slice(0, 200);
+  }
+  return String(error).slice(0, 200);
+}
+
+/**
+ * "The surface is not served by this deployment" — the failure class the
+ * known gaps (no worker plane on staging; the cloud session path) produce.
+ * A 401/403 or a 4xx validation error is NOT this class: those are real reds.
+ */
+export function isSurfaceUnavailable(error: unknown): boolean {
+  return error instanceof ApiRequestError && [404, 405, 500, 501, 502, 503, 504].includes(error.status);
+}
+
+/**
+ * Rethrows `error` as an expected-fail when it matches the known gap's
+ * signature; otherwise rethrows it unchanged (a genuine red).
+ */
+export function rethrowAsExpectedFail(
+  scenarioId: string,
+  error: unknown,
+  matches: (error: unknown) => boolean,
+  diagnosis: string,
+): never {
+  if (matches(error)) {
+    throw new ScenarioExpectedFailError(`${scenarioId}: ${diagnosis} (observed: ${describeFailure(error)})`);
+  }
+  throw error;
+}
+
+/** Cheapest capable model among the observed ids, for the bounded agent turn. */
+export function cheapestModel(ids: readonly string[]): string | undefined {
+  const tier = (id: string): number => {
+    if (/fable/i.test(id)) return 99;
+    if (/haiku|mini|flash|nano/i.test(id)) return 0;
+    if (/sonnet/i.test(id)) return 1;
+    return 2;
+  };
+  return [...ids].sort((a, b) => tier(a) - tier(b))[0];
+}
+
+export function battRunId(): string {
+  return `t3-batt-${Date.now().toString(36)}`;
+}

--- a/tests/release/src/scenarios/battery/t3-batt-auth-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-auth-1.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { BillingHttpClient } from "../../fixtures/billing-http.js";
+import { BATTERY_FLOW_REF, assertStagingLane, authenticateBattery, durableOrgId } from "./common.js";
+
+/**
+ * T3-BATT-AUTH-1 — identity + org membership, live on staging.
+ *
+ * Journey: the durable staging user authenticates (browser-free session
+ * rotation — the same `/auth/mobile/session/refresh` route every client uses),
+ * the session identifies the expected account, and the account's organization
+ * list contains the durable org with an active membership.
+ *
+ * Outcomes asserted: a bearer session exists · `user.email` is the seeded
+ * durable identity · the durable org (RELEASE_E2E_DURABLE_ORG_ID when set,
+ * else exactly one owned org) is listed with a live membership.
+ */
+export const t3BattAuth1: ScenarioDefinition = {
+  id: "T3-BATT-AUTH-1",
+  title: "battery: durable login → identity → org membership",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "rotate the durable staging session (POST /auth/mobile/session/refresh)" },
+    { description: "assert the session names the seeded durable identity" },
+    { description: "GET the organizations list; assert the durable org is present with an active membership" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-AUTH-1", ctx);
+    const { serverUrl, session } = await authenticateBattery("T3-BATT-AUTH-1", ctx);
+
+    assert.ok(session.accessToken.length > 0, "T3-BATT-AUTH-1: session must carry an access token");
+    assert.equal(session.tokenType, "bearer", "T3-BATT-AUTH-1: session token type must be bearer");
+    assert.ok(session.user?.id, "T3-BATT-AUTH-1: session must identify a user");
+    assert.ok(session.user.email.includes("@"), "T3-BATT-AUTH-1: session user must carry an email");
+
+    const billing = new BillingHttpClient(serverUrl, session.accessToken);
+    const orgs = await billing.organizations();
+    assert.ok(orgs.length > 0, "T3-BATT-AUTH-1: the durable user must belong to at least one organization");
+
+    const expectedOrg = durableOrgId();
+    const target = expectedOrg ? orgs.find((org) => org.id === expectedOrg) : orgs.length === 1 ? orgs[0] : undefined;
+    assert.ok(
+      target,
+      `T3-BATT-AUTH-1: durable org ${expectedOrg ?? "(single owned org)"} must appear in the user's organizations ` +
+        `(found ${orgs.map((org) => org.id).join(", ")})`,
+    );
+    if (target.membership) {
+      assert.notEqual(
+        target.membership.status,
+        "revoked",
+        `T3-BATT-AUTH-1: durable org membership must be live (status=${target.membership.status})`,
+      );
+    }
+
+    console.log(
+      `[T3-BATT-AUTH-1/staging] green: user ${session.user.email} authenticated; org ${target.id} (${target.name}) ` +
+        `membership ${target.membership?.role ?? "?"}/${target.membership?.status ?? "?"}.`,
+    );
+  },
+};

--- a/tests/release/src/scenarios/battery/t3-batt-auth-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-auth-1.ts
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 
 import type { ScenarioDefinition } from "../types.js";
 import { BillingHttpClient } from "../../fixtures/billing-http.js";
-import { BATTERY_FLOW_REF, assertStagingLane, authenticateBattery, durableOrgId } from "./common.js";
+import {
+  BATTERY_FLOW_REF,
+  DURABLE_USER_EMAIL_DEFAULT,
+  assertStagingLane,
+  authenticateBattery,
+  durableOrgId,
+} from "./common.js";
 
 /**
  * T3-BATT-AUTH-1 — identity + org membership, live on staging.
@@ -37,7 +43,15 @@ export const t3BattAuth1: ScenarioDefinition = {
     assert.ok(session.accessToken.length > 0, "T3-BATT-AUTH-1: session must carry an access token");
     assert.equal(session.tokenType, "bearer", "T3-BATT-AUTH-1: session token type must be bearer");
     assert.ok(session.user?.id, "T3-BATT-AUTH-1: session must identify a user");
-    assert.ok(session.user.email.includes("@"), "T3-BATT-AUTH-1: session user must carry an email");
+    // The session must belong to THE durable identity — a session for any other
+    // user must red this journey (refuter finding 10). The env override exists
+    // for future worlds; on staging the seeded identity is the default.
+    const expectedEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL?.trim() || DURABLE_USER_EMAIL_DEFAULT;
+    assert.equal(
+      session.user.email,
+      expectedEmail,
+      `T3-BATT-AUTH-1: the session must identify the durable user ${expectedEmail} (got ${session.user.email})`,
+    );
 
     const billing = new BillingHttpClient(serverUrl, session.accessToken);
     const orgs = await billing.organizations();

--- a/tests/release/src/scenarios/battery/t3-batt-bill-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-bill-1.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { ScenarioBlockedError } from "../types.js";
+import { BillingHttpClient, resolveDurableOrgId, type OwnerSelection } from "../../fixtures/billing-http.js";
+import { BATTERY_FLOW_REF, assertStagingLane, authenticateBattery } from "./common.js";
+
+/**
+ * T3-BATT-BILL-1 — the billing surfaces read coherently, live on staging.
+ *
+ * Journey: for both billing subjects the durable user has (personal, and the
+ * durable org) the overview, usage summary, and LLM balance answer and agree
+ * with each other. This is the read-only half of the billing ruling; the
+ * lifecycle (fund → consume → exhaust → refill → overage) stays with
+ * T3-BILL-3/4 and is deferred on staging for the reasons documented there.
+ *
+ * Outcomes asserted: overview carries a plan and billing mode · usage summary
+ * is numeric · LLM balance is numeric and internally consistent
+ * (granted − used = remaining, never negative remaining) · for both subjects.
+ */
+export const t3BattBill1: ScenarioDefinition = {
+  id: "T3-BATT-BILL-1",
+  title: "battery: billing overview / usage / LLM balance read coherently (personal + org)",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user; resolve the durable org" },
+    { description: "for personal + org: GET overview, usage-summary, llm-balance" },
+    { description: "assert each surface answers with coherent numbers (no negative balances, granted−used=remaining)" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-BILL-1", ctx);
+    const { serverUrl, session } = await authenticateBattery("T3-BATT-BILL-1", ctx);
+    const billing = new BillingHttpClient(serverUrl, session.accessToken);
+
+    const orgs = await billing.organizations();
+    const orgId = resolveDurableOrgId(orgs, process.env.RELEASE_E2E_DURABLE_ORG_ID);
+    if (!orgId) {
+      throw new ScenarioBlockedError(
+        `T3-BATT-BILL-1: could not resolve the durable org — set RELEASE_E2E_DURABLE_ORG_ID (found ${orgs.length} orgs).`,
+      );
+    }
+
+    const subjects: Array<[string, OwnerSelection]> = [
+      ["personal", { ownerScope: "personal" }],
+      [`org ${orgId}`, { ownerScope: "organization", organizationId: orgId }],
+    ];
+    const lines: string[] = [];
+    for (const [label, owner] of subjects) {
+      const overview = await billing.overview(owner);
+      assert.ok(overview.plan, `T3-BATT-BILL-1 (${label}): overview must name a plan`);
+      assert.ok(overview.billingMode, `T3-BATT-BILL-1 (${label}): overview must name a billing mode`);
+
+      const usage = await billing.usageSummary(owner);
+      for (const [key, value] of Object.entries({
+        computeUsedSecondsMtd: usage.computeUsedSecondsMtd,
+        computeRemainingSeconds: usage.computeRemainingSeconds,
+        llmUsedUsdMtd: usage.llmUsedUsdMtd,
+        llmRemainingUsd: usage.llmRemainingUsd,
+      })) {
+        assert.equal(typeof value, "number", `T3-BATT-BILL-1 (${label}): usage.${key} must be numeric`);
+        assert.ok(Number.isFinite(value) && value >= 0, `T3-BATT-BILL-1 (${label}): usage.${key} must be a non-negative number`);
+      }
+
+      const llm = await billing.llmBalance(owner);
+      assert.ok(llm.remainingUsd >= 0, `T3-BATT-BILL-1 (${label}): LLM remaining must never be negative (got ${llm.remainingUsd})`);
+      assert.ok(
+        Math.abs(llm.grantedUsd - llm.usedUsd - llm.remainingUsd) < 0.01 || llm.remainingUsd === 0,
+        `T3-BATT-BILL-1 (${label}): LLM balance must be coherent (granted ${llm.grantedUsd} − used ${llm.usedUsd} ≠ remaining ${llm.remainingUsd})`,
+      );
+      lines.push(
+        `${label}: plan=${overview.plan} mode=${overview.billingMode} compute_remaining_s=${usage.computeRemainingSeconds} ` +
+          `llm_remaining_usd=${llm.remainingUsd}`,
+      );
+    }
+
+    console.log(`[T3-BATT-BILL-1/staging] green: ${lines.join(" · ")}`);
+  },
+};

--- a/tests/release/src/scenarios/battery/t3-batt-bill-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-bill-1.ts
@@ -56,13 +56,18 @@ export const t3BattBill1: ScenarioDefinition = {
       assert.ok(overview.billingMode, `T3-BATT-BILL-1 (${label}): overview must name a billing mode`);
 
       const usage = await billing.usageSummary(owner);
+      // Contract note: several usage fields are `float | None` server-side
+      // (unlimited entitlements) — null is contract-legal, negative is not.
       for (const [key, value] of Object.entries({
         computeUsedSecondsMtd: usage.computeUsedSecondsMtd,
         computeRemainingSeconds: usage.computeRemainingSeconds,
         llmUsedUsdMtd: usage.llmUsedUsdMtd,
         llmRemainingUsd: usage.llmRemainingUsd,
       })) {
-        assert.equal(typeof value, "number", `T3-BATT-BILL-1 (${label}): usage.${key} must be numeric`);
+        if (value === null || value === undefined) {
+          continue;
+        }
+        assert.equal(typeof value, "number", `T3-BATT-BILL-1 (${label}): usage.${key} must be numeric or null`);
         assert.ok(Number.isFinite(value) && value >= 0, `T3-BATT-BILL-1 (${label}): usage.${key} must be a non-negative number`);
       }
 

--- a/tests/release/src/scenarios/battery/t3-batt-gh-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-gh-1.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { BATTERY_FLOW_REF, assertStagingLane, authenticateBattery } from "./common.js";
+
+interface UserAuthorizationStatus {
+  connected: boolean;
+  githubLogin?: string | null;
+  status?: string | null;
+  action?: string | null;
+}
+
+interface AccessibleRepos {
+  repositories: Array<{ fullName: string; gitOwner: string; gitRepoName: string }>;
+  nextCursor: string | null;
+}
+
+/**
+ * T3-BATT-GH-1 — the GitHub App user grant works, live on staging.
+ *
+ * Journey: the durable user's GitHub App user authorization is connected
+ * (`GET /v1/cloud/github-app/user-authorization`), and the accessible-repos
+ * surface answers with repositories through that grant. When
+ * RELEASE_E2E_GITHUB_TEST_REPO is set, the fixture repo must be among them.
+ *
+ * Outcomes asserted: `connected=true` with a github login · accessible-repos
+ * returns a list · the fixture repo is listed when named.
+ */
+export const t3BattGh1: ScenarioDefinition = {
+  id: "T3-BATT-GH-1",
+  title: "battery: GitHub App user grant → accessible repos",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user" },
+    { description: "GET /v1/cloud/github-app/user-authorization; assert connected with a github login" },
+    { description: "GET /v1/cloud/github-app/accessible-repos; assert a repository list (fixture repo present when named)" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-GH-1", ctx);
+    const { client } = await authenticateBattery("T3-BATT-GH-1", ctx);
+
+    const authorization = await client.get<UserAuthorizationStatus>("/v1/cloud/github-app/user-authorization");
+    assert.equal(
+      authorization.connected,
+      true,
+      `T3-BATT-GH-1: the durable user's GitHub App user authorization must be connected ` +
+        `(status=${authorization.status ?? "?"}, action=${authorization.action ?? "none"})`,
+    );
+    assert.ok(authorization.githubLogin, "T3-BATT-GH-1: a connected authorization must name the github login");
+
+    const repos = await client.get<AccessibleRepos>("/v1/cloud/github-app/accessible-repos");
+    assert.ok(Array.isArray(repos.repositories), "T3-BATT-GH-1: accessible-repos must return a repository list");
+
+    const fixtureRepo = process.env.RELEASE_E2E_GITHUB_TEST_REPO?.trim();
+    if (fixtureRepo) {
+      assert.ok(
+        repos.repositories.some((repo) => repo.fullName === fixtureRepo),
+        `T3-BATT-GH-1: the fixture repo ${fixtureRepo} must be accessible through the grant ` +
+          `(got ${repos.repositories.length} repos: ${repos.repositories.slice(0, 5).map((repo) => repo.fullName).join(", ")}…)`,
+      );
+    }
+
+    console.log(
+      `[T3-BATT-GH-1/staging] green: github login ${authorization.githubLogin} connected; ` +
+        `${repos.repositories.length} accessible repos${fixtureRepo ? ` incl. ${fixtureRepo}` : ""}.`,
+    );
+  },
+};

--- a/tests/release/src/scenarios/battery/t3-batt-int-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-int-1.ts
@@ -2,13 +2,14 @@ import assert from "node:assert/strict";
 
 import type { ScenarioDefinition } from "../types.js";
 import { ScenarioBlockedError } from "../types.js";
+import { ApiRequestError } from "../../fixtures/http.js";
 import { resolveIntegrationNamespace } from "../../fixtures/integrations.js";
 import {
   BATTERY_FLOW_REF,
   assertStagingLane,
   authenticateBattery,
   durableOrgId,
-  isSurfaceUnavailable,
+  isSurfaceAbsent,
   rethrowAsExpectedFail,
 } from "./common.js";
 
@@ -34,16 +35,21 @@ interface AuthenticateResponse {
  * T3-BATT-INT-1 — an api_key integration connects, live on staging.
  *
  * Journey: the integration catalog lists the api_key-kind seed definition
- * (default `exa`, `RELEASE_E2E_INTEGRATION_NAMESPACE` to override), the health
- * surface answers for the durable org, and — when RELEASE_E2E_INTEGRATION_API_KEY
- * is provisioned — connecting that definition through the product route
- * (`POST /v1/cloud/integrations/authentications`) yields an enabled account
- * that the health surface then reflects. T3-INT-1 owns the deeper tool-call
- * matrix; this journey owns "does connecting work at all".
+ * (default `exa`), the health surface answers for the durable org, and — when
+ * RELEASE_E2E_INTEGRATION_API_KEY is provisioned — connecting that definition
+ * through the product route (`POST /v1/cloud/integrations/authentications`)
+ * yields an enabled account that the health surface then reflects. Accounts
+ * key per (user, definition) on the server, so a re-run against the durable
+ * user tolerates 400/409 "already connected" and verifies via health instead
+ * (T3-INT-1 does the same). Note: the server scopes the account per user, not
+ * per org — no org parameter is sent on connect (an earlier draft passed an
+ * inert `settings.organizationId`; the route only templates settings into
+ * URLs/headers).
  *
- * EXPECTED-FAIL today (ruled 2026-08-26): the integration gateway is mid-fix.
- * Declared ONLY on the surface-unavailable signature (404/405/5xx); an
- * auth/validation failure is a real red.
+ * EXPECTED-FAIL today (ruled 2026-08-26) is scoped to the CONNECT step only,
+ * and only for strictly absent surfaces (404/405/501): the catalog and health
+ * GETs are shipping surfaces whose failures — including a 404 from a wrong
+ * RELEASE_E2E_DURABLE_ORG_ID — are real reds, never laundered into the gap.
  */
 export const t3BattInt1: ScenarioDefinition = {
   id: "T3-BATT-INT-1",
@@ -53,9 +59,9 @@ export const t3BattInt1: ScenarioDefinition = {
   requiredEnv: ["RELEASE_E2E_SERVER_URL"],
   plan: () => [
     { description: "authenticate the durable user; resolve the api_key seed namespace" },
-    { description: "GET /v1/cloud/integrations/catalog; assert the definition is cataloged as api_key" },
-    { description: "GET /v1/cloud/integrations/health for the durable org; assert it answers" },
-    { description: "with RELEASE_E2E_INTEGRATION_API_KEY: POST authentications; assert an enabled account; health reflects it" },
+    { description: "GET /v1/cloud/integrations/catalog; assert the definition is cataloged as api_key (failures = real red)" },
+    { description: "GET /v1/cloud/integrations/health for the durable org; assert it answers (failures = real red)" },
+    { description: "with RELEASE_E2E_INTEGRATION_API_KEY: POST authentications (expected-fail scope); 400/409 = already connected → verify via health" },
   ],
   run: async (ctx) => {
     if (ctx.dryRun) {
@@ -67,50 +73,57 @@ export const t3BattInt1: ScenarioDefinition = {
     const orgId = durableOrgId();
     const orgQuery = orgId ? `?organizationId=${encodeURIComponent(orgId)}` : "";
 
+    // Shipping surfaces — failures here are genuine reds, never the known gap.
+    const catalog = await client.get<{ items: CatalogItem[] }>(`/v1/cloud/integrations/catalog${orgQuery}`);
+    assert.ok(catalog.items.length > 0, "T3-BATT-INT-1: the integration catalog must not be empty");
+    const definition = catalog.items.find((item) => item.namespace === namespace);
+    assert.ok(definition, `T3-BATT-INT-1: catalog must contain the "${namespace}" definition`);
+    assert.equal(definition.authKind, "api_key", `T3-BATT-INT-1: "${namespace}" must be cataloged as api_key`);
+
+    const health = await client.get<{ items: HealthItem[] }>(`/v1/cloud/integrations/health${orgQuery}`);
+    assert.ok(Array.isArray(health.items), "T3-BATT-INT-1: health must answer with an item list");
+
+    const apiKey = process.env.RELEASE_E2E_INTEGRATION_API_KEY?.trim();
+    if (!apiKey) {
+      throw new ScenarioBlockedError(
+        "T3-BATT-INT-1: RELEASE_E2E_INTEGRATION_API_KEY is not provisioned — catalog + health verified, connect step " +
+          "cannot run.",
+      );
+    }
+
+    // The connect step — the declared gap's scope.
+    let accountId: string | undefined;
     try {
-      const catalog = await client.get<{ items: CatalogItem[] }>(`/v1/cloud/integrations/catalog${orgQuery}`);
-      assert.ok(catalog.items.length > 0, "T3-BATT-INT-1: the integration catalog must not be empty");
-      const definition = catalog.items.find((item) => item.namespace === namespace);
-      assert.ok(definition, `T3-BATT-INT-1: catalog must contain the "${namespace}" definition`);
-      assert.equal(definition.authKind, "api_key", `T3-BATT-INT-1: "${namespace}" must be cataloged as api_key`);
-
-      const health = await client.get<{ items: HealthItem[] }>(`/v1/cloud/integrations/health${orgQuery}`);
-      assert.ok(Array.isArray(health.items), "T3-BATT-INT-1: health must answer with an item list");
-
-      const apiKey = process.env.RELEASE_E2E_INTEGRATION_API_KEY?.trim();
-      if (!apiKey) {
-        throw new ScenarioBlockedError(
-          "T3-BATT-INT-1: RELEASE_E2E_INTEGRATION_API_KEY is not provisioned — catalog + health verified, connect step " +
-            "cannot run.",
-        );
-      }
       const connected = await client.post<AuthenticateResponse>("/v1/cloud/integrations/authentications", {
         definitionId: definition.definitionId,
         authKind: "api_key",
         apiKey,
-        ...(orgId ? { settings: { organizationId: orgId } } : {}),
       });
       assert.ok(connected.account, `T3-BATT-INT-1: connecting "${namespace}" must yield an account`);
       assert.equal(connected.account.enabled, true, "T3-BATT-INT-1: the connected account must be enabled");
-
-      const after = await client.get<{ items: HealthItem[] }>(`/v1/cloud/integrations/health${orgQuery}`);
-      const reflected = after.items.find((item) => item.namespace === namespace && item.accountId);
-      assert.ok(reflected, `T3-BATT-INT-1: health must reflect the connected "${namespace}" account`);
-
-      console.log(
-        `[T3-BATT-INT-1/staging] green: "${namespace}" connected (account ${connected.account.accountId}, ` +
-          `status ${connected.account.status}); health reflects it.`,
-      );
+      accountId = connected.account.accountId;
     } catch (error) {
-      if (error instanceof ScenarioBlockedError) {
-        throw error;
+      if (error instanceof ApiRequestError && (error.status === 400 || error.status === 409)) {
+        // Durable fixture: the account already exists from a prior run —
+        // verified via health below, same tolerance T3-INT-1 applies.
+        console.log(`[T3-BATT-INT-1/staging] connect returned ${error.status} — treating as already-connected.`);
+      } else {
+        rethrowAsExpectedFail(
+          "T3-BATT-INT-1",
+          error,
+          isSurfaceAbsent,
+          "the integration connect surface is not served on staging — the integration-gateway fix is in flight",
+        );
       }
-      rethrowAsExpectedFail(
-        "T3-BATT-INT-1",
-        error,
-        isSurfaceUnavailable,
-        "integration connect surface failing on staging — the integration gateway fix is in flight",
-      );
     }
+
+    const after = await client.get<{ items: HealthItem[] }>(`/v1/cloud/integrations/health${orgQuery}`);
+    const reflected = after.items.find((item) => item.namespace === namespace && item.accountId);
+    assert.ok(reflected, `T3-BATT-INT-1: health must reflect a connected "${namespace}" account`);
+
+    console.log(
+      `[T3-BATT-INT-1/staging] green: "${namespace}" connected (account ${accountId ?? reflected.accountId}); ` +
+        "health reflects it.",
+    );
   },
 };

--- a/tests/release/src/scenarios/battery/t3-batt-int-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-int-1.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { ScenarioBlockedError } from "../types.js";
+import { resolveIntegrationNamespace } from "../../fixtures/integrations.js";
+import {
+  BATTERY_FLOW_REF,
+  assertStagingLane,
+  authenticateBattery,
+  durableOrgId,
+  isSurfaceUnavailable,
+  rethrowAsExpectedFail,
+} from "./common.js";
+
+interface CatalogItem {
+  definitionId: string;
+  namespace: string;
+  authKind: string;
+  displayName: string;
+}
+
+interface HealthItem {
+  definitionId: string;
+  namespace: string;
+  accountId?: string | null;
+  status?: string;
+}
+
+interface AuthenticateResponse {
+  account: { accountId: string; namespace: string; status: string; enabled: boolean } | null;
+}
+
+/**
+ * T3-BATT-INT-1 — an api_key integration connects, live on staging.
+ *
+ * Journey: the integration catalog lists the api_key-kind seed definition
+ * (default `exa`, `RELEASE_E2E_INTEGRATION_NAMESPACE` to override), the health
+ * surface answers for the durable org, and — when RELEASE_E2E_INTEGRATION_API_KEY
+ * is provisioned — connecting that definition through the product route
+ * (`POST /v1/cloud/integrations/authentications`) yields an enabled account
+ * that the health surface then reflects. T3-INT-1 owns the deeper tool-call
+ * matrix; this journey owns "does connecting work at all".
+ *
+ * EXPECTED-FAIL today (ruled 2026-08-26): the integration gateway is mid-fix.
+ * Declared ONLY on the surface-unavailable signature (404/405/5xx); an
+ * auth/validation failure is a real red.
+ */
+export const t3BattInt1: ScenarioDefinition = {
+  id: "T3-BATT-INT-1",
+  title: "battery: integration catalog → connect api_key integration → health reflects it",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user; resolve the api_key seed namespace" },
+    { description: "GET /v1/cloud/integrations/catalog; assert the definition is cataloged as api_key" },
+    { description: "GET /v1/cloud/integrations/health for the durable org; assert it answers" },
+    { description: "with RELEASE_E2E_INTEGRATION_API_KEY: POST authentications; assert an enabled account; health reflects it" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-INT-1", ctx);
+    const { client } = await authenticateBattery("T3-BATT-INT-1", ctx);
+    const namespace = resolveIntegrationNamespace();
+    const orgId = durableOrgId();
+    const orgQuery = orgId ? `?organizationId=${encodeURIComponent(orgId)}` : "";
+
+    try {
+      const catalog = await client.get<{ items: CatalogItem[] }>(`/v1/cloud/integrations/catalog${orgQuery}`);
+      assert.ok(catalog.items.length > 0, "T3-BATT-INT-1: the integration catalog must not be empty");
+      const definition = catalog.items.find((item) => item.namespace === namespace);
+      assert.ok(definition, `T3-BATT-INT-1: catalog must contain the "${namespace}" definition`);
+      assert.equal(definition.authKind, "api_key", `T3-BATT-INT-1: "${namespace}" must be cataloged as api_key`);
+
+      const health = await client.get<{ items: HealthItem[] }>(`/v1/cloud/integrations/health${orgQuery}`);
+      assert.ok(Array.isArray(health.items), "T3-BATT-INT-1: health must answer with an item list");
+
+      const apiKey = process.env.RELEASE_E2E_INTEGRATION_API_KEY?.trim();
+      if (!apiKey) {
+        throw new ScenarioBlockedError(
+          "T3-BATT-INT-1: RELEASE_E2E_INTEGRATION_API_KEY is not provisioned — catalog + health verified, connect step " +
+            "cannot run.",
+        );
+      }
+      const connected = await client.post<AuthenticateResponse>("/v1/cloud/integrations/authentications", {
+        definitionId: definition.definitionId,
+        authKind: "api_key",
+        apiKey,
+        ...(orgId ? { settings: { organizationId: orgId } } : {}),
+      });
+      assert.ok(connected.account, `T3-BATT-INT-1: connecting "${namespace}" must yield an account`);
+      assert.equal(connected.account.enabled, true, "T3-BATT-INT-1: the connected account must be enabled");
+
+      const after = await client.get<{ items: HealthItem[] }>(`/v1/cloud/integrations/health${orgQuery}`);
+      const reflected = after.items.find((item) => item.namespace === namespace && item.accountId);
+      assert.ok(reflected, `T3-BATT-INT-1: health must reflect the connected "${namespace}" account`);
+
+      console.log(
+        `[T3-BATT-INT-1/staging] green: "${namespace}" connected (account ${connected.account.accountId}, ` +
+          `status ${connected.account.status}); health reflects it.`,
+      );
+    } catch (error) {
+      if (error instanceof ScenarioBlockedError) {
+        throw error;
+      }
+      rethrowAsExpectedFail(
+        "T3-BATT-INT-1",
+        error,
+        isSurfaceUnavailable,
+        "integration connect surface failing on staging — the integration gateway fix is in flight",
+      );
+    }
+  },
+};

--- a/tests/release/src/scenarios/battery/t3-batt-run-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-run-1.ts
@@ -9,13 +9,15 @@ import {
   warmPersonalCloudSandbox,
 } from "../../fixtures/cloud-sandbox.js";
 import { findTurnEndedEvent, type SessionEventEnvelope } from "../../fixtures/local-runtime.js";
+import { ApiRequestError } from "../../fixtures/http.js";
 import {
   BATTERY_FLOW_REF,
   assertStagingLane,
   authenticateBattery,
   cheapestModel,
   describeFailure,
-  isSurfaceUnavailable,
+  errorCode,
+  isSurfaceAbsent,
 } from "./common.js";
 
 /** The server's real proxy into the sandbox's own AnyHarness runtime (cloud-sandbox.ts). */
@@ -43,10 +45,13 @@ interface SessionSummary {
  * (`turn_ended`), never from what the agent said.
  *
  * EXPECTED-FAIL today (ruled 2026-08-26): the cloud session path is being
- * rebuilt (environments/seam). Declared ONLY on the surface-unavailable
- * signature from the proxy/sandbox path; a credits-exhausted 402 on the
- * durable org is a known ops gate and reports `blocked`; anything else is a
- * real red.
+ * rebuilt (environments/seam), and the gap includes WORKSPACE PROVISIONING —
+ * a fresh sandbox has no git checkout, and provisioning one through the
+ * product is the not-yet-built half (t3-wt-1's sandbox lane documents the
+ * same gap). Declared signatures: a strictly absent surface (404/405/501) on
+ * the proxy path · WORKSPACE_CREATE_FAILED from the runtime · the sandbox
+ * never reaching ready. A credits-exhausted 402 reports `blocked` (ops gate);
+ * anything else is a real red.
  */
 export const t3BattRun1: ScenarioDefinition = {
   id: "T3-BATT-RUN-1",
@@ -119,10 +124,16 @@ export const t3BattRun1: ScenarioDefinition = {
             "provisioning gate on staging, not a product verdict. Grant the e2e subject cloud credit to unblock.",
         );
       }
-      if (isSurfaceUnavailable(error) || /did not reach status=ready/.test(describeFailure(error))) {
+      const isProvisioningGap =
+        isSurfaceAbsent(error) ||
+        errorCode(error) === "WORKSPACE_CREATE_FAILED" ||
+        (error instanceof ApiRequestError && error.status === 400 && /workspace/i.test(describeFailure(error))) ||
+        /did not reach status=ready/.test(describeFailure(error));
+      if (isProvisioningGap) {
         throw new ScenarioExpectedFailError(
-          "T3-BATT-RUN-1: the cloud session path (sandbox materialization → gateway proxy → runtime session) is " +
-            `not serving on staging — the environments/seam rebuild owns the fix (observed: ${describeFailure(error)})`,
+          "T3-BATT-RUN-1: the cloud session path (sandbox materialization → gateway proxy → workspace provisioning " +
+            `→ runtime session) is not serving on staging — the environments/seam rebuild owns the fix ` +
+            `(observed: ${describeFailure(error)})`,
         );
       }
       throw error;
@@ -130,11 +141,18 @@ export const t3BattRun1: ScenarioDefinition = {
   },
 };
 
-/** Reuses an existing sandbox workspace, else creates one in the sandbox home. */
+/**
+ * Reuses the sandbox's existing workspace (deterministically: lowest id) —
+ * the product's own state in a warm sandbox — else attempts creation, whose
+ * 400 WORKSPACE_CREATE_FAILED is part of the declared provisioning gap (the
+ * runtime requires an existing git checkout, and provisioning one through
+ * the product is the unbuilt half).
+ */
 async function ensureWorkspace(client: ApiClient): Promise<string> {
   const listed = await client.get<{ workspaces?: Array<{ id: string }> } | Array<{ id: string }>>(`${PROXY}/v1/workspaces`);
-  const workspaces = Array.isArray(listed) ? listed : (listed.workspaces ?? []);
+  const workspaces = (Array.isArray(listed) ? listed : (listed.workspaces ?? [])).slice();
   if (workspaces.length > 0) {
+    workspaces.sort((a, b) => a.id.localeCompare(b.id));
     return workspaces[0].id;
   }
   const created = await client.post<{ workspace?: { id: string }; id?: string }>(`${PROXY}/v1/workspaces`, {

--- a/tests/release/src/scenarios/battery/t3-batt-run-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-run-1.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { ScenarioBlockedError, ScenarioExpectedFailError } from "../types.js";
+import type { ApiClient } from "../../fixtures/http.js";
+import {
+  isBillingCreditsExhaustedError,
+  probeAgentsThroughGateway,
+  warmPersonalCloudSandbox,
+} from "../../fixtures/cloud-sandbox.js";
+import { findTurnEndedEvent, type SessionEventEnvelope } from "../../fixtures/local-runtime.js";
+import {
+  BATTERY_FLOW_REF,
+  assertStagingLane,
+  authenticateBattery,
+  cheapestModel,
+  describeFailure,
+  isSurfaceUnavailable,
+} from "./common.js";
+
+/** The server's real proxy into the sandbox's own AnyHarness runtime (cloud-sandbox.ts). */
+const PROXY = "/v1/gateway/cloud-sandbox/anyharness";
+
+/** Hard per-run budget: one prompt, one cheap model, bounded waits. */
+const SANDBOX_READY_TIMEOUT_MS = 180_000;
+const TURN_TIMEOUT_MS = 120_000;
+const TURN_POLL_MS = 3_000;
+
+interface SessionSummary {
+  id: string;
+  status: string;
+}
+
+/**
+ * T3-BATT-RUN-1 — the core product journey, live on staging: session → prompt
+ * → one bounded agent turn → outcome observed.
+ *
+ * Journey: the durable user's personal cloud sandbox is materialized for real
+ * (the same secret-PUT lever a first-time user hits), the sandbox's runtime
+ * answers through the server's gateway proxy, a workspace + session are
+ * created there on the CHEAPEST observed model, one prompt is sent, and the
+ * turn completes within the budget — asserted from the event log
+ * (`turn_ended`), never from what the agent said.
+ *
+ * EXPECTED-FAIL today (ruled 2026-08-26): the cloud session path is being
+ * rebuilt (environments/seam). Declared ONLY on the surface-unavailable
+ * signature from the proxy/sandbox path; a credits-exhausted 402 on the
+ * durable org is a known ops gate and reports `blocked`; anything else is a
+ * real red.
+ */
+export const t3BattRun1: ScenarioDefinition = {
+  id: "T3-BATT-RUN-1",
+  title: "battery: cloud session → prompt → bounded agent turn → turn_ended observed",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user; materialize the personal cloud sandbox (bounded wait)" },
+    { description: "probe the sandbox runtime through the gateway proxy (GET …/v1/agents)" },
+    { description: "create a workspace + session on the cheapest observed model; send one prompt" },
+    { description: "wait (bounded) for turn_ended in the session events; assert it was observed" },
+    { description: "expected-fail today only on the surface-unavailable signature; 402 credits = blocked" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-RUN-1", ctx);
+    const { client } = await authenticateBattery("T3-BATT-RUN-1", ctx);
+
+    try {
+      const sandbox = await warmPersonalCloudSandbox(client, { timeoutMs: SANDBOX_READY_TIMEOUT_MS });
+      assert.equal(sandbox.status, "ready", "T3-BATT-RUN-1: the personal sandbox must reach ready");
+
+      const agents = await probeAgentsThroughGateway(client);
+      assert.ok(agents.length > 0, "T3-BATT-RUN-1: the sandbox runtime must list at least one agent");
+      const agentKind = agents.find((agent) => agent.kind === "claude")?.kind ?? agents[0].kind;
+
+      const launch = await client.get<{ options: { models: Array<{ id: string }> } | null }>(
+        `${PROXY}/v1/agents/${encodeURIComponent(agentKind)}/launch-options`,
+      );
+      const modelId = cheapestModel((launch.options?.models ?? []).map((model) => model.id));
+
+      const workspace = await ensureWorkspace(client);
+      const session = await client.post<SessionSummary>(`${PROXY}/v1/sessions`, {
+        workspaceId: workspace,
+        agentKind,
+        modelId,
+      });
+      assert.ok(session.id, "T3-BATT-RUN-1: session creation must return an id");
+
+      await client.post(`${PROXY}/v1/sessions/${session.id}/prompt`, {
+        blocks: [{ type: "text", text: "Reply with exactly the word: pong" }],
+      });
+
+      const deadline = Date.now() + TURN_TIMEOUT_MS;
+      let events: SessionEventEnvelope[] = [];
+      while (Date.now() < deadline) {
+        events = await client.get<SessionEventEnvelope[]>(`${PROXY}/v1/sessions/${session.id}/events?limit=200`);
+        if (findTurnEndedEvent(events)) {
+          break;
+        }
+        await sleep(TURN_POLL_MS);
+      }
+      assert.ok(
+        findTurnEndedEvent(events),
+        `T3-BATT-RUN-1: turn_ended must be observed within ${TURN_TIMEOUT_MS}ms (saw ${events.length} events; ` +
+          `last: ${events.at(-1)?.event.type ?? "none"})`,
+      );
+
+      console.log(
+        `[T3-BATT-RUN-1/staging] green: sandbox ready, agent ${agentKind} on ${modelId ?? "default model"}, ` +
+          `session ${session.id} completed one turn (${events.length} events).`,
+      );
+    } catch (error) {
+      if (isBillingCreditsExhaustedError(error)) {
+        throw new ScenarioBlockedError(
+          "T3-BATT-RUN-1: the durable identity is credits-exhausted (402 billing_credits_exhausted) — an ops " +
+            "provisioning gate on staging, not a product verdict. Grant the e2e subject cloud credit to unblock.",
+        );
+      }
+      if (isSurfaceUnavailable(error) || /did not reach status=ready/.test(describeFailure(error))) {
+        throw new ScenarioExpectedFailError(
+          "T3-BATT-RUN-1: the cloud session path (sandbox materialization → gateway proxy → runtime session) is " +
+            `not serving on staging — the environments/seam rebuild owns the fix (observed: ${describeFailure(error)})`,
+        );
+      }
+      throw error;
+    }
+  },
+};
+
+/** Reuses an existing sandbox workspace, else creates one in the sandbox home. */
+async function ensureWorkspace(client: ApiClient): Promise<string> {
+  const listed = await client.get<{ workspaces?: Array<{ id: string }> } | Array<{ id: string }>>(`${PROXY}/v1/workspaces`);
+  const workspaces = Array.isArray(listed) ? listed : (listed.workspaces ?? []);
+  if (workspaces.length > 0) {
+    return workspaces[0].id;
+  }
+  const created = await client.post<{ workspace?: { id: string }; id?: string }>(`${PROXY}/v1/workspaces`, {
+    path: "/home/user/release-e2e-battery",
+  });
+  const id = created.workspace?.id ?? created.id;
+  assert.ok(id, "T3-BATT-RUN-1: workspace creation must return an id");
+  return id;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/release/src/scenarios/battery/t3-batt-web-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-web-1.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { BATTERY_FLOW_REF, assertStagingLane } from "./common.js";
+
+/**
+ * T3-BATT-WEB-1 — the web shell serves, thin smoke.
+ *
+ * The spine UI journey is DESKTOP (ruled 2026-08-26; own slice). Web is one
+ * thin smoke inside the API body: the deployed web app at RELEASE_E2E_WEB_URL
+ * serves its shell (HTML, 200) at the root and at the login route (SPA
+ * fallback), and the API it is configured against answers its health probe.
+ *
+ * Outcomes asserted: `GET /` → 200 text/html with a document body · `GET /login`
+ * → 200 text/html · `GET {api}/health` → 200 with a version string.
+ */
+export const t3BattWeb1: ScenarioDefinition = {
+  id: "T3-BATT-WEB-1",
+  title: "battery: web shell + login route serve; API health answers",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL", "RELEASE_E2E_WEB_URL"],
+  plan: () => [
+    { description: "GET the web root; assert 200 + text/html with a non-trivial document" },
+    { description: "GET /login; assert the SPA serves it (200 + text/html)" },
+    { description: "GET the API health route; assert 200 and a version" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-WEB-1", ctx);
+    const webUrl = ctx.env.require("RELEASE_E2E_WEB_URL").replace(/\/+$/, "");
+    const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL").replace(/\/+$/, "");
+
+    for (const route of ["/", "/login"]) {
+      const response = await fetch(`${webUrl}${route}`, { redirect: "follow" });
+      assert.equal(response.status, 200, `T3-BATT-WEB-1: GET ${route} must serve 200 (got ${response.status})`);
+      const contentType = response.headers.get("content-type") ?? "";
+      assert.ok(contentType.includes("text/html"), `T3-BATT-WEB-1: GET ${route} must serve HTML (got ${contentType})`);
+      const body = await response.text();
+      assert.ok(/<html[\s>]/i.test(body) && body.length > 256, `T3-BATT-WEB-1: GET ${route} must serve a document`);
+    }
+
+    const health = await fetch(`${serverUrl}/health`);
+    assert.equal(health.status, 200, `T3-BATT-WEB-1: API health must answer 200 (got ${health.status})`);
+    const payload = (await health.json()) as { status?: string; version?: string };
+    assert.equal(payload.status, "ok", "T3-BATT-WEB-1: API health status must be ok");
+    assert.ok(payload.version, "T3-BATT-WEB-1: API health must report a version");
+
+    console.log(`[T3-BATT-WEB-1/staging] green: web shell + /login serve; API ${serverUrl} healthy at ${payload.version}.`);
+  },
+};

--- a/tests/release/src/scenarios/battery/t3-batt-worker-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-worker-1.ts
@@ -8,7 +8,8 @@ import {
   authenticateBattery,
   battRunId,
   durableOrgId,
-  isSurfaceUnavailable,
+  hasErrorCode,
+  isSurfaceAbsent,
   rethrowAsExpectedFail,
 } from "./common.js";
 
@@ -33,10 +34,10 @@ interface WorkerEnrollResponse {
  * revoked afterwards so the durable fixture is left as found.
  *
  * EXPECTED-FAIL today (ruled 2026-08-26): staging runs no worker/background
- * plane (`WORKERS_DEPLOY_ENABLED=false`, no `ECS_WORKER_SERVICE`), so the
- * seam's server side may not serve. The expected-fail is declared ONLY when
- * the failure is the "surface unavailable" class (404/405/5xx); an
- * authentication or validation failure is a real red.
+ * plane (`WORKERS_DEPLOY_ENABLED=false`, no `ECS_WORKER_SERVICE`). The gap's
+ * EXACT signatures: the product's own `cloud_worker_misconfigured` code
+ * (seam/workers/service.py), or a strictly absent surface (404/405/501).
+ * A generic 500/502/503 or an auth/validation failure is a REAL red.
  */
 export const t3BattWorker1: ScenarioDefinition = {
   id: "T3-BATT-WORKER-1",
@@ -88,8 +89,8 @@ export const t3BattWorker1: ScenarioDefinition = {
       rethrowAsExpectedFail(
         "T3-BATT-WORKER-1",
         error,
-        isSurfaceUnavailable,
-        "worker enrollment surface not served on staging — no worker/background plane is deployed there " +
+        (observed) => hasErrorCode(observed, "cloud_worker_misconfigured") || isSurfaceAbsent(observed),
+        "worker enrollment not served on staging — no worker/background plane is deployed there " +
           "(WORKERS_DEPLOY_ENABLED=false); the environments/seam work owns the fix",
       );
     } finally {

--- a/tests/release/src/scenarios/battery/t3-batt-worker-1.ts
+++ b/tests/release/src/scenarios/battery/t3-batt-worker-1.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "../types.js";
+import { ApiClient } from "../../fixtures/http.js";
+import {
+  BATTERY_FLOW_REF,
+  assertStagingLane,
+  authenticateBattery,
+  battRunId,
+  durableOrgId,
+  isSurfaceUnavailable,
+  rethrowAsExpectedFail,
+} from "./common.js";
+
+interface EnrollmentTicket {
+  enrollmentToken: string;
+  expiresAt: string;
+}
+
+interface WorkerEnrollResponse {
+  workerId: string;
+  workerToken: string;
+}
+
+/**
+ * T3-BATT-WORKER-1 — a worker enrolls against the staging seam, live.
+ *
+ * Journey (the desktop-host → seam handshake, driven through the real routes):
+ * the signed-in user mints a desktop enrollment ticket
+ * (`POST /v1/cloud/workers/desktop/enrollment`), a worker redeems it
+ * (`POST /v1/cloud/worker/enroll` → worker id + worker token), and the worker
+ * heartbeats with its token (`POST /v1/cloud/worker/heartbeat`). The ticket is
+ * revoked afterwards so the durable fixture is left as found.
+ *
+ * EXPECTED-FAIL today (ruled 2026-08-26): staging runs no worker/background
+ * plane (`WORKERS_DEPLOY_ENABLED=false`, no `ECS_WORKER_SERVICE`), so the
+ * seam's server side may not serve. The expected-fail is declared ONLY when
+ * the failure is the "surface unavailable" class (404/405/5xx); an
+ * authentication or validation failure is a real red.
+ */
+export const t3BattWorker1: ScenarioDefinition = {
+  id: "T3-BATT-WORKER-1",
+  title: "battery: worker enrollment handshake (ticket → enroll → heartbeat)",
+  registryFlowRef: BATTERY_FLOW_REF,
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user; mint a desktop enrollment ticket for the durable org" },
+    { description: "redeem the ticket as a worker: POST /v1/cloud/worker/enroll → worker id + token" },
+    { description: "heartbeat with the worker token; revoke the desktop enrollment afterwards" },
+    { description: "expected-fail today only on the surface-unavailable signature (no worker plane on staging)" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    assertStagingLane("T3-BATT-WORKER-1", ctx);
+    const { serverUrl, client } = await authenticateBattery("T3-BATT-WORKER-1", ctx);
+    const installId = battRunId();
+
+    try {
+      const ticket = await client.post<EnrollmentTicket>("/v1/cloud/workers/desktop/enrollment", {
+        desktopInstallId: installId,
+        organizationId: durableOrgId() ?? null,
+      });
+      assert.ok(ticket.enrollmentToken, "T3-BATT-WORKER-1: enrollment must mint a token");
+
+      const anonymous = new ApiClient({ baseUrl: serverUrl });
+      const enrolled = await anonymous.post<WorkerEnrollResponse>("/v1/cloud/worker/enroll", {
+        enrollmentToken: ticket.enrollmentToken,
+        machineFingerprint: `battery-${installId}`,
+        hostname: "release-e2e-battery",
+        workerVersion: "e2e-battery",
+        anyharnessVersion: "e2e-battery",
+      });
+      assert.ok(enrolled.workerId && enrolled.workerToken, "T3-BATT-WORKER-1: enroll must return a worker id + token");
+
+      const worker = anonymous.withBearerToken(enrolled.workerToken);
+      const heartbeat = await worker.post<{ workerId?: string }>("/v1/cloud/worker/heartbeat", {
+        status: "idle",
+        workerVersion: "e2e-battery",
+        anyharnessVersion: "e2e-battery",
+      });
+      assert.ok(heartbeat, "T3-BATT-WORKER-1: heartbeat must answer");
+
+      console.log(`[T3-BATT-WORKER-1/staging] green: worker ${enrolled.workerId} enrolled and heartbeat accepted.`);
+    } catch (error) {
+      rethrowAsExpectedFail(
+        "T3-BATT-WORKER-1",
+        error,
+        isSurfaceUnavailable,
+        "worker enrollment surface not served on staging — no worker/background plane is deployed there " +
+          "(WORKERS_DEPLOY_ENABLED=false); the environments/seam work owns the fix",
+      );
+    } finally {
+      try {
+        await client.post("/v1/cloud/workers/desktop/revoke", { desktopInstallId: installId });
+      } catch {
+        // Best-effort cleanup; a failed revoke never changes the verdict.
+      }
+    }
+  },
+};

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -32,6 +32,13 @@ import { selfhostInstall1 } from "./selfhost-install-1.js";
 import { selfhostIsolation1 } from "./selfhost-isolation-1.js";
 import { selfhostQual1 } from "./selfhost-qual-1.js";
 import { selfhostCfn1 } from "./selfhost-cfn-1.js";
+import { t3BattAuth1 } from "./battery/t3-batt-auth-1.js";
+import { t3BattWeb1 } from "./battery/t3-batt-web-1.js";
+import { t3BattGh1 } from "./battery/t3-batt-gh-1.js";
+import { t3BattBill1 } from "./battery/t3-batt-bill-1.js";
+import { t3BattWorker1 } from "./battery/t3-batt-worker-1.js";
+import { t3BattInt1 } from "./battery/t3-batt-int-1.js";
+import { t3BattRun1 } from "./battery/t3-batt-run-1.js";
 
 /**
  * The tier-3 first wave (specs/engineering/testing/scenarios.md#tier-3--first-wave),
@@ -93,6 +100,17 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   selfhostIsolation1,
   selfhostQual1,
   selfhostCfn1,
+  // The staging battery (delivery/testing-cicd/delivery-spec-e2e-observable.md):
+  // observe-mode journeys, `T3-` + sandbox lane so the staging planner gate
+  // admits them unchanged. Three are expected-fail today by ruling; they are
+  // attempted for real and declare expected-fail only on the known signature.
+  t3BattAuth1,
+  t3BattWeb1,
+  t3BattGh1,
+  t3BattBill1,
+  t3BattWorker1,
+  t3BattInt1,
+  t3BattRun1,
 ];
 
 interface QualificationWorldEntry {


### PR DESCRIPTION
Second slice of the 2026-08-26 testing/linting/ci-cd alignment, implemented from the frozen delivery spec (`delivery/testing-cicd/delivery-spec-e2e-observable.md`, #2272) and the testing/ci-cd system specs' target sections. Adversarially reviewed; findings triaged below.

## Scope summary

The staging battery becomes **truthful and nightly**, in observe mode: nothing masks a verdict, the durable credential rotates durably between CI runs, and each morning one digest names exactly what is green, red, expected-fail, and blocked.

- **Credential (operational, done tonight):** the durable staging session was re-minted in-VPC (task `c77ec8752b…`, `proliferate-e2e-bot`), rotated once through the public refresh route to prove the chain, and the rotated token stored as the `staging` env secret. Forever after, recovery is one command: `tests/release/scripts/staging-session-remint.sh`.
- **Rotation write-back:** the runner's rotating state file is persisted between runs via the Actions cache (restore by prefix, save under a per-run key, `always()` so a red battery still keeps its rotation). The `release-e2e-staging` concurrency group serializes runs, so rotation never races. The state file lives outside the uploaded artifact path; the token is a manifest secret, so report messages redact it.
- **Observe mode:** `continue-on-error` stripped. With the runner's diagnostic verdict matrix this yields exactly the ruled truth-table: a genuinely **failed** journey turns the job red (visible — and blocking nothing, since this workflow is in no rollup); expected-fail/blocked stay job-green with the digest carrying them; runner breakage exits 2.
- **Nightly cadence:** `cron 0 8 * * *` (~1am PT) fires **only** the staging battery; the dead schedule-only local job is deleted (its reachable path was already zero since the 2026-08 cull).
- **The digest:** `scripts/ci-cd/battery-digest.mjs` — one message per run: `staging battery N/M green` + every non-green with its one-line cause. Slack via the engineering-alerts webhook when provisioned, else a pinned **"Staging battery — morning digest"** issue (created once, body replaced nightly). Never fails the job.
- **Env mapping (audit gap 7):** `RELEASE_E2E_WEB_URL` (new manifest entry), `RELEASE_E2E_GITHUB_TEST_REPO/_TOKEN`, `RELEASE_E2E_INTEGRATION_API_KEY`, the LiteLLM admin pair — all provisioned, now reaching the runner. The environment's `RELEASE_E2E_DURABLE_USER_EMAIL` names an identity that does not exist on staging (the durable user is `proliferate-e2e-bot` / `support@proliferate.com`, what the seed script implements) and is deliberately **not** mapped; correcting/deleting that variable is left to Pablo.
- **Battery v1 — seven journeys** (`tests/release/src/scenarios/battery/`, ids `T3-BATT-*`, admitted by the existing staging planner gate, `plan.ts` untouched): AUTH-1 (durable login → identity → org membership) · WEB-1 (web shell + login route serve; API health) · GH-1 (GitHub App grant → accessible repos incl. the fixture repo) · BILL-1 (billing overview/usage/LLM balance coherent for personal + org) · WORKER-1 (enrollment ticket → enroll → heartbeat; **expected-fail**: no worker plane on staging) · INT-1 (catalog → connect api_key integration → health reflects it; **expected-fail**: gateway mid-fix) · RUN-1 (sandbox materialization → session → one bounded cheap-model turn → `turn_ended` from the event log; **expected-fail**: cloud session path mid-rebuild). Expected-fails are attempted for real and declared only on the known gap's signature; outcomes only, never transcripts.

## Acceptance gate (verbatim from the delivery spec — performed by Pablo)

> Tomorrow morning, **one digest message** (Slack, or the pinned "Staging battery — morning digest" issue if no webhook is provisioned) names every battery journey with its verdict — green / red / expected-fail / blocked — and a one-line cause for each non-green. Falsifier: no digest arrives · a red journey is reported green · the staging lane's run-level verdict is masked by `continue-on-error` · the digest names a journey the registry does not contain.

## Proof tests

- `scripts/ci-cd/battery-digest.test.mjs` — verdict grouping, red-never-green, expected-fail labeled distinctly, NO-RESULTS case, delivery routing (Slack → issue → stdout), never-throws delivery, re-run replacement, report discovery.
- `tests/release/src/runner/staging-workflow.test.ts` — the new doctrine pinned: observe mode (no `continue-on-error`), the cron exists and only the battery keys on `schedule`, cache restore+save with the state path, digest always-runs, the mapped env vars, and all seven `T3-BATT-*` cells planning on the staging lane.
- `qualification-execution-workflow.test.ts` — updated for the deleted schedule-only local job.
- Full `pnpm -C tests/release test` 1061/1061 · `typecheck` clean · `node --test scripts/ci-cd/*.test.mjs` 207/207 · workflow YAML parses · `check_docs` green.
- Live proof: tonight's dispatched battery run + the vault report (run link recorded in a PR comment after dispatch).

## Findings triage (one fresh-context refuter; 16 findings, 15 fixed, 1 accepted-and-documented)

| # | Finding | Outcome |
|---|---------|---------|
| 1 | Digest gated on preflight — the "no digest arrives" falsifier was reachable via a silent green skip; preflight also hard-required the bootstrap secret the cache makes optional | **Fixed**: checkout+node unconditional, digest `if: always()` with the preflight reason as a digest note; preflight hard-gates only `API_BASE_URL` — a missing credential surfaces as blocked cells in the digest |
| 2 | `cache/save` fails the job when no login happened (state file absent) — false red in the truth lane | **Fixed**: existence-guarded save step |
| 3 | Actions cache is branch-scoped — tonight's branch save can't seed main's nightly; and the spec's premise "refresh tokens rotate on every use" is false (refresh is non-revoking; bootstrap valid 30 days) | **Accepted + documented** (workflow comment + this body): the secret is the floor, the cache an optimization, `staging-session-remint.sh` the recovery; main's nightly self-seeds from the secret on first run. Raised as a spec correction, not silently absorbed |
| 4 | Expected-fail overreach: generic 5xx classified as "the gap" across whole journeys; a wrong org id laundered a 404 into expected-fail | **Fixed**: exact signatures only — worker matches the product's `cloud_worker_misconfigured` code or a strictly absent surface (404/405/501); INT-1's expected-fail scope narrowed to the connect step; catalog/health failures are real reds |
| 5 | Digest fragile: one corrupt report or a failing webhook → no digest, green step | **Fixed**: per-file parse guard (unreadable reports become digest notes), delivery chain falls through Slack → issue → stdout, never throws |
| 6 | Pinned-issue lookup unpaginated (repo at 99 open) → nightly duplicate issues imminent | **Fixed**: search-API lookup with paginated list fallback |
| 7 | Spec deviation: digest wired to `SLACK_ENGINEERING_ALERTS_WEBHOOK_URL`, spec names `SLACK_BATTERY_WEBHOOK_URL` | **Fixed**: spec name first, alerts webhook as fallback |
| 8 | A stale credential yields seven REDs instead of the spec's `blocked` — one ops problem misread as seven regressions | **Fixed**: 401/403 from the refresh route → `ScenarioBlockedError` naming the one-command remint |
| 9 | `T3-BATT-RUN-1` workspace creation 400s (`resolve_git_context`) → the ruled expected-fail surfaces as a scenario-bug red; arbitrary-workspace reuse was order-dependent | **Fixed**: `WORKSPACE_CREATE_FAILED` is part of the declared provisioning gap (t3-wt-1's sandbox lane documents the same unbuilt half); reuse made deterministic |
| 10 | `T3-BATT-AUTH-1` never asserted WHICH user — a wrong-identity session reported green | **Fixed**: exact durable-email assertion |
| 11 | Every battery cell's `registry_flow_ref` pointed at a spec file that doesn't exist yet | **Fixed**: points at the merged frozen delivery spec |
| 12 | `.release-e2e/` (plaintext staging token on operator laptops copying the CI recipe) not gitignored | **Fixed** |
| 13 | `settings: { organizationId }` on the connect route is inert server-side (templates only; accounts key per user+definition) | **Fixed**: removed; server behavior documented in the scenario |
| 14 | INT-1 reds on durable re-connect (already-connected 400/409) — nightly false red after the first success | **Fixed**: 400/409 tolerated as already-connected, verified via health (T3-INT-1's own pattern) |
| 15 | BILL-1 stricter than the API contract (`float \| None` fields) — a contract-legal null reds the journey | **Fixed**: null-tolerant, negative still red |
| 16 | Stale header prose contradicted the new law; dead `lane` dispatch input | **Fixed**: both |

Dismissed by the refuter after verification (recorded for the reviewer): diagnostic exit codes DO red the job on failed cells (`deriveVerdict` exits 1) · no `continue-on-error` anywhere in the job · the token cannot reach artifacts (path outside upload; manifest-secret redaction) · the cron reaches only the battery · concurrency + non-revoking refresh make rotation race-free · route paths/casing verified against the live handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
