### PR TITLE
fix(lints): ruff-clean check_lanes.py + gate census rows after the #2293/#2275 cross-merge

### DIFF
--- a/scripts/check_lanes.py
+++ b/scripts/check_lanes.py
@@ -149,8 +149,7 @@ def parse_workflow(path: Path) -> WorkflowFacts:
                 # silent empty trigger tuple; nested sequence items (cron
                 # entries under schedule:) are fine and skipped.
                 raise ValueError(
-                    f"{path.name}:{index}: sequence-form `on:` is unparseable — "
-                    "use the block form"
+                    f"{path.name}:{index}: sequence-form `on:` is unparseable — use the block form"
                 )
             trigger = _TRIGGER_RE.match(line)
             if trigger:
@@ -172,9 +171,7 @@ def parse_workflow(path: Path) -> WorkflowFacts:
                 )
             elif stripped.startswith(("continue-on-error:", "- continue-on-error:")):
                 if not current_job:
-                    raise ValueError(
-                        f"{path.name}:{index}: continue-on-error before any job id"
-                    )
+                    raise ValueError(f"{path.name}:{index}: continue-on-error before any job id")
                 continue_on_error.append((current_job, index))
 
     if not saw_on or not saw_jobs:
@@ -308,7 +305,7 @@ def collect_violations(
                         (
                             CADENCE_RULE_ID,
                             f"{workflow}:{job}",
-                            "dispatch-with-sunset requires sunset = \"YYYY-MM-DD\"",
+                            'dispatch-with-sunset requires sunset = "YYYY-MM-DD"',
                         )
                     )
                 elif sunset < today:
@@ -331,7 +328,7 @@ def collect_violations(
                 )
 
     # Direction 2: no row outlives reality.
-    for (workflow_name, job), row in sorted(census.lanes.items()):
+    for (workflow_name, job), _row in sorted(census.lanes.items()):
         f = facts_by_name.get(workflow_name)
         if f is None or job not in f.jobs:
             violations.append(
@@ -364,7 +361,7 @@ def collect_violations(
                     (
                         QUARANTINE_RULE_ID,
                         f"{workflow}:{job} (line {line})",
-                        "quarantine row needs expires = \"YYYY-MM-DD\"",
+                        'quarantine row needs expires = "YYYY-MM-DD"',
                     )
                 )
             elif expires < today:
@@ -376,7 +373,7 @@ def collect_violations(
                         "fix the flake or re-rule the row",
                     )
                 )
-    for (workflow_name, job), row in sorted(census.quarantine.items()):
+    for (workflow_name, job), _row in sorted(census.quarantine.items()):
         f = facts_by_name.get(workflow_name)
         alive = f is not None and any(j == job for j, _ in f.continue_on_error)
         if not alive:
@@ -398,7 +395,8 @@ def print_missing(facts: list[WorkflowFacts], census: Census) -> None:
                 print("[[lane]]")
                 print(f'workflow = "{f.name}"')
                 print(f'job = "{job}"')
-                print(f'pipeline = ""  # one of: {", ".join(PIPELINES)}; triggers: {", ".join(f.triggers)}')
+                pipelines = ", ".join(PIPELINES)
+                print(f'pipeline = ""  # one of: {pipelines}; triggers: {", ".join(f.triggers)}')
                 print('cadence = ""')
                 print("gate_mirrored = false")
                 print()

--- a/scripts/gate
+++ b/scripts/gate
@@ -65,6 +65,7 @@ ALWAYS_ENGINES: tuple[tuple[str, str], ...] = (
     ("manifests", "python3 scripts/check_manifests.py"),
     ("session mutation admission", "python3 scripts/check_session_mutation_admission.py"),
     ("update flow", "python3 scripts/check_update_flow_lints.py"),
+    ("lane census", "python3 scripts/check_lanes.py"),
     ("docs", "python3 scripts/check_docs.py"),
 )
 
