### PR TITLE
fix(ci): make check_lanes pass its own CI step — ruff + gate mirror

### DIFF
--- a/scripts/check_lanes.py
+++ b/scripts/check_lanes.py
@@ -149,8 +149,7 @@ def parse_workflow(path: Path) -> WorkflowFacts:
                 # silent empty trigger tuple; nested sequence items (cron
                 # entries under schedule:) are fine and skipped.
                 raise ValueError(
-                    f"{path.name}:{index}: sequence-form `on:` is unparseable — "
-                    "use the block form"
+                    f"{path.name}:{index}: sequence-form `on:` is unparseable — use the block form"
                 )
             trigger = _TRIGGER_RE.match(line)
             if trigger:
@@ -172,9 +171,7 @@ def parse_workflow(path: Path) -> WorkflowFacts:
                 )
             elif stripped.startswith(("continue-on-error:", "- continue-on-error:")):
                 if not current_job:
-                    raise ValueError(
-                        f"{path.name}:{index}: continue-on-error before any job id"
-                    )
+                    raise ValueError(f"{path.name}:{index}: continue-on-error before any job id")
                 continue_on_error.append((current_job, index))
 
     if not saw_on or not saw_jobs:
@@ -308,7 +305,7 @@ def collect_violations(
                         (
                             CADENCE_RULE_ID,
                             f"{workflow}:{job}",
-                            "dispatch-with-sunset requires sunset = \"YYYY-MM-DD\"",
+                            'dispatch-with-sunset requires sunset = "YYYY-MM-DD"',
                         )
                     )
                 elif sunset < today:
@@ -331,7 +328,7 @@ def collect_violations(
                 )
 
     # Direction 2: no row outlives reality.
-    for (workflow_name, job), row in sorted(census.lanes.items()):
+    for (workflow_name, job), _row in sorted(census.lanes.items()):
         f = facts_by_name.get(workflow_name)
         if f is None or job not in f.jobs:
             violations.append(
@@ -364,7 +361,7 @@ def collect_violations(
                     (
                         QUARANTINE_RULE_ID,
                         f"{workflow}:{job} (line {line})",
-                        "quarantine row needs expires = \"YYYY-MM-DD\"",
+                        'quarantine row needs expires = "YYYY-MM-DD"',
                     )
                 )
             elif expires < today:
@@ -376,7 +373,7 @@ def collect_violations(
                         "fix the flake or re-rule the row",
                     )
                 )
-    for (workflow_name, job), row in sorted(census.quarantine.items()):
+    for (workflow_name, job), _row in sorted(census.quarantine.items()):
         f = facts_by_name.get(workflow_name)
         alive = f is not None and any(j == job for j, _ in f.continue_on_error)
         if not alive:
@@ -398,7 +395,10 @@ def print_missing(facts: list[WorkflowFacts], census: Census) -> None:
                 print("[[lane]]")
                 print(f'workflow = "{f.name}"')
                 print(f'job = "{job}"')
-                print(f'pipeline = ""  # one of: {", ".join(PIPELINES)}; triggers: {", ".join(f.triggers)}')
+                print(
+                    f'pipeline = ""  # one of: {", ".join(PIPELINES)}; '
+                    f"triggers: {', '.join(f.triggers)}"
+                )
                 print('cadence = ""')
                 print("gate_mirrored = false")
                 print()

