### PR TITLE
fix(product-client): drop false cutover threat from native-bridge prompt copy

### DIFF
--- a/apps/packages/product-client/src/copy/settings/native-bridge-copy.ts
+++ b/apps/packages/product-client/src/copy/settings/native-bridge-copy.ts
@@ -6,8 +6,6 @@ export const NATIVE_BRIDGE_COPY = {
   title: (displayName: string) => `${displayName} is using your own login`,
   body: (displayName: string) =>
     `Agents now pick an auth method in Proliferate. Your existing ${displayName} `
-    + "login keeps working until you act on this. Pick a method below — or "
-    + "dismiss, which means launches will require a configured method once "
-    + "managed auth becomes required.",
+    + "login keeps working — choosing a method below is optional.",
   dismiss: "Dismiss",
 } as const;


### PR DESCRIPTION
## Summary
- The native-migration bridge prompt's body copy claimed that dismissing it (or leaving it unconfigured) would eventually make a configured auth method mandatory ("...once managed auth becomes required"). That threat is false: the founder ruled on 2026-08-27 that native auth is permanent — a detected native login keeps launching natively forever, and managed auth methods are an optional upgrade, not a future requirement.
- This patch rewrites only the false clause of the body string in `apps/packages/product-client/src/copy/settings/native-bridge-copy.ts`. The title and the "Dismiss" label are unchanged.
- The whole native-bridge prompt family is slated for deletion at convergence; this is strictly an interim honesty fix so the live, user-reachable string (mounted unconditionally via `HarnessNativeBridgePrompt` in `HarnessPane.tsx`) stops threatening a cutover that will never happen.

**Old body:**
> Agents now pick an auth method in Proliferate. Your existing ${displayName} login keeps working until you act on this. Pick a method below — or dismiss, which means launches will require a configured method once managed auth becomes required.

**New body:**
> Agents now pick an auth method in Proliferate. Your existing ${displayName} login keeps working — choosing a method below is optional.

Note for review: this is placeholder UX copy (flagged as such in the file's own header comment) — the exact wording is the founder's to adjust; this PR only removes the false claim.

## Test plan
- [x] `pnpm --filter @proliferate/product-client build` — passes
- [x] `pnpm --filter @proliferate/product-client typecheck` — passes
- [x] Scoped vitest: `HarnessNativeBridgePrompt.test.tsx` (3 tests) — passes unchanged (no test asserted the old/false body text, so none needed updating)
- [x] `check_frontend_boundaries.py` — passes
- [x] Full pre-push gate suite (25 checks, incl. frontend structure/boundaries/fences, product-client vitest, shared typecheck) — 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)