### PR TITLE
docs(specs): agent_auth fence table — launch_options door + seat_cooling census line (ruled 2026-08-27)

### DIFF
--- a/specs/systems/agent_auth/README.md
+++ b/specs/systems/agent_auth/README.md
@@ -17,6 +17,8 @@ This spec reads as ground truth for the final system. Every difference from what
 | client | the courier files (`use-local-auth-state-sync.ts`, `local-auth-state.ts`, the sidecar origin line) · the settings auth panes and onboarding auth surfaces (consumers) |
 | data | `fixtures/contracts/agent-auth-state/` (the wire pin) · the generated SDK clients |
 
+`domains/agents/seat_cooling/` — the per-seat cooling state store (`0077_seat_cooling.sql`) — is agent_auth-owned but not yet colocated with the rest of the runtime cell; it folds into `domains/agent_auth/` at convergence.
+
 **Responsibilities:**
 
 - Know which auth methods exist for each harness, and hold each person's choice per (harness, surface).
@@ -97,6 +99,8 @@ Two rules of the road are held by review, not machinery: *couriers carry, never 
         - The local HTTP API serves it to the frontend; the courier reports the ack from it; readiness consumes it through one seam (`apply_launch_route_upgrade`).
     - `start_login(harness, variant)` — the login terminal, including the `mint_seat` variant.
         - The settings pane's "Authenticate" and the seat-minting affordance are its only callers.
+    - `current_server_origin()` / `load_effective_state(runtime_home, origin)` / `state_file_path(runtime_home)` — the effective-state read surface: which server issued the applied document, and where its file lives on disk.
+        - **One consumer: `launch_options` (`basis.rs`, `tests.rs`).** The launch-options basis reads the same effective-state seam a launch uses, so its persisted revision never drifts from what a real launch would apply; `tests.rs` also reaches `launch_probe::test_support::snapshot` (test-only).
 - **Consumes:** the applied document (from the courier) · the catalog surface (which harnesses exist, which auth contexts each declares) · the terminal machinery for login flows.
 
 ### the courier — desktop TS


### PR DESCRIPTION
## Rulings (founder, 2026-08-27)

**Ruling 1 — Doors list incomplete, not a code violation.** `domains/agents/launch_options/{basis.rs,tests.rs}` legitimately import `agent_auth::route_auth::{current_server_origin, load_effective_state, state_file_path}`; the spec's runtime-cell Doors list was missing this Door. Added a `launch_options → agent_auth` Door row naming exactly those three functions, with the `launch_probe::test_support` helper noted test-only in the same row.

Evidence (verified against `origin/agent-auth-slice-6b-wave3`, where this Door's target shape (`domains/agent_auth::route_auth::…`) already lives — this Door becomes load-bearing on `main` once #2289 (Wave-3) lands):
- `anyharness/crates/anyharness-lib/src/domains/agents/launch_options/basis.rs:11` — `use crate::domains::agent_auth::route_auth::{current_server_origin, load_effective_state};`
- `anyharness/crates/anyharness-lib/src/domains/agents/launch_options/basis.rs:367,466` — `crate::domains::agent_auth::route_auth::state_file_path(...)`
- `anyharness/crates/anyharness-lib/src/domains/agents/launch_options/tests.rs:66,151` — `crate::domains::agent_auth::launch_probe::test_support::snapshot(...)` (test-only)

**Ruling 2 — seat_cooling is agent_auth-owned, not yet colocated.** `domains/agents/seat_cooling/` (cooling state store + SQL migration 0077) is agent_auth-owned but physically sits under `domains/agents/` today; it folds into `domains/agent_auth/` at convergence. Added one census line to §0 stating this.

Evidence (present on slice branches, not yet on `main`):
- `anyharness/crates/anyharness-lib/src/domains/agents/seat_cooling/mod.rs`
- `anyharness/crates/anyharness-lib/src/domains/agents/seat_cooling/store.rs`
- `anyharness/crates/anyharness-lib/src/persistence/sql/0077_seat_cooling.sql`

Both rulings were made by the founder on 2026-08-27.

## Test plan
- [x] `make gate` (pre-push hook) — 23 checks, 0 failed
- [x] Diff limited to `specs/systems/agent_auth/README.md`, two minimal insertions, no drive-by rewording

🤖 Generated with [Claude Code](https://claude.com/claude-code)