--- a/scripts/gate
+++ b/scripts/gate
@@ -66,6 +66,7 @@ ALWAYS_ENGINES: tuple[tuple[str, str], ...] = (
     ("session mutation admission", "python3 scripts/check_session_mutation_admission.py"),
     ("update flow", "python3 scripts/check_update_flow_lints.py"),
     ("docs", "python3 scripts/check_docs.py"),
+    ("lanes", "python3 scripts/check_lanes.py"),
 )
 
 SCRIPTS_PROOFS: tuple[tuple[str, str], ...] = (
@@ -84,6 +85,7 @@ SCRIPTS_PROOFS: tuple[tuple[str, str], ...] = (
     ("checker tests: server fences", "python3 -m unittest scripts/test_check_server_fences.py"),
     ("checker tests: manifests", "python3 -m unittest scripts/test_check_manifests.py"),
     ("checker tests: docs", "python3 -m unittest scripts/test_check_docs.py"),
+    ("checker tests: lanes", "python3 -m unittest scripts/test_check_lanes.py"),
     ("checker tests: gate", "python3 -m unittest scripts/test_gate.py"),
     (
         "checker tests: server boundary checker",

--- a/scripts/test_check_lanes.py
+++ b/scripts/test_check_lanes.py
@@ -200,9 +200,7 @@ class ParserTests(unittest.TestCase):
         self.assertIn("job depth", str(ctx.exception))
 
     def test_sequence_form_on_fails_loud(self) -> None:
-        self.fx.write_workflow(
-            "seq.yml", "name: x\non:\n  - push\njobs:\n  a:\n    steps: []\n"
-        )
+        self.fx.write_workflow("seq.yml", "name: x\non:\n  - push\njobs:\n  a:\n    steps: []\n")
         with self.assertRaises(ValueError) as ctx:
             check_lanes.parse_workflow(self.fx.workflows / "seq.yml")
         self.assertIn("sequence-form", str(ctx.exception))
@@ -258,7 +256,9 @@ class CensusTests(unittest.TestCase):
     def test_pipeline_must_match_a_real_trigger(self) -> None:
         # ci.yml has no schedule trigger, so "nightly" is a lie
         self.fx.write_census(
-            self.green.replace(lane("ci.yml", "repo-shape", "pr"), lane("ci.yml", "repo-shape", "nightly"))
+            self.green.replace(
+                lane("ci.yml", "repo-shape", "pr"), lane("ci.yml", "repo-shape", "nightly")
+            )
         )
         self.assertEqual(self.rule_ids(), [check_lanes.CADENCE_RULE_ID])
 
@@ -324,12 +324,16 @@ class CensusTests(unittest.TestCase):
 
     def test_reusable_requires_workflow_call(self) -> None:
         self.fx.write_census(
-            self.green.replace(lane("ci.yml", "analyze", "pr"), lane("ci.yml", "analyze", "reusable"))
+            self.green.replace(
+                lane("ci.yml", "analyze", "pr"), lane("ci.yml", "analyze", "reusable")
+            )
         )
         self.assertEqual(self.rule_ids(), [check_lanes.CADENCE_RULE_ID])
 
     def test_continue_on_error_needs_quarantine(self) -> None:
-        self.fx.write_census(self.green.replace(quarantine("parked.yml", "smoke", "2026-09-30"), ""))
+        self.fx.write_census(
+            self.green.replace(quarantine("parked.yml", "smoke", "2026-09-30"), "")
+        )
         violations = self.fx.violations()
         # one diagnostic per occurrence line: smoke carries two
         self.assertEqual(
@@ -389,10 +393,7 @@ class LiveRepositoryTests(unittest.TestCase):
         census = check_lanes.load_census()
         self.assertGreater(len(facts), 0)
         missing = [
-            (f.name, job)
-            for f in facts
-            for job in f.jobs
-            if (f.name, job) not in census.lanes
+            (f.name, job) for f in facts for job in f.jobs if (f.name, job) not in census.lanes
         ]
         self.assertEqual(missing, [])
         for f in facts:


### PR DESCRIPTION
## What

Main's CI has been red since #2275 (a3d9decc4, 20:25Z): its own "Repo shape checks" step fails on the files it added, in two ways —

1. **ruff**: two unused `row` loop bindings + one 108-char line in `scripts/check_lanes.py` fail `ruff check`, and `ruff format --check` rewraps five sites across the engine and its test file. Fixed mechanically (`_row`, line splits, formatter output). No logic change.
2. **gate mirror**: ci.yml gained `python3 scripts/check_lanes.py` + its unittest, but the gate's `ALWAYS_ENGINES`/`SCRIPTS_PROOFS` never did — `test_gate`'s two-directional mirror test fails. Both rows added.

## Proof

- `uvx ruff@0.16.2 check scripts/` + `format --check`: clean (CI's exact commands).
- `check_lanes.py` itself: census matches reality exactly (75 lanes, 4 quarantine rows).
- 23/23 engine tests, 38/38 gate tests; full pre-push gate 42/42.

## Why urgent

`ci-ok` aggregates Repo shape checks, so **every open PR carrying a3d9decc4 fails CI** until this lands — including #2254 (slice 1), whose only red checks are these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)