@@ -84,6 +85,7 @@ SCRIPTS_PROOFS: tuple[tuple[str, str], ...] = (
     ("checker tests: server fences", "python3 -m unittest scripts/test_check_server_fences.py"),
     ("checker tests: manifests", "python3 -m unittest scripts/test_check_manifests.py"),
     ("checker tests: docs", "python3 -m unittest scripts/test_check_docs.py"),
+    ("checker tests: lane census", "python3 -m unittest scripts/test_check_lanes.py"),
     ("checker tests: gate", "python3 -m unittest scripts/test_gate.py"),
     (
         "checker tests: server boundary checker",

--- a/scripts/test_check_lanes.py
+++ b/scripts/test_check_lanes.py
@@ -200,9 +200,7 @@ class ParserTests(unittest.TestCase):
         self.assertIn("job depth", str(ctx.exception))
 
     def test_sequence_form_on_fails_loud(self) -> None:
-        self.fx.write_workflow(
-            "seq.yml", "name: x\non:\n  - push\njobs:\n  a:\n    steps: []\n"
-        )
+        self.fx.write_workflow("seq.yml", "name: x\non:\n  - push\njobs:\n  a:\n    steps: []\n")
         with self.assertRaises(ValueError) as ctx:
             check_lanes.parse_workflow(self.fx.workflows / "seq.yml")
         self.assertIn("sequence-form", str(ctx.exception))
@@ -258,7 +256,9 @@ class CensusTests(unittest.TestCase):
     def test_pipeline_must_match_a_real_trigger(self) -> None:
         # ci.yml has no schedule trigger, so "nightly" is a lie
         self.fx.write_census(
-            self.green.replace(lane("ci.yml", "repo-shape", "pr"), lane("ci.yml", "repo-shape", "nightly"))
+            self.green.replace(
+                lane("ci.yml", "repo-shape", "pr"), lane("ci.yml", "repo-shape", "nightly")
+            )
         )
         self.assertEqual(self.rule_ids(), [check_lanes.CADENCE_RULE_ID])
 
@@ -324,12 +324,16 @@ class CensusTests(unittest.TestCase):
 
     def test_reusable_requires_workflow_call(self) -> None:
         self.fx.write_census(
-            self.green.replace(lane("ci.yml", "analyze", "pr"), lane("ci.yml", "analyze", "reusable"))
+            self.green.replace(
+                lane("ci.yml", "analyze", "pr"), lane("ci.yml", "analyze", "reusable")
+            )
         )
         self.assertEqual(self.rule_ids(), [check_lanes.CADENCE_RULE_ID])
 
     def test_continue_on_error_needs_quarantine(self) -> None:
-        self.fx.write_census(self.green.replace(quarantine("parked.yml", "smoke", "2026-09-30"), ""))
+        self.fx.write_census(
+            self.green.replace(quarantine("parked.yml", "smoke", "2026-09-30"), "")
+        )
         violations = self.fx.violations()
         # one diagnostic per occurrence line: smoke carries two
         self.assertEqual(
@@ -389,10 +393,7 @@ class LiveRepositoryTests(unittest.TestCase):
         census = check_lanes.load_census()
         self.assertGreater(len(facts), 0)
         missing = [
-            (f.name, job)
-            for f in facts
-            for job in f.jobs
-            if (f.name, job) not in census.lanes
+            (f.name, job) for f in facts for job in f.jobs if (f.name, job) not in census.lanes
         ]
         self.assertEqual(missing, [])
         for f in facts:


### PR DESCRIPTION
## Summary
Main's repo-shape step went red for every PR after two individually-green merges combined: **#2293** added the *ruff over the engines* CI step + the gate's two-directional python3 census, and **#2275** (merged after) added `check_lanes.py` + two repo-shape CI steps — carrying three ruff violations and missing its gate census lines, both invisible to each PR's own pre-merge CI.

Fixes, all mechanical:
- `check_lanes.py`: `B007` ×2 (unused loop vars → `_row`), `E501` (stub-printer line split), `ruff format` applied. Behavior identical — census still reports exactly 75/4/75/26, unit suite OK.
- `scripts/gate`: the two new repo-shape commands added to `ALWAYS_ENGINES`/`SCRIPTS_PROOFS` (byte-identical strings), satisfying the mirror census.

Poetic justice on record: the pre-push hook (built last night) blocked this hotfix's own first push until the gate was green — the gate caught in seconds what CI could only catch per-PR.

## Testing
- `ruff check` + `format --check` under `scripts/ruff.toml`: clean
- `python3.12 -m unittest scripts.test_check_lanes` + `scripts.test_gate` (census two-directional): OK
- `make gate` end-to-end: **42 checks, 0 failed** (up from 40 — the two new engines run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)